### PR TITLE
Skip slow callback timing for an infinite threshold

### DIFF
--- a/docs/usage/instrumentation.md
+++ b/docs/usage/instrumentation.md
@@ -68,6 +68,16 @@ the threshold as you would on any loop:
 loop.slow_callback_duration = 0.05
 ```
 
+Set the threshold to infinity to disable slow-callback monitoring while keeping
+other OpenTelemetry signals enabled. This takes the native fast path and skips
+the per-callback clock reads as well as spans and metrics:
+
+```python
+import math
+
+loop.slow_callback_duration = math.inf
+```
+
 /// note | Why the gauges are synchronous
 
 They are pushed from the loop's timer rather than pulled by an observable

--- a/tests/test_instrumentation.py
+++ b/tests/test_instrumentation.py
@@ -45,6 +45,23 @@ async def test_slow_callbacks_are_reported_without_debug_mode(telemetry: Telemet
     assert telemetry.counted("zuvloop.slow_callbacks") >= 1
 
 
+async def test_an_infinite_threshold_disables_slow_callback_reports(telemetry: Telemetry) -> None:
+    loop = running_loop()
+    loop.slow_callback_duration = float("inf")
+
+    def unreported_slow_callback() -> None:
+        time.sleep(0.05)
+
+    try:
+        loop.call_soon(unreported_slow_callback)
+        await asyncio.sleep(0.1)
+    finally:
+        loop.slow_callback_duration = 0.1
+
+    callbacks = [str(attribute(span, "code.callback")) for span in telemetry.spans("zuvloop.slow_callback")]
+    assert not any("unreported_slow_callback" in callback for callback in callbacks)
+
+
 async def test_a_slow_callback_span_covers_the_time_it_took(telemetry: Telemetry) -> None:
     """The loop times with a monotonic clock, so the span is rebuilt backwards."""
     loop = running_loop()

--- a/zig/loop.zig
+++ b/zig/loop.zig
@@ -261,7 +261,7 @@ fn runReady(self: *LoopObject) void {
     while (remaining != 0) : (remaining -= 1) {
         const obj = st.ready.pop() orelse break;
         const h: *Handle = @ptrCast(@alignCast(obj));
-        if (st.debug or st.slow_callback_monitoring) {
+        if ((st.debug or st.slow_callback_monitoring) and st.slow_callback_duration < std.math.inf(f64)) {
             const started = uv.uv_hrtime();
             handlemod.run(h);
             const elapsed = @as(f64, @floatFromInt(uv.uv_hrtime() - started)) / 1e9;


### PR DESCRIPTION
## Summary

- treat `slow_callback_duration = math.inf` as a native fast-path disable
- skip both per-callback clock reads as well as slow spans and metrics
- document the supported disable mechanism and add regression coverage

## Performance

Interleaved local benchmark over 200,000 scheduled callbacks (20 samples):

- monitoring off: 94.7 ns/callback
- monitoring on: 103.0 ns/callback
- provider enabled with infinite threshold: 95.4 ns/callback

The infinite-threshold path was within 0.72% of monitoring-off noise, while finite monitoring cost 8.73% in this no-op workload.

## Testing

- `uv run ruff check`
- `uv run ruff format --check`
- `uv run mypy`
- `uv run coverage run -m pytest` (307 passed)
- `uv run coverage report` (100%)
- `./scripts/docs`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip slow-callback timing when `loop.slow_callback_duration` is set to `math.inf`, disabling per-callback clock reads and slow spans/metrics while keeping other OpenTelemetry signals. Updated docs and added tests for the disable path.

- **Performance**
  - 95.4 ns/callback with `math.inf` vs 94.7 ns (monitoring off) and 103.0 ns (monitoring on); within 0.72% of off and avoids ~8.73% overhead.

<sup>Written for commit 0fccf5438b1f2fafc0c449374e621b86aa560f4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/35?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Setting the slow-callback threshold to infinity now disables slow-callback monitoring while preserving other telemetry signals.
  * Added documentation and configuration guidance for disabling slow-callback monitoring.

* **Bug Fixes**
  * Infinite slow-callback thresholds no longer generate spans or perform unnecessary callback timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->