### PR TITLE
Finish the native mutation before releasing what it held

### DIFF
--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -310,3 +310,44 @@ async def test_a_cancelled_read_leaves_the_next_one_watching() -> None:
     finally:
         left.close()
         right.close()
+
+
+async def test_replacing_a_watcher_survives_a_reentrant_finaliser() -> None:
+    """The slot has to name the new watcher before the old one is released.
+
+    Releasing a watcher runs its arguments' finalisers, and a finaliser is free to
+    call `remove_reader` for the same descriptor. If it finds the slot still
+    naming the handle being destroyed, it releases it a second time and closes a
+    poll handle the replacement is about to be armed on.
+    """
+    loop = running_loop()
+    left, right = socket.socketpair()
+    left.setblocking(False)
+    right.setblocking(False)
+    fd = right.fileno()
+    reentered: list[bool] = []
+
+    class Reentrant:
+        def __del__(self) -> None:
+            reentered.append(True)
+            loop.remove_reader(fd)
+
+    try:
+        loop.add_reader(fd, lambda _held: None, Reentrant())
+        loop.add_reader(fd, lambda: None)
+        assert reentered == [True]
+
+        # The descriptor has to remain watchable: an orphaned poll handle makes
+        # the next registration fail with EEXIST.
+        seen: list[str] = []
+        loop.remove_reader(fd)
+        loop.add_reader(fd, seen.append, "after")
+        left.send(b"!")
+        await asyncio.sleep(0.05)
+        # Level-triggered, so it fires until the data is read; only the surviving
+        # registration should ever have run.
+        assert seen and set(seen) == {"after"}
+        assert loop.remove_reader(fd) is True
+    finally:
+        left.close()
+        right.close()

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -344,8 +344,9 @@ async def test_replacing_a_watcher_survives_a_reentrant_finaliser() -> None:
         loop.add_reader(fd, seen.append, "after")
         left.send(b"!")
         await asyncio.sleep(0.05)
-        # Level-triggered, so it fires until the data is read; only the surviving
-        # registration should ever have run.
+        # That it fires at all is the point: an orphaned poll handle would have
+        # made the registration above fail. Level-triggered, so it fires until
+        # the data is read.
         assert seen and set(seen) == {"after"}
         assert loop.remove_reader(fd) is True
     finally:

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -349,5 +349,8 @@ async def test_replacing_a_watcher_survives_a_reentrant_finaliser() -> None:
         assert seen and set(seen) == {"after"}
         assert loop.remove_reader(fd) is True
     finally:
+        # An assertion above leaves the watcher armed, and closing a descriptor
+        # libuv is still polling is its own kind of trouble.
+        loop.remove_reader(fd)
         left.close()
         right.close()

--- a/zig/collections.zig
+++ b/zig/collections.zig
@@ -128,31 +128,28 @@ pub const Timers = struct {
     /// from inside the array would land on an entry not yet released. Which is
     /// also why the doomed handles are copied out rather than parked in the tail.
     pub fn compact(self: *Timers, isCancelled: *const fn (*py.Object) bool) void {
-        var none: [0]*py.Object = .{};
-        const doomed: []*py.Object = alloc.alloc(*py.Object, self.cancelled) catch none[0..];
-        defer if (doomed.len != 0) alloc.free(doomed);
+        // Sized by the heap rather than by `cancelled`, which is a hint and not a
+        // guarantee: `Handle.cancel` only reports to the loop while it still has
+        // one, so an entry can be cancelled without ever being counted. Nowhere
+        // to set them aside means nothing can be released, so the heap is left
+        // exactly as it was - count included - for the next cancellation to retry.
+        const doomed = alloc.alloc(*py.Object, self.len) catch return;
+        defer alloc.free(doomed);
         var dropped: usize = 0;
-        var kept: usize = 0;
         var write: usize = 0;
         var read: usize = 0;
         while (read < self.len) : (read += 1) {
             const entry = self.items[read];
             if (isCancelled(entry.handle)) {
-                if (dropped < doomed.len) {
-                    doomed[dropped] = entry.handle;
-                    dropped += 1;
-                    continue;
-                }
-                // Without room to set it aside it stays on the heap, cancelled
-                // and inert. It still counts, or the next compaction waits for a
-                // fresh `min_cancelled_timers` before it will reclaim it.
-                kept += 1;
+                doomed[dropped] = entry.handle;
+                dropped += 1;
+            } else {
+                self.items[write] = entry;
+                write += 1;
             }
-            self.items[write] = entry;
-            write += 1;
         }
         self.len = write;
-        self.cancelled = kept;
+        self.cancelled = 0;
         if (write >= 2) {
             var i = write / 2;
             while (i > 0) {

--- a/zig/collections.zig
+++ b/zig/collections.zig
@@ -132,22 +132,27 @@ pub const Timers = struct {
         const doomed: []*py.Object = alloc.alloc(*py.Object, self.cancelled) catch none[0..];
         defer if (doomed.len != 0) alloc.free(doomed);
         var dropped: usize = 0;
+        var kept: usize = 0;
         var write: usize = 0;
         var read: usize = 0;
         while (read < self.len) : (read += 1) {
             const entry = self.items[read];
-            // Without room to set it aside it stays on the heap, cancelled and
-            // inert, for the next compaction to reclaim.
-            if (isCancelled(entry.handle) and dropped < doomed.len) {
-                doomed[dropped] = entry.handle;
-                dropped += 1;
-            } else {
-                self.items[write] = entry;
-                write += 1;
+            if (isCancelled(entry.handle)) {
+                if (dropped < doomed.len) {
+                    doomed[dropped] = entry.handle;
+                    dropped += 1;
+                    continue;
+                }
+                // Without room to set it aside it stays on the heap, cancelled
+                // and inert. It still counts, or the next compaction waits for a
+                // fresh `min_cancelled_timers` before it will reclaim it.
+                kept += 1;
             }
+            self.items[write] = entry;
+            write += 1;
         }
         self.len = write;
-        self.cancelled = 0;
+        self.cancelled = kept;
         if (write >= 2) {
             var i = write / 2;
             while (i > 0) {

--- a/zig/collections.zig
+++ b/zig/collections.zig
@@ -119,13 +119,28 @@ pub const Timers = struct {
     }
 
     /// Drops cancelled entries once they dominate the heap.
+    /// Drops cancelled entries and restores the heap.
+    ///
+    /// The handles are released only once the heap is whole again. Releasing one
+    /// runs its arguments' finalizers, and a finalizer calling `call_later`
+    /// reaches `push`, which writes at `items[len]` and sifts - so a release from
+    /// inside the pass would shuffle slots the pass has already moved, and one
+    /// from inside the array would land on an entry not yet released. Which is
+    /// also why the doomed handles are copied out rather than parked in the tail.
     pub fn compact(self: *Timers, isCancelled: *const fn (*py.Object) bool) void {
+        var none: [0]*py.Object = .{};
+        const doomed: []*py.Object = alloc.alloc(*py.Object, self.cancelled) catch none[0..];
+        defer if (doomed.len != 0) alloc.free(doomed);
+        var dropped: usize = 0;
         var write: usize = 0;
         var read: usize = 0;
         while (read < self.len) : (read += 1) {
             const entry = self.items[read];
-            if (isCancelled(entry.handle)) {
-                py.decref(entry.handle);
+            // Without room to set it aside it stays on the heap, cancelled and
+            // inert, for the next compaction to reclaim.
+            if (isCancelled(entry.handle) and dropped < doomed.len) {
+                doomed[dropped] = entry.handle;
+                dropped += 1;
             } else {
                 self.items[write] = entry;
                 write += 1;
@@ -133,12 +148,14 @@ pub const Timers = struct {
         }
         self.len = write;
         self.cancelled = 0;
-        if (write < 2) return;
-        var i = write / 2;
-        while (i > 0) {
-            i -= 1;
-            self.siftDown(i);
+        if (write >= 2) {
+            var i = write / 2;
+            while (i > 0) {
+                i -= 1;
+                self.siftDown(i);
+            }
         }
+        for (doomed[0..dropped]) |handle| py.decref(handle);
     }
 
     fn grow(self: *Timers) error{OutOfMemory}!void {

--- a/zig/poller.zig
+++ b/zig/poller.zig
@@ -54,18 +54,26 @@ fn onClosed(handle: ?*uv.Handle) callconv(.c) void {
     alloc.free(@as([*]u8, @ptrCast(self))[0 .. poll_offset + uv.uv_handle_size(.poll)]);
 }
 
+/// Detaches the handles and closes the descriptor before releasing anything.
+///
+/// Releasing a handle runs its arguments' finalizers, and a finalizer is free to
+/// call `remove_reader` for this same descriptor. Anything it can reach has to be
+/// consistent by then, or it re-enters onto a slot holding a dying handle and a
+/// `uv_poll_t` that is about to be closed twice.
 fn destroy(self: *Poller) void {
-    if (self.reader) |h| {
-        h.flags |= handlemod.CANCELLED;
-        py.decref(h);
-        self.reader = null;
-    }
-    if (self.writer) |h| {
-        h.flags |= handlemod.CANCELLED;
-        py.decref(h);
-        self.writer = null;
-    }
+    const reader = self.reader;
+    const writer = self.writer;
+    self.reader = null;
+    self.writer = null;
     uv.uv_close(uv.asHandle(self.uvPoll()), onClosed);
+    if (reader) |h| {
+        h.flags |= handlemod.CANCELLED;
+        py.decref(h);
+    }
+    if (writer) |h| {
+        h.flags |= handlemod.CANCELLED;
+        py.decref(h);
+    }
 }
 
 fn get(st: *State, loop: *LoopObject, fd: c_int) py.Error!*Poller {
@@ -112,11 +120,12 @@ fn add(self_obj: *py.Object, args: []const ?*py.Object, comptime writer: bool) p
     const poller = try get(st, loop, fd);
     const h = try handlemod.create(handlemod.handle_type.?, self_obj, args[1].?, args[2..], null);
     const slot = if (writer) &poller.writer else &poller.reader;
-    if (slot.*) |old| {
-        old.flags |= handlemod.CANCELLED;
-        py.decref(old);
-    }
+    // The slot has to name the new handle before the old one is released; see
+    // `destroy`. The `defer` also covers the error path out of `rearm`.
+    const superseded = slot.*;
     slot.* = h;
+    defer if (superseded) |old| py.decref(old);
+    if (superseded) |old| old.flags |= handlemod.CANCELLED;
     try rearm(st, poller);
     return py.noneRef();
 }
@@ -127,9 +136,9 @@ fn remove(self_obj: *py.Object, arg: *py.Object, comptime writer: bool) py.Error
     const poller = st.pollers.get(fd) orelse return py.boolRef(false);
     const slot = if (writer) &poller.writer else &poller.reader;
     const h = slot.* orelse return py.boolRef(false);
-    h.flags |= handlemod.CANCELLED;
-    py.decref(h);
     slot.* = null;
+    h.flags |= handlemod.CANCELLED;
+    defer py.decref(h);
     try rearm(st, poller);
     return py.boolRef(true);
 }

--- a/zig/process.zig
+++ b/zig/process.zig
@@ -258,7 +258,14 @@ pub fn spawnProcess(self_obj: *py.Object, args_in: []const ?*py.Object) py.Error
 
     uv.setData(self.handle(), self);
     const status = uv.uv_spawn(st.uvloop, self.handle(), &options);
-    if (status < 0) return py.errUv(status);
+    if (status < 0) {
+        // `uv_spawn` links the handle into the loop before anything in it can
+        // fail, and only `uv_close` unlinks it. Freeing the object here would
+        // leave the loop holding a queue node inside it.
+        py.incref(obj); // released by the close callback
+        uv.uv_close(uv.asHandle(self.handle()), onClosed);
+        return py.errUv(status);
+    }
 
     self.flags |= OPEN;
     py.incref(obj); // released by the close callback


### PR DESCRIPTION
Three places released a Python reference while the structure it belonged to was still half-updated. `Py_DECREF` can run arbitrary Python - a finaliser, a weakref callback, no `__del__` required - and every one of these is reachable from the loop's own public API, so that Python sees the half-updated structure and acts on it.

Found by a measured audit of the Zig layer. All three went through adversarial verification and none were refuted.

## `poller.zig` - releases before the slot names the replacement

`add` released the superseded watcher while the slot still pointed at it, so a finaliser calling `remove_reader` for the same descriptor released it a second time, drove the poller to zero events, and closed the `uv_poll_t` that the replacement was about to be armed on. The descriptor was left unwatchable:

```
FileExistsError: [Errno 17] file already exists
```

`destroy` had the same ordering and `remove` the mirror image. All three now detach first and release last. The `defer` also covers the error path out of `rearm`, which leaked before.

## `process.zig` - frees a handle libuv still owns

`uv_spawn` runs `uv__handle_init` as its **first** statement, before any `goto error` exists (`vendor/libuv/src/unix/process.c:991`), and that links the handle into `loop->handle_queue` (`uv-common.h:332-340`). The only thing that unlinks it is `uv__finish_close` (`unix/core.c:360`), reachable only through `uv_close`. On failure the `errdefer py.decref(obj)` freed the object anyway, leaving the loop holding an intrusive queue node inside freed memory.

It now closes the handle on that path, exactly as the datagram path already did.

## `collections.zig` - releases timers mid-compaction

`compact` released cancelled handles inside the pass walking `self.items`. That release reaches `call_later`, which pushes at `items[len]` and sifts - shuffling slots the pass has already moved, so the heap ends up with entries duplicated, others dropped, and its ordering invariant broken.

The doomed handles are copied out first and released once the heap is whole again. Parking them in the array's tail would not work: that is precisely where a re-entrant push lands.

## Verification

`tests/test_sockets.py::test_replacing_a_watcher_survives_a_reentrant_finaliser` fails with `FileExistsError` against the previous build and passes here.

The other two corrupt silently rather than raising - reading freed memory usually appears to work, which is why they are dangerous rather than why they are not bugs. They are covered by their reproductions from the audit, and the `uv_spawn` one is established from libuv's own source rather than from a probe.

300 tests, 100% branch coverage, ruff, ruff format, mypy strict.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finish native updates before releasing Python refs to prevent re-entrant corruption. Also fix watcher replacement/removal ordering, process spawn failure cleanup, and timer compaction to avoid double frees, unwatchable descriptors, and missed cancellations.

- Bug Fixes
  - Poller: set the slot to the new handle before releasing the old one; detach reader/writer and close `uv_poll_t` in destroy before decref; in remove, clear the slot before decref; `defer` now also covers `rearm` failures.
  - Process: on `uv_spawn` error, incref and `uv_close` the handle instead of freeing while it’s still linked in the loop.
  - Timers: copy canceled handles out, rebuild the heap, then release; size the compaction buffer by the heap (not the canceled count); on allocation failure, leave them canceled on the heap and keep the `cancelled` count so the next compaction reclaims them.

<sup>Written for commit b53753aedd6735b9b95cf237636a2cf691252454. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/15?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved watcher replacement so callbacks remain safe during removal and re-registration.
  - Prevented timer cleanup from disrupting scheduling and heap maintenance.
  - Improved poller handle replacement, removal, and shutdown reliability.
  - Ensured process resources are properly closed when launching a process fails.

- **Tests**
  - Added regression coverage for watcher replacement, re-registration, and readiness notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->