### PR TITLE
Add SECURITY, CONTRIBUTING and a changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,5 +47,6 @@ First release. A libuv event loop for CPython 3.14, written in Zig.
 - OpenTelemetry spans and metrics, sampled natively, with no runtime dependency
   on an SDK.
 - Wheels for macOS and Linux, x86-64 and arm64, glibc and musl.
-- 88 of CPython's 92 `test_asyncio` loop conformance tests pass; the four skips
-  are white-box tests of CPython's own internals.
+- 88 of CPython's 92 `test_asyncio` loop conformance tests pass. Three of the
+  four skips are white-box tests of CPython's own internals, which no loop
+  outside the standard library can satisfy; the fourth the suite skips itself.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,51 @@
+# Changelog
+
+All notable changes are recorded here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
+follows [semantic versioning](https://semver.org/spec/v2.0.0.html) - with the
+usual caveat that anything below `1.0.0` may break between minor versions.
+
+## Unreleased
+
+### Fixed
+
+- `connection_lost` receives the reason the transport closed rather than the
+  `ECANCELED` libuv reports for writes cancelled by the close itself. `abort()`
+  delivered `OSError(89)` where asyncio and uvloop deliver `None`, and a peer
+  reset arrived as a cancellation instead of `BrokenPipeError`.
+- `write()`, `writelines()` and `sendto()` drop what they are given on a closing
+  transport rather than raising `RuntimeError`. Only `write_eof()` makes a later
+  write an error, as in asyncio.
+- A read callback that raises closes the connection and delivers the exception
+  to `connection_lost`, instead of being reported and then handed the next chunk.
+- A connected datagram endpoint accepts `sendto(data, addr)` when `addr` names
+  the peer it is connected to.
+- A port outside 0-65535 is refused rather than truncated: a datagram addressed
+  to port 70000 was being delivered to port 4464.
+- `getnameinfo` raises `socket.gaierror` for a host that is not an address
+  literal, rather than the `OSError(EINVAL)` libuv reports for refusing to parse
+  it.
+- Three places in the native layer released a Python reference while the
+  structure holding it was still half-updated, where a finaliser could reach it:
+  the reader and writer registrations, a `uv_process_t` freed after a failed
+  spawn while libuv still had it queued, and the timer heap's compaction.
+- `create_unix_server` reports "address already in use" on platforms whose
+  `EADDRINUSE` is not Linux's 98.
+
+### Added
+
+- The Zig is compiled in CI for every target a wheel is published for. Two
+  Linux-only defects have shipped that this would have caught.
+- `SECURITY.md`, `CONTRIBUTING.md` and this file.
+
+## 0.0.1 - 2026-08-05
+
+First release. A libuv event loop for CPython 3.14, written in Zig.
+
+- The whole `AbstractEventLoop` surface: connections, servers, TLS, datagrams,
+  pipes, subprocesses, signals, readers and writers, and name resolution.
+- OpenTelemetry spans and metrics, sampled natively, with no runtime dependency
+  on an SDK.
+- Wheels for macOS and Linux, x86-64 and arm64, glibc and musl.
+- 88 of CPython's 92 `test_asyncio` loop conformance tests pass; the four skips
+  are white-box tests of CPython's own internals.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,8 +38,12 @@ through `std.c`, whose shape differs per target, so code that builds on your
 machine can still fail elsewhere:
 
 ```console
+$ export HATCH_ZIG_PYTHON_INCLUDE="$(uv run python -c 'import sysconfig; print(sysconfig.get_path("include"))')"
 $ zig build -Dtarget=x86_64-linux-gnu
 ```
+
+The build takes the Python headers from that variable, which the wheel hook
+normally sets for you - without it `zig build` stops and says so.
 
 Benchmarks run through CodSpeed on every commit. They are noisy, and a CodSpeed
 regression on its own does not block a change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,79 @@
+# Contributing
+
+## Getting set up
+
+```console
+$ uv venv --python 3.14
+$ uv sync --group dev --group bench
+$ uv run pytest
+```
+
+Building the extension needs Zig 0.16. `uv sync` installs it from the `ziglang`
+package, so nothing has to be on your `PATH`; a system Zig is used if you have
+one. After changing anything under `zig/`, rebuild before testing:
+
+```console
+$ uv pip install -e . --reinstall-package zuvloop
+```
+
+## What CI checks
+
+Everything below runs on Linux and macOS, and all of it has to pass:
+
+```console
+$ uv run ruff check
+$ uv run ruff format --check
+$ uv run mypy
+$ uv run coverage run -m pytest
+$ uv run coverage report          # fails under 100%
+```
+
+Coverage is enforced at 100% branch coverage over `zuvloop` and `tests`. A line
+that genuinely cannot be reached takes a `# pragma: no cover` with a reason
+after it - but check first that it is really unreachable rather than merely
+untested, because that comment is also how a dead branch hides.
+
+The Zig is compiled for every target a wheel is published for. It reaches libc
+through `std.c`, whose shape differs per target, so code that builds on your
+machine can still fail elsewhere:
+
+```console
+$ zig build -Dtarget=x86_64-linux-gnu
+```
+
+Benchmarks run through CodSpeed on every commit. They are noisy, and a CodSpeed
+regression on its own does not block a change.
+
+## Conformance
+
+CPython's own `test_asyncio` runs against this loop:
+
+```console
+$ uv run python scripts/conformance.py
+```
+
+It downloads the source of whichever interpreter you are running and runs each
+test in its own process, so a hang is reported rather than stopping the run.
+Everything that is skipped says why in the harness.
+
+## Measuring against uvloop
+
+Do not read `pytest --codspeed`'s table across rows. `pytest-codspeed` divides
+by `iter_per_round` twice and picks that divisor per row, so the ratio between
+two rows is scaled by an unrelated number. `benchmarks/compare.py` alternates
+the loops in one process and is the harness for that question.
+
+## Changes to the native layer
+
+The Zig has no coverage gate, and most of the defects found in this project have
+been there - reference counts and C API contracts especially. Two rules carry
+most of the weight:
+
+- Finish the mutation before releasing what it held. `Py_DECREF` can run
+  arbitrary Python, and that Python can reach the structure being mutated.
+- Take contracts from CPython's source rather than from memory. Which functions
+  return borrowed references and which return new ones is not guessable.
+
+Claims about behaviour are worth what they are measured at. A comparison against
+stock asyncio and uvloop is usually a dozen lines, and this project has a
+history of confident reasoning that measurement then contradicted.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security
+
+## Reporting
+
+Report a vulnerability through
+[GitHub's advisory form](https://github.com/Kludex/zuvloop/security/advisories/new),
+which keeps the report private until there is a fix. Please do not open a public
+issue for one.
+
+Expect an acknowledgement within a few days.
+
+## Supported versions
+
+Only the latest release. zuvloop is at `0.0.x` and nothing older is patched.
+
+## What is in scope
+
+zuvloop is a CPython extension written in Zig around a vendored libuv, so a
+memory-safety fault here is reachable from ordinary Python:
+
+- Reference counting: a leak, a double release, or a release that lets a
+  finaliser see a structure mid-mutation.
+- Descriptor ownership: a double close, or use of a descriptor libuv has closed.
+- The hand-declared libuv ABI in `zig/uv.zig`, which is not generated from
+  libuv's headers and can silently disagree with them.
+- Anything that lets a peer's input reach memory it should not.
+
+The vendored libuv is under `vendor/libuv`. Vulnerabilities in libuv itself
+belong upstream; tell us as well, and the vendored copy will be updated.
+
+Note that the released wheels are built `ReleaseFast`, which disables Zig's
+bounds and overflow checks. That is deliberate for the hot paths, and it means a
+bug that would trap in a debug build can corrupt memory in a released one.


### PR DESCRIPTION
Three files the repository did not have.

**`SECURITY.md`** - where to report, and what counts. zuvloop is a CPython extension written in Zig around a vendored libuv, so the interesting faults are reference counting, descriptor ownership and the hand-declared libuv ABI in `zig/uv.zig`, all reachable from ordinary Python. It also states plainly that released wheels are built `ReleaseFast`, which disables Zig's bounds and overflow checks - a bug that would trap in a debug build can corrupt memory in a released one, and someone assessing a report should know that.

**`CONTRIBUTING.md`** - setup, what CI enforces, and how to run the conformance suite. The section on the native layer is the part worth reading: it names the two mistakes that have actually produced defects here, which are releasing a reference before the mutation holding it has finished, and taking C API contracts from memory instead of from CPython's source. It also warns against reading CodSpeed's table across rows, since that comparison is not valid and has already misled once.

**`CHANGELOG.md`** - 0.0.1 and everything fixed since.

Verified the docs build still passes (`./scripts/docs` → no issues), suite green, ruff and mypy clean.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `SECURITY.md`, `CONTRIBUTING.md`, and `CHANGELOG.md` for security reporting, contribution workflow, and release history. Clarifies memory-safety focus for the Zig/CPython + libuv layer, fixes the conformance skip count, documents CI builds for all wheel targets, makes the cross-compile example work by exporting `HATCH_ZIG_PYTHON_INCLUDE`, and notes wheels are built with `ReleaseFast`.

<sup>Written for commit 23cd948f1ed4ae0f4ccf98037f527d8bf9800022. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/25?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

