### PR TITLE
Fix Linux build: std.c.fstat is void in Zig 0.16

### DIFF
--- a/zig/transport.zig
+++ b/zig/transport.zig
@@ -395,9 +395,11 @@ fn repr(obj: ?*py.Object) callconv(.c) ?*py.Object {
 }
 
 fn isSocket(fd: uv.OsFd) bool {
-    var info: std.c.Stat = undefined;
-    if (std.c.fstat(fd, &info) != 0) return false;
-    return info.mode & std.c.S.IFMT == std.c.S.IFSOCK;
+    // getsockopt succeeds only on a socket, and unlike fstat it reaches libc on
+    // every platform Zig targets (std.c.fstat is unavailable on Linux).
+    var kind: c_int = 0;
+    var len: std.c.socklen_t = @sizeOf(c_int);
+    return std.c.getsockopt(fd, std.c.SOL.SOCKET, std.c.SO.TYPE, &kind, &len) == 0;
 }
 
 fn takeUvError(status: c_int) ?*py.Object {


### PR DESCRIPTION
CI on main fails at `zig/transport.zig:399: error: type 'void' not a function` on Linux: `std.c.fstat` resolves to `{}` for `.linux` in Zig 0.16, since glibc doesn't export `fstat` directly.

Replace the fstat probe in `isSocket` with `getsockopt(SO_TYPE)`, which succeeds only on a socket and is a plain libc extern on every supported platform. macOS build and full test suite pass locally.