### PR TITLE
Compile for every target a wheel is published for

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,45 @@ jobs:
           uv run coverage report
 
 
+  # The Zig layer reaches libc through `std.c`, whose shape differs per target,
+  # and the tests only ever run on the host. Two bugs have shipped that a
+  # compile for the other target would have caught on the way in.
+  cross-compile:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - x86_64-linux-gnu
+          - aarch64-linux-gnu
+          - x86_64-linux-musl
+          - aarch64-linux-musl
+          - x86_64-macos
+          - aarch64-macos
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install
+        run: uv sync --python 3.14 --group dev
+
+      # The headers are the host's, which is enough: this compiles the Zig, and
+      # what differs between targets is `std.c`, not `Python.h`.
+      - name: Compile for ${{ matrix.target }}
+        run: |
+          HATCH_ZIG_PYTHON_INCLUDE="$(uv run python -c 'import sysconfig; print(sysconfig.get_path("include"))')" \
+            zig build -Dtarget=${{ matrix.target }} -Doptimize=ReleaseFast
+
+
   benchmarks:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
The Zig layer reaches libc through `std.c`, whose shape differs per target, and the tests only ever run on the host. Two bugs have already shipped that a compile for the other target would have caught on the way in:

- `std.c.fstat`, which does not exist on Linux (fixed in #8)
- descriptors left inheritable, which only matters there (fixed in #6)

## What it is worth

Putting `std.c.fstat` back shows the job doing its job - the host build is clean and the cross build is not:

```
macos target             exit=0
x86_64-linux-gnu target  zig/transport.zig:412:14: error: type 'void' not a function
```

## Coverage

The matrix is the six targets wheels are published for:

```
x86_64-linux-gnu     aarch64-linux-gnu
x86_64-linux-musl    aarch64-linux-musl
x86_64-macos         aarch64-macos
```

All six compile on `main` today; verified locally before adding them.

It compiles against the host's Python headers rather than fetching per-target ones. That is enough for what this catches: the thing that differs between targets is `std.c`, not `Python.h`. It is a compile check, not a build of a shippable artifact - `cibuildwheel` still does that in `publish.yml`.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a CI cross-compile job that builds the Zig layer for every wheel target to catch `std.c` target differences before release. Compiles against host Python headers and prevents Linux-only regressions like missing `std.c.fstat` or inheritable descriptors.

- **New Features**
  - Adds `cross-compile` job for: `x86_64-linux-gnu`, `aarch64-linux-gnu`, `x86_64-linux-musl`, `aarch64-linux-musl`, `x86_64-macos`, `aarch64-macos`.
  - Uses `zig` 0.16.0 with `uv` (`uv sync --python 3.14`); runs `zig build -Dtarget=... -Doptimize=ReleaseFast`.
  - Points `HATCH_ZIG_PYTHON_INCLUDE` to host headers; compile-only check. Publishing stays in `cibuildwheel`.

<sup>Written for commit ff935bec41538a805a24b048d3a11cf11c91b02e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/21?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

