### PR TITLE
Reject NaN slow callback thresholds

### DIFF
--- a/tests/test_instrumentation.py
+++ b/tests/test_instrumentation.py
@@ -45,19 +45,33 @@ async def test_slow_callbacks_are_reported_without_debug_mode(telemetry: Telemet
     assert telemetry.counted("zuvloop.slow_callbacks") >= 1
 
 
-async def test_an_infinite_threshold_disables_slow_callback_reports(telemetry: Telemetry) -> None:
+async def test_an_infinite_threshold_disables_slow_callback_reports(
+    telemetry: Telemetry, monkeypatch: pytest.MonkeyPatch
+) -> None:
     loop = running_loop()
+    previous_threshold = loop.slow_callback_duration
     loop.slow_callback_duration = float("inf")
+    reports: list[tuple[object, float]] = []
+    monkeypatch.setattr(
+        loop._instrumentation,
+        "report_slow_callback",
+        lambda handle, duration: reports.append((handle, duration)),
+    )
+    ran = False
 
     def unreported_slow_callback() -> None:
+        nonlocal ran
+        ran = True
         time.sleep(0.05)
 
     try:
         loop.call_soon(unreported_slow_callback)
         await asyncio.sleep(0.1)
     finally:
-        loop.slow_callback_duration = 0.1
+        loop.slow_callback_duration = previous_threshold
 
+    assert ran
+    assert reports == []
     callbacks = [str(attribute(span, "code.callback")) for span in telemetry.spans("zuvloop.slow_callback")]
     assert not any("unreported_slow_callback" in callback for callback in callbacks)
 

--- a/tests/test_instrumentation.py
+++ b/tests/test_instrumentation.py
@@ -51,11 +51,11 @@ async def test_an_infinite_threshold_disables_slow_callback_reports(
     loop = running_loop()
     previous_threshold = loop.slow_callback_duration
     loop.slow_callback_duration = float("inf")
-    reports: list[tuple[object, float]] = []
+    reported_durations: list[float] = []
     monkeypatch.setattr(
         loop._instrumentation,
         "report_slow_callback",
-        lambda handle, duration: reports.append((handle, duration)),
+        lambda _handle, duration: reported_durations.append(duration),
     )
     ran = False
 
@@ -71,7 +71,7 @@ async def test_an_infinite_threshold_disables_slow_callback_reports(
         loop.slow_callback_duration = previous_threshold
 
     assert ran
-    assert reports == []
+    assert reported_durations == []
     callbacks = [str(attribute(span, "code.callback")) for span in telemetry.spans("zuvloop.slow_callback")]
     assert not any("unreported_slow_callback" in callback for callback in callbacks)
 

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -232,6 +232,14 @@ async def test_slow_callback_duration_is_settable() -> None:
     loop.slow_callback_duration = 0.1
 
 
+async def test_slow_callback_duration_rejects_nan() -> None:
+    loop = running_loop()
+    previous = loop.slow_callback_duration
+    with pytest.raises(ValueError, match="slow_callback_duration must not be NaN"):
+        loop.slow_callback_duration = float("nan")
+    assert loop.slow_callback_duration == previous
+
+
 async def test_metrics_report_loop_activity() -> None:
     loop = running_loop()
     await asyncio.sleep(0.01)

--- a/zig/loop.zig
+++ b/zig/loop.zig
@@ -575,6 +575,10 @@ fn getSlowCallbackDuration(self_obj: ?*py.Object, _: ?*anyopaque) callconv(.c) ?
 
 fn setSlowCallbackDuration(self_obj: ?*py.Object, value: ?*py.Object, _: ?*anyopaque) callconv(.c) c_int {
     const v = py.asF64(value orelse return -1) catch return -1;
+    if (std.math.isNan(v)) {
+        c.PyErr_SetString(@ptrCast(c.PyExc_ValueError), "slow_callback_duration must not be NaN");
+        return -1;
+    }
     asLoop(self_obj.?).state().slow_callback_duration = v;
     return 0;
 }


### PR DESCRIPTION
## Summary

- reject `NaN` assignments to `slow_callback_duration` while continuing to allow `math.inf`
- verify an infinite threshold executes callbacks without entering Python slow-callback reporting
- restore the prior threshold after the instrumentation test

## Testing

- `uv run ruff check`
- `uv run ruff format --check`
- `uv run mypy`
- `uv run coverage run -m pytest` (308 passed)
- `uv run coverage report` (100%)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject `NaN` for `slow_callback_duration` while keeping support for `math.inf`. This prevents invalid thresholds and ensures an infinite threshold disables slow-callback reporting while callbacks still run.

- **Bug Fixes**
  - Setter validation in `zig/loop.zig`: raise `ValueError("slow_callback_duration must not be NaN")` on `NaN`, allow `inf`.
  - Tests: capture only reported durations; assert none with an infinite threshold, confirm the callback runs, restore the previous threshold; ensure `NaN` is rejected without changing the current value.

<sup>Written for commit ee423c864d8693949289465971783057a49f844e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/36?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid `NaN` values are now rejected when setting the slow-callback duration, preserving the previous valid setting.
  * An infinite slow-callback threshold continues to allow callbacks to run without generating slow-callback reports.

* **Tests**
  * Added coverage confirming the new validation and reporting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->