### PR TITLE
Drop zuvloop.instrument(): sample gauges automatically when a meter provider is installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,16 @@ import zuvloop
 logfire.configure()  # installs the OTel providers
 
 
-async def main() -> None:
-    zuvloop.instrument()  # start the periodic loop gauges
-    ...
+async def main() -> None: ...
+
+
+zuvloop.run(main())
 ```
+
+That's all — there is no zuvloop-specific setup. Spans and counters are emitted
+as events happen, and the loop gauges are sampled automatically while the loop
+runs (only when a real provider is installed, so an uninstrumented program never
+pays for sampling).
 
 You get:
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -67,24 +67,21 @@ have the same property.
 
 ## Instrumentation
 
-### `zuvloop.instrument`
+Everything is automatic: spans and counters are emitted as events happen, and
+the loop gauges are sampled while the loop runs whenever a real OpenTelemetry
+meter provider is installed. See [Instrumentation](../usage/instrumentation.md).
+
+### `EventLoop.metrics_interval`
 
 ```python
-zuvloop.instrument(interval=1.0) -> None
+loop.metrics_interval = 10.0  # seconds, the default
 ```
 
-Starts periodic sampling of the loop gauges on the running loop. Spans and
-counters need no setup; only the gauges are sampled. See
-[Instrumentation](../usage/instrumentation.md).
+How often the gauges are sampled. Assign before running the loop.
 
 ### `zuvloop.Instrumentation`
 
-The per-loop instrumentation state, reachable as `loop._instrumentation`. Useful
-if you want to drive sampling yourself rather than through `instrument()`.
-
-### `zuvloop.MetricsReporter`
-
-The callable the native sampler invokes with each batch of gauge values.
+The per-loop instrumentation state, reachable as `loop._instrumentation`.
 
 ## Utilities
 

--- a/docs/usage/instrumentation.md
+++ b/docs/usage/instrumentation.md
@@ -21,25 +21,32 @@ there is no flag to turn this off.
 
 ## Collecting it
 
-Anything that speaks OpenTelemetry collects it. `logfire.configure()` is one such
-thing, and zuvloop does not import logfire to work with it:
+Anything that speaks OpenTelemetry collects it, and nothing needs to be turned
+on. `logfire.configure()` is one such thing, and zuvloop does not import logfire
+to work with it:
 
 ```python
 import logfire
 import zuvloop
 
 
-async def main() -> None:
-    zuvloop.instrument()  # start the periodic loop gauges
-    ...
+async def main() -> None: ...
 
 
 logfire.configure()  # installs the OTel providers
 zuvloop.run(main())
 ```
 
-[`zuvloop.instrument()`](../reference/api.md#zuvloopinstrument) starts the gauge sampler. Spans and counters
-need no setup — they are emitted as the events happen.
+Spans and counters are emitted as the events happen. The gauges are sampled
+automatically while the loop runs, but only when a real meter provider is
+installed - without one there would be nowhere for the numbers to go, so the
+sampler never starts. The default interval is 10 seconds; set
+`loop.metrics_interval` before running the loop to change it:
+
+```python
+loop = zuvloop.new_event_loop()
+loop.metrics_interval = 1.0
+```
 
 ## Slow callbacks
 

--- a/tests/test_instrumentation.py
+++ b/tests/test_instrumentation.py
@@ -9,7 +9,7 @@ from opentelemetry.trace import StatusCode
 
 import zuvloop
 from conftest import Telemetry, attribute, collect_contexts, numeric_attribute, running_loop
-from zuvloop._instrumentation import capture_call_graph, publish_metrics
+from zuvloop._instrumentation import capture_call_graph, metrics_provider_installed, publish_metrics
 
 pytestmark = pytest.mark.anyio
 
@@ -154,14 +154,19 @@ async def test_metrics_are_published_as_gauges(telemetry: Telemetry) -> None:
     assert telemetry.metric("zuvloop.timers") == 4
 
 
-async def test_instrument_samples_on_a_native_timer(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_gauges_sample_on_a_native_timer(monkeypatch: pytest.MonkeyPatch) -> None:
     snapshots: list[dict[str, int]] = []
-    monkeypatch.setattr("zuvloop._runner.publish_metrics", snapshots.append)
-    reporter = zuvloop.instrument(interval=0.02)
-    try:
-        await asyncio.sleep(0.09)
-    finally:
-        reporter.cancel()
+    monkeypatch.setattr("zuvloop._base.publish_metrics", snapshots.append)
+
+    def main() -> None:
+        loop = zuvloop.new_event_loop()
+        loop.metrics_interval = 0.02
+        try:
+            loop.run_until_complete(asyncio.sleep(0.09))
+        finally:
+            loop.close()
+
+    await asyncio.to_thread(main)
     assert len(snapshots) >= 2
     assert snapshots[0].keys() == running_loop()._metrics().keys()
     before = len(snapshots)
@@ -169,27 +174,53 @@ async def test_instrument_samples_on_a_native_timer(monkeypatch: pytest.MonkeyPa
     assert len(snapshots) == before
 
 
-async def test_instrument_reaches_the_exporter(telemetry: Telemetry) -> None:
-    reporter = zuvloop.instrument(interval=0.02)
-    try:
-        await asyncio.sleep(0.05)
-    finally:
-        reporter.cancel()
+async def test_gauges_reach_the_exporter(telemetry: Telemetry) -> None:
+    def main() -> None:
+        loop = zuvloop.new_event_loop()
+        loop.metrics_interval = 0.02
+        try:
+            loop.run_until_complete(asyncio.sleep(0.05))
+        finally:
+            loop.close()
+
+    await asyncio.to_thread(main)
     assert telemetry.counted("zuvloop.callbacks_run") > 0
 
 
-async def test_instrument_accepts_an_explicit_loop() -> None:
-    reporter = zuvloop.instrument(running_loop(), interval=5.0)
-    reporter.cancel()
+def test_a_real_provider_is_detected(telemetry: Telemetry) -> None:
+    # The telemetry fixture installs SDK providers for the whole session.
+    assert metrics_provider_installed()
 
 
-async def test_instrument_rejects_a_foreign_loop() -> None:
-    other = asyncio.new_event_loop()
-    try:
-        with pytest.raises(TypeError, match="needs a zuvloop event loop"):
-            zuvloop.instrument(other)  # type: ignore[arg-type]
-    finally:
-        other.close()
+def test_a_noop_provider_is_not_detected(monkeypatch: pytest.MonkeyPatch) -> None:
+    from opentelemetry.metrics import NoOpMeterProvider
+
+    monkeypatch.setattr("zuvloop._instrumentation.metrics.get_meter_provider", NoOpMeterProvider)
+    assert not metrics_provider_installed()
+
+
+def test_an_unset_proxy_provider_is_not_detected(monkeypatch: pytest.MonkeyPatch) -> None:
+    from opentelemetry.metrics._internal import _ProxyMeterProvider
+
+    monkeypatch.setattr("zuvloop._instrumentation.metrics.get_meter_provider", _ProxyMeterProvider)
+    assert not metrics_provider_installed()
+
+
+async def test_gauges_stay_off_without_a_meter_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    snapshots: list[dict[str, int]] = []
+    monkeypatch.setattr("zuvloop._base.publish_metrics", snapshots.append)
+    monkeypatch.setattr("zuvloop._base.metrics_provider_installed", lambda: False)
+
+    def main() -> None:
+        loop = zuvloop.new_event_loop()
+        loop.metrics_interval = 0.02
+        try:
+            loop.run_until_complete(asyncio.sleep(0.09))
+        finally:
+            loop.close()
+
+    await asyncio.to_thread(main)
+    assert snapshots == []
 
 
 async def test_the_sampling_interval_must_be_positive() -> None:

--- a/zuvloop/__init__.py
+++ b/zuvloop/__init__.py
@@ -1,6 +1,6 @@
 from ._instrumentation import Instrumentation
 from ._loop import EventLoop
-from ._runner import MetricsReporter, instrument, new_event_loop, run
+from ._runner import new_event_loop, run
 from ._server import Server
 from ._zuvloop import Handle, TimerHandle, Transport, libuv_version
 
@@ -8,11 +8,9 @@ __all__ = [
     "EventLoop",
     "Handle",
     "Instrumentation",
-    "MetricsReporter",
     "Server",
     "TimerHandle",
     "Transport",
-    "instrument",
     "libuv_version",
     "new_event_loop",
     "run",

--- a/zuvloop/_base.py
+++ b/zuvloop/_base.py
@@ -16,7 +16,7 @@ from functools import partial
 from typing import Any
 
 from . import _zuvloop
-from ._instrumentation import Instrumentation
+from ._instrumentation import Instrumentation, metrics_provider_installed, publish_metrics
 
 _ExceptionHandler = Callable[[asyncio.AbstractEventLoop, dict[str, Any]], object]
 
@@ -30,6 +30,10 @@ class LoopBase(_zuvloop.Loop, asyncio.AbstractEventLoop):  # type: ignore[misc]
     writer registrations) come from the Zig extension; everything here is
     orchestration that runs once per loop or once per connection.
     """
+
+    # How often the loop gauges are sampled while a real OpenTelemetry meter
+    # provider is installed. Assign before running the loop to change it.
+    metrics_interval: float = 10.0
 
     def __init__(self) -> None:
         self._exception_handler: _ExceptionHandler | None = None
@@ -91,9 +95,14 @@ class LoopBase(_zuvloop.Loop, asyncio.AbstractEventLoop):  # type: ignore[misc]
         self._attach_wakeup_fd()
         _events._set_running_loop(self)
         sys.set_asyncgen_hooks(firstiter=self._asyncgen_firstiter, finalizer=self._asyncgen_finalizer)
+        # Gauges cost nothing to skip and something to sample, so the sampler
+        # runs exactly when there is somewhere for the numbers to go.
+        if metrics_provider_installed():
+            self._start_metrics(self.metrics_interval, publish_metrics)
         try:
             self._run()
         finally:
+            self._stop_metrics()
             sys.set_asyncgen_hooks(*old_hooks)
             _events._set_running_loop(None)
             self._detach_wakeup_fd()

--- a/zuvloop/_instrumentation.py
+++ b/zuvloop/_instrumentation.py
@@ -6,6 +6,7 @@ import time
 from typing import Any
 
 from opentelemetry import metrics, trace
+from opentelemetry.metrics import NoOpMeterProvider
 from opentelemetry.trace import Status, StatusCode
 
 _NAMESPACE = "zuvloop"
@@ -99,6 +100,23 @@ def capture_call_graph(handle: object = None) -> str | None:
     if task is None:
         return None
     return asyncio.format_call_graph(task)
+
+
+def metrics_provider_installed() -> bool:
+    """Whether the application has installed a real meter provider.
+
+    Before that happens, OpenTelemetry hands out proxies whose instruments do
+    nothing - sampling the loop to feed them would be pure overhead.
+    """
+    provider = metrics.get_meter_provider()
+    if isinstance(provider, NoOpMeterProvider):
+        return False
+    real = getattr(provider, "_real_meter_provider", _MISSING)
+    # A _ProxyMeterProvider delegates only once set_meter_provider() ran.
+    return real is _MISSING or real is not None
+
+
+_MISSING = object()
 
 
 _GAUGES = {

--- a/zuvloop/_runner.py
+++ b/zuvloop/_runner.py
@@ -4,7 +4,6 @@ import asyncio
 from collections.abc import Coroutine
 from typing import Any
 
-from ._instrumentation import publish_metrics
 from ._loop import EventLoop
 
 
@@ -17,30 +16,3 @@ def run[T](main: Coroutine[Any, Any, T], *, debug: bool | None = None) -> T:
     """Run `main` on a libuv-backed loop, mirroring `asyncio.run`."""
     with asyncio.Runner(debug=debug, loop_factory=new_event_loop) as runner:
         return runner.run(main)
-
-
-class MetricsReporter:
-    """Publishes the loop's counters as OpenTelemetry gauges.
-
-    Sampling runs on a dedicated libuv timer inside the extension, so it never
-    enters the callback queue; Python is handed a finished snapshot.
-    """
-
-    def __init__(self, loop: EventLoop, interval: float) -> None:
-        self._loop = loop
-        loop._start_metrics(interval, publish_metrics)
-
-    def cancel(self) -> None:
-        self._loop._stop_metrics()
-
-
-def instrument(loop: EventLoop | None = None, *, interval: float = 10.0) -> MetricsReporter:
-    """Record loop counters as OpenTelemetry gauges every `interval` seconds.
-
-    Slow callbacks and unhandled exceptions are always reported; this adds the
-    periodic gauges, which need a running loop to sample from.
-    """
-    target = loop if loop is not None else asyncio.get_running_loop()
-    if not isinstance(target, EventLoop):
-        raise TypeError(f"zuvloop.instrument() needs a zuvloop event loop, got {target!r}")
-    return MetricsReporter(target, interval)


### PR DESCRIPTION
Installing an OpenTelemetry meter provider (e.g. `logfire.configure()`) already expresses the intent `zuvloop.instrument()` asked for a second time. Now `run_forever()` checks whether a real provider is installed — not the NoOp or an unset proxy — and starts the native gauge sampler itself, stopping it when the loop stops.

- `zuvloop.instrument()` and `MetricsReporter` are removed
- The interval lives on the loop: `loop.metrics_interval = 1.0` (default 10s), assigned before running
- No provider → the sampler never starts, so an uninstrumented program pays nothing (as before, but now with zero API surface)
- Spans and counters are unchanged: emitted as events happen through OTel proxies

Docs and README updated; observability is now literally `logfire.configure()` and nothing else.