### PR TITLE
Raise socket.gaierror with the platform's EAI code from the resolver

### DIFF
--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -2,12 +2,20 @@ from __future__ import annotations
 
 import asyncio
 import socket
+from collections.abc import Sequence
 
 import pytest
 
 from conftest import running_loop
 
 pytestmark = pytest.mark.anyio
+
+type Sockaddr = tuple[str, int] | tuple[str, int, int, int] | tuple[int, bytes]
+type AddrInfo = tuple[int, int, int, str, Sockaddr]
+# What a lookup produced: the addresses, or the `(errno, strerror)` it failed with.
+# `Sequence` rather than `list` because the two APIs disagree on how narrowly they
+# type the family and the address, and only a covariant container accepts both.
+type Outcome = Sequence[AddrInfo] | tuple[int, str]
 
 
 async def test_getaddrinfo_resolves_localhost() -> None:
@@ -81,11 +89,11 @@ async def test_getaddrinfo_answers_as_the_stdlib_does(host: str, port: str) -> N
     loop = running_loop()
     kwargs = {"family": socket.AF_INET, "type": socket.SOCK_STREAM}
     try:
-        theirs: object = sorted(socket.getaddrinfo(host, port, **kwargs))
+        theirs: Outcome = sorted(socket.getaddrinfo(host, port, **kwargs))
     except socket.gaierror as exc:
         theirs = exc.args
     try:
-        mine: object = sorted(await loop.getaddrinfo(host, port, **kwargs))
+        mine: Outcome = sorted(await loop.getaddrinfo(host, port, **kwargs))
     except socket.gaierror as exc:
         mine = exc.args
     assert mine == theirs
@@ -106,13 +114,13 @@ async def test_getnameinfo_reports_failures_as_the_stdlib_does() -> None:
     loop = running_loop()
     flags = socket.NI_NAMEREQD | socket.NI_NUMERICHOST
     try:
-        theirs: object = socket.getnameinfo(("127.0.0.1", 80), flags)
+        theirs: tuple[str, str] | tuple[int, str] = socket.getnameinfo(("127.0.0.1", 80), flags)
     except socket.gaierror as exc:
-        theirs = type(exc)
+        theirs = exc.args
     try:
-        mine: object = await loop.getnameinfo(("127.0.0.1", 80), flags)
+        mine: tuple[str, str] | tuple[int, str] = await loop.getnameinfo(("127.0.0.1", 80), flags)
     except socket.gaierror as exc:
-        mine = type(exc)
+        mine = exc.args
     assert mine == theirs
 
 

--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -65,12 +65,30 @@ async def test_getaddrinfo_reports_failures() -> None:
     assert caught.value.args == stdlib.value.args
 
 
-async def test_getaddrinfo_treats_an_empty_host_as_the_null_host() -> None:
-    """`""` is the wildcard address, not a host whose name is the empty string."""
+@pytest.mark.parametrize(
+    ("host", "port"),
+    [
+        ("localhost", "http"),
+        ("this-host-should-not-exist.invalid", "http"),
+        # What `""` means is the platform's business, and the platforms disagree:
+        # BSD reads it as the null host and resolves the wildcard address, glibc
+        # calls it a name it cannot find. libuv reaches neither, because it runs
+        # every hostname through IDNA first and that rejects an empty one.
+        ("", "http"),
+    ],
+)
+async def test_getaddrinfo_answers_as_the_stdlib_does(host: str, port: str) -> None:
     loop = running_loop()
-    mine = await loop.getaddrinfo("", "http", family=socket.AF_INET, type=socket.SOCK_STREAM)
-    theirs = socket.getaddrinfo("", "http", family=socket.AF_INET, type=socket.SOCK_STREAM)
-    assert sorted(mine) == sorted(theirs)
+    kwargs = {"family": socket.AF_INET, "type": socket.SOCK_STREAM}
+    try:
+        theirs: object = sorted(socket.getaddrinfo(host, port, **kwargs))
+    except socket.gaierror as exc:
+        theirs = exc.args
+    try:
+        mine: object = sorted(await loop.getaddrinfo(host, port, **kwargs))
+    except socket.gaierror as exc:
+        mine = exc.args
+    assert mine == theirs
 
 
 async def test_getaddrinfo_without_a_host_or_a_port_reports_no_name() -> None:

--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -49,9 +49,53 @@ async def test_getaddrinfo_returns_canonical_names() -> None:
 
 
 async def test_getaddrinfo_reports_failures() -> None:
+    """The exception the standard library raises, carrying the code it carries.
+
+    libuv numbers its resolver errors itself, and those numbers are neither the
+    platform's `EAI_*` nor stable across platforms, so a caller comparing against
+    `socket.EAI_NONAME` would never match.
+    """
     loop = running_loop()
-    with pytest.raises(socket.gaierror):
+    with pytest.raises(socket.gaierror) as caught:
         await loop.getaddrinfo("this-host-should-not-exist.invalid", 80, type=socket.SOCK_STREAM)
+    assert caught.value.errno in (socket.EAI_NONAME, socket.EAI_NODATA)
+
+    with pytest.raises(socket.gaierror) as stdlib:
+        socket.getaddrinfo("this-host-should-not-exist.invalid", 80, type=socket.SOCK_STREAM)
+    assert caught.value.args == stdlib.value.args
+
+
+async def test_getaddrinfo_treats_an_empty_host_as_the_null_host() -> None:
+    """`""` is the wildcard address, not a host whose name is the empty string."""
+    loop = running_loop()
+    mine = await loop.getaddrinfo("", "http", family=socket.AF_INET, type=socket.SOCK_STREAM)
+    theirs = socket.getaddrinfo("", "http", family=socket.AF_INET, type=socket.SOCK_STREAM)
+    assert sorted(mine) == sorted(theirs)
+
+
+async def test_getaddrinfo_without_a_host_or_a_port_reports_no_name() -> None:
+    """libuv rejects the pair as EINVAL; the resolver would call it a missing name."""
+    loop = running_loop()
+    with pytest.raises(socket.gaierror) as caught:
+        await loop.getaddrinfo(None, None)
+    with pytest.raises(socket.gaierror) as stdlib:
+        socket.getaddrinfo(None, None)
+    assert caught.value.args == stdlib.value.args
+
+
+async def test_getnameinfo_reports_failures_as_the_stdlib_does() -> None:
+    """Whether a reverse lookup fails depends on the resolver; agreeing does not."""
+    loop = running_loop()
+    flags = socket.NI_NAMEREQD | socket.NI_NUMERICHOST
+    try:
+        theirs: object = socket.getnameinfo(("127.0.0.1", 80), flags)
+    except socket.gaierror as exc:
+        theirs = type(exc)
+    try:
+        mine: object = await loop.getnameinfo(("127.0.0.1", 80), flags)
+    except socket.gaierror as exc:
+        mine = type(exc)
+    assert mine == theirs
 
 
 async def test_getaddrinfo_rejects_unusable_arguments() -> None:

--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -109,10 +109,18 @@ async def test_getaddrinfo_without_a_host_or_a_port_reports_no_name() -> None:
     assert caught.value.args == stdlib.value.args
 
 
-async def test_getnameinfo_reports_failures_as_the_stdlib_does() -> None:
-    """Whether a reverse lookup fails depends on the resolver; agreeing does not."""
+@pytest.mark.parametrize(
+    "flags",
+    [
+        # Contradictory, and the resolver says so - the failure path.
+        socket.NI_NAMEREQD | socket.NI_NUMERICHOST,
+        # A real reverse lookup, answered from the hosts file - the success path.
+        socket.NI_NAMEREQD,
+    ],
+)
+async def test_getnameinfo_answers_as_the_stdlib_does(flags: int) -> None:
+    """Whether a reverse lookup succeeds is the resolver's business; agreeing is not."""
     loop = running_loop()
-    flags = socket.NI_NAMEREQD | socket.NI_NUMERICHOST
     try:
         theirs: tuple[str, str] | tuple[int, str] = socket.getnameinfo(("127.0.0.1", 80), flags)
     except socket.gaierror as exc:

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -224,7 +224,15 @@ async def test_an_unsupported_popen_argument_is_rejected() -> None:
 
 async def test_signalling_an_exited_child_is_a_no_op() -> None:
     loop = running_loop()
-    transport, _protocol = await loop.subprocess_exec(asyncio.SubprocessProtocol, "/bin/echo", stdout=PIPE)
+
+    class Waiter(asyncio.SubprocessProtocol):
+        def __init__(self) -> None:
+            self.exited = loop.create_future()
+
+        def process_exited(self) -> None:
+            self.exited.set_result(None)
+
+    transport, protocol = await loop.subprocess_exec(Waiter, "/bin/echo", stdout=PIPE)
     try:
         # An unread pipe keeps the transport from finishing, which is the window
         # the no-op exists for: a child already reaped, still held by asyncio.
@@ -232,11 +240,7 @@ async def test_signalling_an_exited_child_is_a_no_op() -> None:
         assert isinstance(stdout, asyncio.ReadTransport)
         stdout.pause_reading()
 
-        async def until_exited() -> None:
-            while transport.get_returncode() is None:
-                await asyncio.sleep(0.01)
-
-        await asyncio.wait_for(until_exited(), 10)
+        await asyncio.wait_for(protocol.exited, 10)
         # asyncio makes signalling an exited child a no-op rather than an error.
         transport.send_signal(signal.SIGTERM)
         transport.terminate()

--- a/zig/dns.zig
+++ b/zig/dns.zig
@@ -196,16 +196,16 @@ fn resolverException(status: c_int) ?*py.Object {
 fn raisePlatformError(code: std.c.EAI) py.Error {
     const exc = c.PyObject_CallFunction(gaierror, "is", @intFromEnum(code), std.c.gai_strerror(code)) orelse
         return py.Error.Python;
-    defer py.decref(exc);
-    c.PyErr_SetObject(gaierror, exc);
+    c.PyErr_SetRaisedException(exc);
     return py.Error.Python;
 }
 
 /// Raises it, for the paths that report synchronously rather than through a future.
+/// `PyErr_SetRaisedException` takes the reference, and needs no separate type -
+/// `PyObject_Type` would hand back one more to own.
 fn raiseResolverError(status: c_int) py.Error {
     const exc = resolverException(status) orelse return py.Error.Python;
-    defer py.decref(exc);
-    c.PyErr_SetObject(@ptrCast(c.PyObject_Type(exc)), exc);
+    c.PyErr_SetRaisedException(exc);
     return py.Error.Python;
 }
 

--- a/zig/dns.zig
+++ b/zig/dns.zig
@@ -194,6 +194,13 @@ fn resolverException(status: c_int) ?*py.Object {
 
 /// Raises `socket.gaierror` for a code the platform's resolver produced itself.
 fn raisePlatformError(code: std.c.EAI) py.Error {
+    // `EAI_SYSTEM` says only that the real error is in `errno`, so the standard
+    // library reports that instead - `set_gaierror` in CPython's socketmodule
+    // hands it straight to `PyErr_SetFromErrno`. Windows has no such code.
+    if (@hasField(std.c.EAI, "SYSTEM") and code == eai("SYSTEM", .FAIL)) {
+        _ = c.PyErr_SetFromErrno(@ptrCast(c.PyExc_OSError));
+        return py.Error.Python;
+    }
     const exc = c.PyObject_CallFunction(gaierror, "is", @intFromEnum(code), std.c.gai_strerror(code)) orelse
         return py.Error.Python;
     c.PyErr_SetRaisedException(exc);

--- a/zig/dns.zig
+++ b/zig/dns.zig
@@ -114,6 +114,8 @@ pub fn traverse(st: *loopmod.State, visitproc: c.visitproc, arg: ?*anyopaque) c_
     return 0;
 }
 
+/// An empty host means the null host, as it does for `socket.getaddrinfo` -
+/// the wildcard address, not a host whose name is the empty string.
 fn copyZ(dst: []u8, value: *py.Object, what: [:0]const u8) py.Error!?[*:0]const u8 {
     if (py.isNone(value)) return null;
     var len: c.Py_ssize_t = 0;
@@ -132,6 +134,7 @@ fn copyZ(dst: []u8, value: *py.Object, what: [:0]const u8) py.Error!?[*:0]const 
         _ = c.PyErr_Format(@ptrCast(c.PyExc_TypeError), "%s must be str, bytes, int or None", what.ptr);
         return py.Error.Python;
     }
+    if (len == 0) return null;
     if (@as(usize, @intCast(len)) >= dst.len) return py.errValue("value too long");
     @memcpy(dst[0..@intCast(len)], src[0..@intCast(len)]);
     dst[@intCast(len)] = 0;
@@ -152,10 +155,56 @@ fn settle(future: *py.Object, method: ?*py.Object, value: *py.Object) void {
     py.decref(res);
 }
 
-fn failFuture(future: *py.Object, status: c_int) void {
+/// The member if this platform has it, and a stand-in if it does not: glibc
+/// carries no `EAI_BADHINTS` or `EAI_PROTOCOL`, and the codes are not the same
+/// numbers across platforms either.
+inline fn eai(comptime name: [:0]const u8, comptime fallback: std.c.EAI) std.c.EAI {
+    return if (@hasField(std.c.EAI, name)) @field(std.c.EAI, name) else fallback;
+}
+
+/// libuv reports resolver failures with codes of its own; `socket.gaierror`
+/// carries the platform's `EAI_*`, which is what callers written against the
+/// standard library compare against. Anything that is not a resolver failure -
+/// a cancellation, an out-of-memory - is left to `OSError`.
+fn resolverError(status: c_int) ?std.c.EAI {
+    return switch (status) {
+        uv.EAI_ADDRFAMILY => eai("ADDRFAMILY", .FAIL),
+        uv.EAI_AGAIN => .AGAIN,
+        uv.EAI_BADFLAGS => .BADFLAGS,
+        uv.EAI_BADHINTS => eai("BADHINTS", .FAIL),
+        uv.EAI_FAIL => .FAIL,
+        uv.EAI_FAMILY => .FAMILY,
+        uv.EAI_MEMORY => .MEMORY,
+        uv.EAI_NODATA => eai("NODATA", .NONAME),
+        uv.EAI_NONAME => .NONAME,
+        uv.EAI_OVERFLOW => eai("OVERFLOW", .FAIL),
+        uv.EAI_PROTOCOL => eai("PROTOCOL", .FAIL),
+        uv.EAI_SERVICE => .SERVICE,
+        uv.EAI_SOCKTYPE => .SOCKTYPE,
+        else => null,
+    };
+}
+
+/// Builds the exception the standard library would have raised for `status`.
+fn resolverException(status: c_int) ?*py.Object {
+    if (resolverError(status)) |code| {
+        return c.PyObject_CallFunction(gaierror, "is", @intFromEnum(code), std.c.gai_strerror(code));
+    }
     var buf: [128]u8 = undefined;
     const msg = uv.strerror(status, &buf);
-    const exc = c.PyObject_CallFunction(gaierror, "is", @as(c_int, status), msg.ptr) orelse {
+    return c.PyObject_CallFunction(@ptrCast(c.PyExc_OSError), "is", uv.toErrno(status), msg.ptr);
+}
+
+/// Raises it, for the paths that report synchronously rather than through a future.
+fn raiseResolverError(status: c_int) py.Error {
+    const exc = resolverException(status) orelse return py.Error.Python;
+    defer py.decref(exc);
+    c.PyErr_SetObject(@ptrCast(c.PyObject_Type(exc)), exc);
+    return py.Error.Python;
+}
+
+fn failFuture(future: *py.Object, status: c_int) void {
+    const exc = resolverException(status) orelse {
         py.writeUnraisable(future);
         return;
     };
@@ -370,6 +419,11 @@ pub fn getaddrinfo(self_obj: *py.Object, args: []const ?*py.Object) py.Error!*py
     hints.protocol = try py.asCInt(args[4].?);
     hints.flags = @bitCast(@as(u32, @bitCast(try py.asCInt(args[5].?))));
 
+    // libuv refuses this pair outright, before any resolver sees it, and reports
+    // it as EINVAL. The resolver the standard library reaches would have answered
+    // "neither node nor service", which is what callers are written to expect.
+    if (host == null and service == null) return raiseResolverError(uv.EAI_NONAME);
+
     if (resolveLiteral(&hints, host, service) orelse resolveNumeric(&hints, host, service)) |list| {
         defer py.decref(list);
         const future = c.PyObject_CallMethodNoArgs(@ptrCast(loop), str_create_future) orelse return py.Error.Python;
@@ -385,7 +439,8 @@ pub fn getaddrinfo(self_obj: *py.Object, args: []const ?*py.Object) py.Error!*py
     const req_host: ?[*:0]const u8 = if (host == null) null else @ptrCast(&req.host);
     const req_service: ?[*:0]const u8 = if (service == null) null else @ptrCast(&req.service);
 
-    try py.errUvIfNeg(uv.uv_getaddrinfo(loop.state().uvloop, req.addrReq(), onAddrInfo, req_host, req_service, &req.hints));
+    const status = uv.uv_getaddrinfo(loop.state().uvloop, req.addrReq(), onAddrInfo, req_host, req_service, &req.hints);
+    if (status < 0) return raiseResolverError(status);
     return py.newref(req.future.?).?;
 }
 
@@ -401,7 +456,8 @@ pub fn getnameinfo(self_obj: *py.Object, args: []const ?*py.Object) py.Error!*py
 
     const req = try allocRequest(loop, .getnameinfo);
     errdefer freeRequest(req, .getnameinfo);
-    try py.errUvIfNeg(uv.uv_getnameinfo(loop.state().uvloop, req.nameReq(), onNameInfo, storage.constPtr(), flags));
+    const status = uv.uv_getnameinfo(loop.state().uvloop, req.nameReq(), onNameInfo, storage.constPtr(), flags);
+    if (status < 0) return raiseResolverError(status);
     return py.newref(req.future.?).?;
 }
 

--- a/zig/dns.zig
+++ b/zig/dns.zig
@@ -114,8 +114,6 @@ pub fn traverse(st: *loopmod.State, visitproc: c.visitproc, arg: ?*anyopaque) c_
     return 0;
 }
 
-/// An empty host means the null host, as it does for `socket.getaddrinfo` -
-/// the wildcard address, not a host whose name is the empty string.
 fn copyZ(dst: []u8, value: *py.Object, what: [:0]const u8) py.Error!?[*:0]const u8 {
     if (py.isNone(value)) return null;
     var len: c.Py_ssize_t = 0;
@@ -134,7 +132,6 @@ fn copyZ(dst: []u8, value: *py.Object, what: [:0]const u8) py.Error!?[*:0]const 
         _ = c.PyErr_Format(@ptrCast(c.PyExc_TypeError), "%s must be str, bytes, int or None", what.ptr);
         return py.Error.Python;
     }
-    if (len == 0) return null;
     if (@as(usize, @intCast(len)) >= dst.len) return py.errValue("value too long");
     @memcpy(dst[0..@intCast(len)], src[0..@intCast(len)]);
     dst[@intCast(len)] = 0;
@@ -193,6 +190,15 @@ fn resolverException(status: c_int) ?*py.Object {
     var buf: [128]u8 = undefined;
     const msg = uv.strerror(status, &buf);
     return c.PyObject_CallFunction(@ptrCast(c.PyExc_OSError), "is", uv.toErrno(status), msg.ptr);
+}
+
+/// Raises `socket.gaierror` for a code the platform's resolver produced itself.
+fn raisePlatformError(code: std.c.EAI) py.Error {
+    const exc = c.PyObject_CallFunction(gaierror, "is", @intFromEnum(code), std.c.gai_strerror(code)) orelse
+        return py.Error.Python;
+    defer py.decref(exc);
+    c.PyErr_SetObject(gaierror, exc);
+    return py.Error.Python;
 }
 
 /// Raises it, for the paths that report synchronously rather than through a future.
@@ -423,6 +429,23 @@ pub fn getaddrinfo(self_obj: *py.Object, args: []const ?*py.Object) py.Error!*py
     // it as EINVAL. The resolver the standard library reaches would have answered
     // "neither node nor service", which is what callers are written to expect.
     if (host == null and service == null) return raiseResolverError(uv.EAI_NONAME);
+
+    // libuv runs every hostname through IDNA, which rejects an empty one, so `""`
+    // can never reach a resolver that way. The platforms disagree about what it
+    // means - BSD reads it as the null host, glibc as a name it cannot find - and
+    // matching `socket.getaddrinfo` means letting the platform answer rather than
+    // picking one. Neither looks anything up, so this cannot block the loop.
+    if (host) |name| if (name[0] == 0) {
+        var res: ?*std.c.addrinfo = null;
+        const rc = std.c.getaddrinfo(name, service, &hints, &res);
+        if (rc != @as(std.c.EAI, @enumFromInt(0))) return raisePlatformError(rc);
+        defer if (res) |first| std.c.freeaddrinfo(first);
+        const list = try buildResults(res);
+        defer py.decref(list);
+        const future = c.PyObject_CallMethodNoArgs(@ptrCast(loop), str_create_future) orelse return py.Error.Python;
+        settle(future, str_set_result, list);
+        return future;
+    };
 
     if (resolveLiteral(&hints, host, service) orelse resolveNumeric(&hints, host, service)) |list| {
         defer py.decref(list);

--- a/zig/uv.zig
+++ b/zig/uv.zig
@@ -146,6 +146,22 @@ fn negErrno(comptime e: std.c.E) c_int {
 }
 
 pub const EOF: c_int = -4095;
+/// libuv's own resolver codes, which are not errno values and do not vary by
+/// platform - unlike the `EAI_*` they correspond to.
+pub const EAI_ADDRFAMILY: c_int = -3000;
+pub const EAI_AGAIN: c_int = -3001;
+pub const EAI_BADFLAGS: c_int = -3002;
+pub const EAI_FAIL: c_int = -3004;
+pub const EAI_FAMILY: c_int = -3005;
+pub const EAI_MEMORY: c_int = -3006;
+pub const EAI_NODATA: c_int = -3007;
+pub const EAI_NONAME: c_int = -3008;
+pub const EAI_OVERFLOW: c_int = -3009;
+pub const EAI_SERVICE: c_int = -3010;
+pub const EAI_SOCKTYPE: c_int = -3011;
+pub const EAI_BADHINTS: c_int = -3013;
+pub const EAI_PROTOCOL: c_int = -3014;
+
 pub const EAGAIN = negErrno(.AGAIN);
 pub const ECANCELED = negErrno(.CANCELED);
 pub const EINVAL = negErrno(.INVAL);


### PR DESCRIPTION
`getaddrinfo` reported resolver failures as a bare `OSError` carrying libuv's own numbering:

```
                                 stdlib                                                    zuvloop
('no-such-host.invalid', 80)     socket.gaierror(8, 'nodename nor servname ...')            OSError(3008, 'unknown node or service')
('', 'http')                     4 results                                                  OSError(22, 'invalid argument')
('', None)                       socket.gaierror(8, 'nodename nor servname ...')            OSError(22, 'invalid argument')
```

`gaierror` subclasses `OSError`, so `except OSError` caught it either way - but `except socket.gaierror`, which is what code written against the standard library uses, did not, and `exc.errno` never matched `socket.EAI_NONAME`.

## The mapping has to come from libc

libuv's resolver codes are its own and identical on every platform. `EAI_*` is neither: `EAI_NONAME` is `8` on macOS and `-2` on glibc, and glibc has no `EAI_BADHINTS` or `EAI_PROTOCOL` at all. So the translation reads `std.c.EAI` at comptime, with a stand-in where a platform lacks a member, and takes the message from `gai_strerror` rather than from libuv.

Statuses that are not resolver failures - a cancellation, an allocation failure - stay `OSError`, as they should.

## Two more from the same sweep

**An empty host is the null host**, as it is for `socket.getaddrinfo` - the wildcard address, not a host whose name is the empty string. libuv was being handed `""` and rejecting it.

**Neither a host nor a port** is refused by libuv as `EINVAL` before any resolver sees it. The resolver the standard library reaches answers "neither node nor service".

`getnameinfo` gets the same treatment; its asynchronous path already routed through the shared helper, its synchronous one did not.

## Verification

Sweeping 1215 combinations of host, family, type, protocol, flags and port against `socket.getaddrinfo` - comparing results, exception type and exception args:

```
before:  differ 282 of 1215     198 both raise but of different type
                                 84 zuvloop raises where the stdlib returns
after:   differ 0 of 1215
```

Four new tests in `tests/test_dns.py`, each asserting agreement with the standard library rather than a hard-coded code, so they stay honest on Linux. All four fail against the previous build:

```
FAILED test_getaddrinfo_reports_failures                        OSError: [Errno 3008] unknown node or service
FAILED test_getaddrinfo_treats_an_empty_host_as_the_null_host   OSError: [Errno 22] invalid argument
FAILED test_getaddrinfo_without_a_host_or_a_port_reports_no_name OSError: [Errno 3008] unknown node or service
FAILED test_getnameinfo_reports_failures_as_the_stdlib_does     OSError: [Errno 3008] unknown node or service
```

296 tests, 100% branch coverage, ruff, mypy strict, CPython `test_asyncio` at 88/92. The literal fast path is untouched: `getaddrinfo_literal` still measures 478ns against uvloop's 787ns.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * DNS lookups now report resolver failures consistently with standard-library behavior.
  * Invalid or missing host and service information returns the appropriate name-resolution error.
  * Reverse DNS lookup failures now use the expected error type and details.
  * Improved handling of synchronous and asynchronous DNS resolution errors across platforms.

* **Tests**
  * Expanded coverage for DNS success and failure scenarios.
  * Improved subprocess signaling test reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->