### PR TITLE
Hand libuv the shared read buffer without taking the GIL

### DIFF
--- a/benchmarks/compare.py
+++ b/benchmarks/compare.py
@@ -1,0 +1,137 @@
+"""Compare zuvloop against uvloop on one workload, honestly.
+
+    uv run --group bench python benchmarks/compare.py
+
+`test_benchmarks.py` records what changed between commits, which is what CodSpeed
+is for, but its table cannot answer "how does this compare to uvloop" - see the
+note there. This alternates the two loops inside a single process so machine
+drift moves both arms equally, and reports the median as well as the minimum: a
+minimum taken across distributions with different spread favours whichever arm is
+noisier, and uvloop's spread here runs several times zuvloop's.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gc
+import os
+import statistics
+import time
+from collections.abc import Callable
+
+import uvloop
+
+import zuvloop
+
+PAYLOAD = os.urandom(1024)
+ROUNDTRIPS = 2000
+REPS = 60
+
+Factory = Callable[[], asyncio.AbstractEventLoop]
+
+
+class Arm:
+    """One loop, its echo server, and the samples taken against it."""
+
+    def __init__(self, factory: Factory) -> None:
+        self.loop = factory()
+        self.wall: list[float] = []
+        self.cpu: list[float] = []
+
+        class Server(asyncio.Protocol):
+            def connection_made(self, transport: asyncio.BaseTransport) -> None:
+                self.transport = transport
+
+            def data_received(self, data: bytes) -> None:
+                self.transport.write(data)  # type: ignore[attr-defined]
+
+        self.server = self.loop.run_until_complete(self.loop.create_server(Server, "127.0.0.1", 0))
+        self.port: int = self.server.sockets[0].getsockname()[1]
+
+    def _client(self) -> type[asyncio.Protocol]:
+        loop = self.loop
+
+        class Client(asyncio.Protocol):
+            def __init__(self) -> None:
+                self.pending = 0
+                self.remaining = ROUNDTRIPS
+                self.done = loop.create_future()
+
+            def connection_made(self, transport: asyncio.BaseTransport) -> None:
+                self.transport = transport
+                transport.write(PAYLOAD)  # type: ignore[attr-defined]
+
+            def data_received(self, data: bytes) -> None:
+                self.pending += len(data)
+                while self.pending >= len(PAYLOAD):
+                    self.pending -= len(PAYLOAD)
+                    self.remaining -= 1
+                    if self.remaining == 0:
+                        self.done.set_result(None)
+                        return
+                    self.transport.write(PAYLOAD)  # type: ignore[attr-defined]
+
+        return Client
+
+    def run(self) -> None:
+        client_type = self._client()
+
+        async def once() -> None:
+            transport, protocol = await self.loop.create_connection(client_type, "127.0.0.1", self.port)
+            await protocol.done  # type: ignore[attr-defined]
+            transport.close()
+
+        self.loop.run_until_complete(once())
+
+    def sample(self) -> None:
+        started_cpu = time.process_time()
+        started = time.perf_counter()
+        self.run()
+        self.wall.append(time.perf_counter() - started)
+        self.cpu.append(time.process_time() - started_cpu)
+
+    def close(self) -> None:
+        self.server.close()
+        self.loop.run_until_complete(self.server.wait_closed())
+        self.loop.close()
+
+    def report(self, name: str) -> None:
+        spread = statistics.stdev(self.wall) / statistics.mean(self.wall) * 100
+        print(
+            f"  {name:8s} wall min {min(self.wall) * 1000:7.2f}ms"
+            f"  median {statistics.median(self.wall) * 1000:7.2f}ms"
+            f"  (+/- {spread:4.1f}%)   cpu min {min(self.cpu) * 1000:7.2f}ms"
+        )
+
+
+def main() -> None:
+    arms = {"zuvloop": Arm(zuvloop.new_event_loop), "uvloop": Arm(uvloop.new_event_loop)}
+    for arm in arms.values():
+        for _ in range(3):
+            arm.run()
+
+    gc.disable()
+    try:
+        for rep in range(REPS):
+            # Alternating the order too, so neither arm always follows the other.
+            names = list(arms) if rep % 2 == 0 else list(arms)[::-1]
+            for name in names:
+                arms[name].sample()
+    finally:
+        gc.enable()
+
+    for name, arm in arms.items():
+        arm.close()
+        arm.report(name)
+
+    fast, slow = arms["zuvloop"], arms["uvloop"]
+    wall_min = min(slow.wall) / min(fast.wall)
+    wall_median = statistics.median(slow.wall) / statistics.median(fast.wall)
+    cpu_min = min(slow.cpu) / min(fast.cpu)
+    cpu_median = statistics.median(slow.cpu) / statistics.median(fast.cpu)
+    print(f"\n  zuvloop / uvloop  wall: min {wall_min:.3f}x  median {wall_median:.3f}x")
+    print(f"                     cpu: min {cpu_min:.3f}x  median {cpu_median:.3f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/test_benchmarks.py
+++ b/benchmarks/test_benchmarks.py
@@ -1,9 +1,16 @@
 """Benchmarks, measured by CodSpeed on every commit.
 
-Each one is parametrised by event loop, so a run records both what changed since
-the last commit and how zuvloop stands against asyncio and uvloop. `pytest-codspeed`
-does not run coroutines, so every benchmark is driven through `run_until_complete`
-on a loop the fixture owns; loop construction stays outside the measurement.
+Each one is parametrised by event loop, so a run records what changed since the
+last commit. `pytest-codspeed` does not run coroutines, so every benchmark is
+driven through `run_until_complete` on a loop the fixture owns; loop construction
+stays outside the measurement.
+
+Do not compare the loops by the `Time (best)` column. `pytest-codspeed` 5.0.3
+divides by `iter_per_round` twice - once building the stats and again rendering
+the table - and picks that divisor per row from the row's own warmup, so a ratio
+between two rows is scaled by a number that has nothing to do with either. It
+reported this loop as 0.86x uvloop on `echo_roundtrips` when interleaved
+measurement puts it at 1.09x. `compare.py` is the harness for that question.
 
 The HTTP benchmarks are not here. They need a server process and an external load
 generator, which is not something a benchmark harness can measure in-process -

--- a/zig/transport.zig
+++ b/zig/transport.zig
@@ -272,6 +272,17 @@ fn onAlloc(handle: ?*uv.Handle, suggested: usize, buf: *uv.Buf) callconv(.c) voi
     _ = suggested;
     const self: *Transport = @ptrCast(@alignCast(uv.getData(handle.?)));
     const st = self.loopState();
+
+    // Handing back the loop's shared buffer touches no Python object, and libuv
+    // asks for one on every readable event, so the GIL round trip the rest of
+    // this needs would be paid per read for nothing.
+    if (self.flags & BUFFERED == 0 and self.read_bytes == null and self.read_size <= copy_threshold) {
+        if (loopmod.scratchBuffer(st)) |scratch| {
+            buf.* = .{ .base = scratch, .len = self.read_size };
+            return;
+        }
+    }
+
     st.gilEnter();
     defer st.gilExit();
 


### PR DESCRIPTION
libuv asks for a buffer on every readable event, and the common answer - a non-buffered protocol reading less than the copy threshold - is the loop's shared scratch buffer, which touches no Python object. The GIL round trip the rest of `onAlloc` needs was being paid per read to do nothing but clear an already-null slot.

Four GIL transitions per echo roundtrip instead of six, counted with a `DYLD_INTERPOSE` hook on `PyEval_RestoreThread`/`SaveThread`: 24000 -> 16000 over a 2000-roundtrip run. Userspace time per run falls 7-14%. Wall moves ~1.5%, because that benchmark is 91% syscalls.

## The benchmark table was lying

This started as "`echo_roundtrips` is 0.86x uvloop". It never was.

`pytest-codspeed` 5.0.3 divides by `iter_per_round` twice - once building the stats (`walltime.py:107`) and again rendering the table (`:383`) - and derives that divisor from each row's own warmup. A ratio between two rows is therefore scaled by a number unrelated to either. Two fixed busy-waits demonstrate it: a true 1.16x difference displays as 1.75x.

Compounding it, the table reports a *minimum* across distributions with very different spread. uvloop's echo row runs 7-17% relative stdev against this loop's 4-5%, so its minimum reaches much further into its tail.

Measured by alternating both loops inside one process, order swapped each rep, 60 reps, GC off:

```
  zuvloop  wall min   29.83ms  median   33.59ms  (+/- 5.3%)   cpu min   21.64ms
  uvloop   wall min   32.61ms  median   36.94ms  (+/- 6.5%)   cpu min   24.39ms

  zuvloop / uvloop  wall: min 1.093x  median 1.100x
                     cpu: min 1.127x  median 1.120x
```

`benchmarks/compare.py` is that harness. `test_benchmarks.py` gains a note not to read its table across rows.

## What was ruled out

Three hypotheses for the supposed gap, each measured and refuted:

- **Syscalls.** Identical per roundtrip - 2 read, 2 write, 2 kevent for both loops, via a `DYLD_INSERT_LIBRARIES` interposer, differenced across run lengths so fixed cost cancels. Neither loop makes a speculative `EAGAIN` read.
- **Loop machinery.** 2.002 libuv iterations per roundtrip, which is the floor for one shared loop. The idle handle is never armed; the sampler timer is inert.
- **Read-path allocation.** ~1.25% of wall. The benchmark is 91% syscalls and ~8.6% userspace, of which the Python `data_received` call is the largest single item.

Also measured and rejected: dropping `uv_loop_configure(.metrics_idle_time)`. It genuinely costs an extra `kevent` per *blocking* poll, but echo never blocks, and the paired A/B came out inconsistent - not worth losing `loop._metrics()["idle_time_ns"]`.

## Verification

291 tests, 100% branch coverage, `ruff`, `ruff format`, `mypy --strict`, CPython `test_asyncio` conformance at 88/92 (4 skipped, none failing or hanging), uvicorn 1.06x plaintext and 1.06x 10kb against uvloop.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
