### PR TITLE
Compare every shape against uvloop, not just the echo

### DIFF
--- a/benchmarks/compare.py
+++ b/benchmarks/compare.py
@@ -21,7 +21,6 @@ import statistics
 import sys
 import time
 from collections.abc import Callable, Coroutine
-from typing import Any
 
 import uvloop
 
@@ -132,13 +131,15 @@ def bulk(loop: asyncio.AbstractEventLoop) -> Callable[[], None]:
     """16 MiB in one direction, with flow control engaged."""
     chunk = b"x" * 65536
     total = 16 << 20
-    sinks: list[Any] = []
+    # `create_connection` returns on the client's connect; the server's protocol
+    # is built when the loop accepts, which need not have happened yet.
+    accepted: asyncio.Future[Sink] = loop.create_future()
 
     class Sink(asyncio.Protocol):
         def __init__(self) -> None:
             self.received = 0
-            self.done = loop.create_future()
-            sinks.append(self)
+            self.done: asyncio.Future[None] = loop.create_future()
+            accepted.set_result(self)
 
         def data_received(self, data: bytes) -> None:
             self.received += len(data)
@@ -149,15 +150,17 @@ def bulk(loop: asyncio.AbstractEventLoop) -> Callable[[], None]:
     port = server.sockets[0].getsockname()[1]
 
     async def once() -> None:
-        sinks.clear()
+        nonlocal accepted
+        accepted = loop.create_future()
         transport, _protocol = await loop.create_connection(asyncio.Protocol, "127.0.0.1", port)
+        sink = await accepted
         sent = 0
         while sent < total:
             transport.write(chunk)
             sent += len(chunk)
             if transport.get_write_buffer_size() > (4 << 20):
                 await asyncio.sleep(0)
-        await sinks[0].done
+        await sink.done
         transport.close()
 
     return _driver(loop, once)
@@ -236,7 +239,7 @@ def _noop() -> None:
     pass
 
 
-def _driver(loop: asyncio.AbstractEventLoop, once: Callable[[], Coroutine[Any, Any, None]]) -> Callable[[], None]:
+def _driver(loop: asyncio.AbstractEventLoop, once: Callable[[], Coroutine[None, None, None]]) -> Callable[[], None]:
     return lambda: loop.run_until_complete(once())
 
 

--- a/benchmarks/compare.py
+++ b/benchmarks/compare.py
@@ -1,13 +1,14 @@
-"""Compare zuvloop against uvloop on one workload, honestly.
+"""Compare zuvloop against uvloop, honestly.
 
     uv run --group bench python benchmarks/compare.py
+    uv run --group bench python benchmarks/compare.py echo timers
 
 `test_benchmarks.py` records what changed between commits, which is what CodSpeed
 is for, but its table cannot answer "how does this compare to uvloop" - see the
-note there. This alternates the two loops inside a single process so machine
-drift moves both arms equally, and reports the median as well as the minimum: a
-minimum taken across distributions with different spread favours whichever arm is
-noisier, and uvloop's spread here runs several times zuvloop's.
+note there. This alternates the loops inside a single process so machine drift
+moves both arms equally, and reports the median as well as the minimum: a minimum
+taken across distributions with different spread favours whichever arm is
+noisier, and uvloop's spread runs several times zuvloop's on some of these.
 """
 
 from __future__ import annotations
@@ -15,73 +16,243 @@ from __future__ import annotations
 import asyncio
 import gc
 import os
+import socket
 import statistics
+import sys
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
+from typing import Any
 
 import uvloop
 
 import zuvloop
 
-PAYLOAD = os.urandom(1024)
-ROUNDTRIPS = 2000
-REPS = 60
+type Factory = Callable[[], asyncio.AbstractEventLoop]
+type Workload = Callable[[asyncio.AbstractEventLoop], Callable[[], None]]
 
-Factory = Callable[[], asyncio.AbstractEventLoop]
+PAYLOAD = os.urandom(1024)
+REPS = 40
+
+
+# ---------------------------------------------------------------------------
+# workloads
+#
+# Each builds whatever it needs against one loop and returns the thing to time.
+# Setup stays outside the measurement; only the returned callable is timed.
+
+
+def echo(loop: asyncio.AbstractEventLoop) -> Callable[[], None]:
+    """A 1 KiB ping-pong, 2000 times. Latency on one connection."""
+    roundtrips = 2000
+
+    class Server(asyncio.Protocol):
+        def connection_made(self, transport: asyncio.BaseTransport) -> None:
+            self.transport = transport
+
+        def data_received(self, data: bytes) -> None:
+            self.transport.write(data)  # type: ignore[attr-defined]
+
+    server = loop.run_until_complete(loop.create_server(Server, "127.0.0.1", 0))
+    port = server.sockets[0].getsockname()[1]
+
+    class Client(asyncio.Protocol):
+        def __init__(self) -> None:
+            self.pending = 0
+            self.remaining = roundtrips
+            self.done = loop.create_future()
+
+        def connection_made(self, transport: asyncio.BaseTransport) -> None:
+            self.transport = transport
+            transport.write(PAYLOAD)  # type: ignore[attr-defined]
+
+        def data_received(self, data: bytes) -> None:
+            self.pending += len(data)
+            while self.pending >= len(PAYLOAD):
+                self.pending -= len(PAYLOAD)
+                self.remaining -= 1
+                if self.remaining == 0:
+                    self.done.set_result(None)
+                    return
+                self.transport.write(PAYLOAD)  # type: ignore[attr-defined]
+
+    async def once() -> None:
+        transport, protocol = await loop.create_connection(Client, "127.0.0.1", port)
+        await protocol.done
+        transport.close()
+
+    return _driver(loop, once)
+
+
+def split_write(loop: asyncio.AbstractEventLoop) -> Callable[[], None]:
+    """A response written as a header and a body, as ASGI does it."""
+    head, body = b"HTTP/1.1 200 OK\r\ncontent-length: 2\r\n\r\n", b"ok"
+    responses = 1000
+
+    class Server(asyncio.Protocol):
+        def connection_made(self, transport: asyncio.BaseTransport) -> None:
+            self.transport = transport
+
+        def data_received(self, data: bytes) -> None:
+            for _ in range(data.count(b"\n")):
+                self.transport.write(head)  # type: ignore[attr-defined]
+                self.transport.write(body)  # type: ignore[attr-defined]
+
+    server = loop.run_until_complete(loop.create_server(Server, "127.0.0.1", 0))
+    port = server.sockets[0].getsockname()[1]
+
+    class Client(asyncio.Protocol):
+        def __init__(self) -> None:
+            self.seen = 0
+            self.remaining = responses
+            self.done = loop.create_future()
+
+        def connection_made(self, transport: asyncio.BaseTransport) -> None:
+            self.transport = transport
+            transport.write(b"\n")  # type: ignore[attr-defined]
+
+        def data_received(self, data: bytes) -> None:
+            self.seen += len(data)
+            while self.seen >= len(head) + len(body):
+                self.seen -= len(head) + len(body)
+                self.remaining -= 1
+                if self.remaining == 0:
+                    self.done.set_result(None)
+                    return
+                self.transport.write(b"\n")  # type: ignore[attr-defined]
+
+    async def once() -> None:
+        transport, protocol = await loop.create_connection(Client, "127.0.0.1", port)
+        await protocol.done
+        transport.close()
+
+    return _driver(loop, once)
+
+
+def bulk(loop: asyncio.AbstractEventLoop) -> Callable[[], None]:
+    """16 MiB in one direction, with flow control engaged."""
+    chunk = b"x" * 65536
+    total = 16 << 20
+    sinks: list[Any] = []
+
+    class Sink(asyncio.Protocol):
+        def __init__(self) -> None:
+            self.received = 0
+            self.done = loop.create_future()
+            sinks.append(self)
+
+        def data_received(self, data: bytes) -> None:
+            self.received += len(data)
+            if self.received >= total and not self.done.done():
+                self.done.set_result(None)
+
+    server = loop.run_until_complete(loop.create_server(Sink, "127.0.0.1", 0))
+    port = server.sockets[0].getsockname()[1]
+
+    async def once() -> None:
+        sinks.clear()
+        transport, _protocol = await loop.create_connection(asyncio.Protocol, "127.0.0.1", port)
+        sent = 0
+        while sent < total:
+            transport.write(chunk)
+            sent += len(chunk)
+            if transport.get_write_buffer_size() > (4 << 20):
+                await asyncio.sleep(0)
+        await sinks[0].done
+        transport.close()
+
+    return _driver(loop, once)
+
+
+def call_soon(loop: asyncio.AbstractEventLoop) -> Callable[[], None]:
+    """Scheduling on its own: 10000 callbacks, no arguments."""
+    iterations = 10_000
+
+    async def once() -> None:
+        done = loop.create_future()
+        seen = 0
+
+        def step() -> None:
+            nonlocal seen
+            seen += 1
+            if seen == iterations:
+                done.set_result(None)
+
+        for _ in range(iterations):
+            loop.call_soon(step)
+        await done
+
+    return _driver(loop, once)
+
+
+def timers(loop: asyncio.AbstractEventLoop) -> Callable[[], None]:
+    """Timer bookkeeping: schedule and cancel, never firing."""
+    iterations = 10_000
+
+    async def once() -> None:
+        for _ in range(iterations):
+            loop.call_later(30, _noop).cancel()
+
+    return _driver(loop, once)
+
+
+def getaddrinfo(loop: asyncio.AbstractEventLoop) -> Callable[[], None]:
+    """An address literal, which is what create_connection is handed most often."""
+
+    async def once() -> None:
+        for _ in range(200):
+            await loop.getaddrinfo("127.0.0.1", 80, type=socket.SOCK_STREAM)
+
+    return _driver(loop, once)
+
+
+def spawn(loop: asyncio.AbstractEventLoop) -> Callable[[], None]:
+    """Twenty processes, spawned and reaped."""
+
+    async def once() -> None:
+        for _ in range(20):
+            process = await asyncio.create_subprocess_exec(
+                "/usr/bin/true",
+                stdin=asyncio.subprocess.DEVNULL,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            await process.wait()
+
+    return _driver(loop, once)
+
+
+WORKLOADS: dict[str, Workload] = {
+    "echo": echo,
+    "split_write": split_write,
+    "bulk": bulk,
+    "call_soon": call_soon,
+    "timers": timers,
+    "getaddrinfo": getaddrinfo,
+    "spawn": spawn,
+}
+
+
+def _noop() -> None:
+    pass
+
+
+def _driver(loop: asyncio.AbstractEventLoop, once: Callable[[], Coroutine[Any, Any, None]]) -> Callable[[], None]:
+    return lambda: loop.run_until_complete(once())
+
+
+# ---------------------------------------------------------------------------
+# measurement
 
 
 class Arm:
-    """One loop, its echo server, and the samples taken against it."""
+    """One loop running one workload, and the samples taken against it."""
 
-    def __init__(self, factory: Factory) -> None:
+    def __init__(self, factory: Factory, workload: Workload) -> None:
         self.loop = factory()
+        asyncio.set_event_loop(self.loop)
+        self.run = workload(self.loop)
         self.wall: list[float] = []
         self.cpu: list[float] = []
-
-        class Server(asyncio.Protocol):
-            def connection_made(self, transport: asyncio.BaseTransport) -> None:
-                self.transport = transport
-
-            def data_received(self, data: bytes) -> None:
-                self.transport.write(data)  # type: ignore[attr-defined]
-
-        self.server = self.loop.run_until_complete(self.loop.create_server(Server, "127.0.0.1", 0))
-        self.port: int = self.server.sockets[0].getsockname()[1]
-
-    def _client(self) -> type[asyncio.Protocol]:
-        loop = self.loop
-
-        class Client(asyncio.Protocol):
-            def __init__(self) -> None:
-                self.pending = 0
-                self.remaining = ROUNDTRIPS
-                self.done = loop.create_future()
-
-            def connection_made(self, transport: asyncio.BaseTransport) -> None:
-                self.transport = transport
-                transport.write(PAYLOAD)  # type: ignore[attr-defined]
-
-            def data_received(self, data: bytes) -> None:
-                self.pending += len(data)
-                while self.pending >= len(PAYLOAD):
-                    self.pending -= len(PAYLOAD)
-                    self.remaining -= 1
-                    if self.remaining == 0:
-                        self.done.set_result(None)
-                        return
-                    self.transport.write(PAYLOAD)  # type: ignore[attr-defined]
-
-        return Client
-
-    def run(self) -> None:
-        client_type = self._client()
-
-        async def once() -> None:
-            transport, protocol = await self.loop.create_connection(client_type, "127.0.0.1", self.port)
-            await protocol.done  # type: ignore[attr-defined]
-            transport.close()
-
-        self.loop.run_until_complete(once())
 
     def sample(self) -> None:
         started_cpu = time.process_time()
@@ -91,21 +262,14 @@ class Arm:
         self.cpu.append(time.process_time() - started_cpu)
 
     def close(self) -> None:
-        self.server.close()
-        self.loop.run_until_complete(self.server.wait_closed())
         self.loop.close()
 
-    def report(self, name: str) -> None:
-        spread = statistics.stdev(self.wall) / statistics.mean(self.wall) * 100
-        print(
-            f"  {name:8s} wall min {min(self.wall) * 1000:7.2f}ms"
-            f"  median {statistics.median(self.wall) * 1000:7.2f}ms"
-            f"  (+/- {spread:4.1f}%)   cpu min {min(self.cpu) * 1000:7.2f}ms"
-        )
 
-
-def main() -> None:
-    arms = {"zuvloop": Arm(zuvloop.new_event_loop), "uvloop": Arm(uvloop.new_event_loop)}
+def compare(name: str, workload: Workload) -> None:
+    arms = {
+        "zuvloop": Arm(zuvloop.new_event_loop, workload),
+        "uvloop": Arm(uvloop.new_event_loop, workload),
+    }
     for arm in arms.values():
         for _ in range(3):
             arm.run()
@@ -114,24 +278,43 @@ def main() -> None:
     try:
         for rep in range(REPS):
             # Alternating the order too, so neither arm always follows the other.
-            names = list(arms) if rep % 2 == 0 else list(arms)[::-1]
-            for name in names:
-                arms[name].sample()
+            for label in list(arms) if rep % 2 == 0 else list(arms)[::-1]:
+                arms[label].sample()
     finally:
         gc.enable()
 
-    for name, arm in arms.items():
-        arm.close()
-        arm.report(name)
+    print(f"\n{name}")
+    for label, arm in arms.items():
+        spread = statistics.stdev(arm.wall) / statistics.mean(arm.wall) * 100
+        print(
+            f"  {label:8s} wall min {min(arm.wall) * 1000:8.3f}ms"
+            f"  median {statistics.median(arm.wall) * 1000:8.3f}ms"
+            f"  (+/- {spread:4.1f}%)   cpu min {min(arm.cpu) * 1000:8.3f}ms"
+        )
 
     fast, slow = arms["zuvloop"], arms["uvloop"]
-    wall_min = min(slow.wall) / min(fast.wall)
-    wall_median = statistics.median(slow.wall) / statistics.median(fast.wall)
-    cpu_min = min(slow.cpu) / min(fast.cpu)
-    cpu_median = statistics.median(slow.cpu) / statistics.median(fast.cpu)
-    print(f"\n  zuvloop / uvloop  wall: min {wall_min:.3f}x  median {wall_median:.3f}x")
-    print(f"                     cpu: min {cpu_min:.3f}x  median {cpu_median:.3f}x")
+    ratios = (
+        min(slow.wall) / min(fast.wall),
+        statistics.median(slow.wall) / statistics.median(fast.wall),
+        statistics.median(slow.cpu) / statistics.median(fast.cpu),
+    )
+    print(f"  {'':8s} zuvloop / uvloop  wall min {ratios[0]:.3f}x  median {ratios[1]:.3f}x  cpu {ratios[2]:.3f}x")
+
+    for arm in arms.values():
+        arm.close()
+
+
+def main() -> int:
+    wanted = sys.argv[1:] or list(WORKLOADS)
+    unknown = [name for name in wanted if name not in WORKLOADS]
+    if unknown:
+        print(f"unknown workload(s): {', '.join(unknown)}", file=sys.stderr)
+        print(f"available: {', '.join(WORKLOADS)}", file=sys.stderr)
+        return 2
+    for name in wanted:
+        compare(name, WORKLOADS[name])
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
`compare.py` measured one workload. Every other shape had no honest number - only CodSpeed's table, which divides by `iter_per_round` twice and picks that divisor per row, so it cannot be read across rows at all.

Each workload builds what it needs against one loop and returns the thing to time, so setup stays out of the measurement. Naming workloads on the command line runs only those:

```console
$ uv run --group bench python benchmarks/compare.py echo timers
```

## What the numbers actually are

zuvloop over uvloop, median wall, 40 interleaved reps with the order alternating:

| workload | wall (min) | wall (median) | cpu |
| --- | ---: | ---: | ---: |
| `echo` | 1.037x | 1.035x | 1.057x |
| `split_write` | 1.011x | 1.027x | 1.087x |
| `bulk` | 1.117x | 1.109x | 1.119x |
| `call_soon` | 1.536x | 1.540x | 1.554x |
| `timers` | 3.362x | 3.307x | 3.343x |
| `getaddrinfo` | 1.337x | 1.319x | 1.293x |
| `spawn` | 0.991x | 0.990x | 1.080x |

`spawn` is worth having on the record: it is the one shape where this is behind, by about a percent of wall - though ahead by 8% of CPU, so what it is behind on is waiting rather than work.

These line up with the throughput ratios in the README (echo 1.03x there, 1.035x here; timers 3.65x there, 3.31x here), which is the check that mattered - those numbers are what users read.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compare every benchmark shape between `zuvloop` and `uvloop`, not just `echo`, with fair, in-process alternating runs and clear ratio output. This makes cross-workload results accurate and lets you run selected workloads via CLI args.

- **New Features**
  - Added a workload framework: each shape builds against one loop and returns a callable to time (setup excluded).
  - Covered workloads: `echo`, `split_write`, `bulk`, `call_soon`, `timers`, `getaddrinfo`, `spawn`.
  - Alternates loops each rep (40 reps), records wall and CPU, and prints per-arm min/median plus `zuvloop/uvloop` ratios.
  - CLI supports selecting workloads by name; validates unknown names and lists available ones.
  - Replaces ambiguous CodSpeed cross-row comparisons with consistent, comparable numbers.

- **Bug Fixes**
  - Fixed a race in `bulk`: wait for the server’s accepted connection via a future, avoiding `IndexError` and making setup deterministic.

<sup>Written for commit 7588a8eae5f8568cd4e6d98f5039e2dc565544d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/29?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

