### PR TITLE
Keep our pipe end out of the child

### DIFF
--- a/zuvloop/_process.py
+++ b/zuvloop/_process.py
@@ -111,9 +111,13 @@ def _open_stream(index: int, request: Any) -> tuple[int, int | None]:
         return os.open(os.devnull, os.O_RDONLY if index == 0 else os.O_WRONLY), None
     if request == subprocess.PIPE:
         read_fd, write_fd = os.pipe()
-        os.set_inheritable(read_fd, True)
-        os.set_inheritable(write_fd, True)
-        return (read_fd, write_fd) if index == 0 else (write_fd, read_fd)
+        # Only the child's end may be inheritable. If our end leaked into the
+        # child (as it would on Linux, where uv_spawn leaves inheritable
+        # descriptors open), the child would hold a writer on its own stdin
+        # pipe and never see EOF.
+        child_fd, our_fd = (read_fd, write_fd) if index == 0 else (write_fd, read_fd)
+        os.set_inheritable(child_fd, True)
+        return child_fd, our_fd
     if request == subprocess.STDOUT:
         return _dup_std(1), None
     fd = request if isinstance(request, int) else request.fileno()


### PR DESCRIPTION
## What

The CI test job on `ubuntu-latest` has been hanging for hours (e.g. [run 30986856414](https://github.com/Kludex/zuvloop/actions/runs/30986856414)), stalling in `tests/test_subprocess.py` after `test_sockets` at 89%.

## Why

`Popen._open_stream` marked **both** ends of a `subprocess.PIPE` inheritable. `uv_spawn` on Linux leaves inheritable descriptors open in the child, so the child inherited our end of its own stdin pipe. Holding a live writer on its own pipe, `/bin/cat` never saw EOF and `communicate()` hung forever — `test_stdin_reaches_the_child` blocked until the runner was cancelled. macOS was unaffected because of how the fds happened to be handled there.

## Fix

Only the child's end of the pipe is set inheritable; ours stays close-on-exec.

Full test suite passes locally (281 passed).