### PR TITLE
Take EADDRINUSE from the platform rather than from the source

### DIFF
--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1306,3 +1306,15 @@ async def test_the_asyncio_server_hook_unregisters_and_closes() -> None:
     loop._stop_serving(sock)
 
     assert sock.fileno() == -1
+
+
+async def test_binding_a_unix_path_twice_names_the_path() -> None:
+    """The check read Linux's EADDRINUSE, so on any other platform it never fired."""
+    loop = running_loop()
+    with tempfile.TemporaryDirectory() as directory:
+        path = Path(directory) / "taken.sock"
+        server = await loop.create_unix_server(Echo, path)
+        async with server:
+            with pytest.raises(OSError, match="already in use") as caught:
+                await loop.create_unix_server(Echo, path)
+            assert str(path) in str(caught.value)

--- a/zuvloop/_connect.py
+++ b/zuvloop/_connect.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import errno
 import os
 import signal
 import socket
@@ -219,7 +220,9 @@ class ConnectionOperations(SocketOperations):
                 sock.bind(path)
             except OSError as exc:
                 sock.close()
-                if exc.errno == 98 or isinstance(exc, FileExistsError):  # pragma: no cover - platform dependent
+                # 98 is Linux's EADDRINUSE and 48 is this platform's, so the
+                # number has to come from the platform rather than the source.
+                if exc.errno == errno.EADDRINUSE or isinstance(exc, FileExistsError):
                     raise OSError(exc.errno, f"Address {path!r} is already in use") from None
                 raise
             sock.setblocking(False)


### PR DESCRIPTION
`create_unix_server` compared `exc.errno` against the literal `98`, which is Linux's `EADDRINUSE`:

```python
if exc.errno == 98 or isinstance(exc, FileExistsError):  # pragma: no cover - platform dependent
    raise OSError(exc.errno, f"Address {path!r} is already in use") from None
```

It is 48 on macOS, so the branch was dead there and the message it exists to produce never appeared. Being dead, it also carried a `# pragma: no cover`, which is why nothing noticed.

It reads `errno.EADDRINUSE` now, which is correct on both. The pragma goes with it - the branch is reachable everywhere, and there is a test that binds a path twice and asserts the path is named in the error.

```
EADDRINUSE on this platform = 48
rebinding a unix path       -> OSError errno=48
```

301 tests, 100% branch coverage, ruff, ruff format, mypy strict.

Found by a measured audit of the Zig and Python layers, in the pass looking specifically for things that only differ on Linux.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use platform `errno.EADDRINUSE` in `create_unix_server` instead of a Linux-only errno. This ensures the "address already in use" error triggers on all platforms and includes a test that checks the path appears in the message.

- **Bug Fixes**
  - Compare `exc.errno` to `errno.EADDRINUSE` (keep `FileExistsError` handling) to surface the correct error on macOS and Linux.
  - Remove the `# pragma: no cover` and add a test that binds a UNIX path twice and asserts the path is named in the error.

<sup>Written for commit d80ebbddf2c410a2eceabe7d3d454dee6c468edc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/22?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

