### PR TITLE
Resync the lock with the version it locks

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -883,7 +883,7 @@ wheels = [
 
 [[package]]
 name = "zuvloop"
-version = "0.1.0"
+version = "0.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-api" },


### PR DESCRIPTION
`uv.lock` recorded `zuvloop 0.1.0` while `pyproject.toml` declares `0.0.1`, so every `uv run` rewrote it and left the checkout dirty.

That is a nuisance on its own, and worse, it quietly attaches itself to whatever is being committed at the time - I have had to strip it out of half a dozen commits this week.

```
$ uv lock
Resolved 45 packages in 8ms
Updated zuvloop v0.1.0 -> v0.0.1
```

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resynced `uv.lock` to `zuvloop` version `0.0.1` to match `pyproject.toml`. This prevents `uv run` from rewriting the lock file and leaving the repo dirty or adding noise to commits.

<sup>Written for commit 3d169e9e5e708f992d01f6ca5d03a341758676db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/24?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

