### PR TITLE
Build wheels for the baseline CPU rather than the build machine's

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,23 @@ jobs:
       - name: Install
         run: uv sync --python ${{ matrix.python-version }} --group dev --group bench
 
+      # A wheel is compiled on whichever machine the job landed on, so a build
+      # that defaults to that machine's CPU bakes its instruction set into a
+      # published artifact - which then raises SIGILL on an older one. Asserted
+      # here rather than at release time, where it would be too late.
+      - name: Confirm the build defaults to the baseline CPU
+        run: |
+          export HATCH_ZIG_PYTHON_INCLUDE="$(uv run python -c 'import sysconfig; print(sysconfig.get_path("include"))')"
+          HATCH_ZIG_EXT_SUFFIX=".cpucheck-default.so" zig build -Doptimize=ReleaseFast
+          HATCH_ZIG_EXT_SUFFIX=".cpucheck-baseline.so" zig build -Doptimize=ReleaseFast -Dcpu=baseline
+          if ! cmp -s zuvloop/_zuvloop.cpucheck-default.so zuvloop/_zuvloop.cpucheck-baseline.so; then
+            echo "::error::A default build differs from -Dcpu=baseline, so it is compiling for this" \
+                 "runner's CPU. A wheel built that way raises SIGILL on older machines. See the" \
+                 "standardTargetOptions default in build.zig."
+            exit 1
+          fi
+          rm -f zuvloop/_zuvloop.cpucheck-*.so
+
       - name: Lint
         run: |
           uv run ruff check

--- a/build.zig
+++ b/build.zig
@@ -55,7 +55,12 @@ const uv_linux = [_][]const u8{
 };
 
 pub fn build(b: *std.Build) void {
-    const target = b.standardTargetOptions(.{});
+    // A wheel is built on whatever machine the job landed on, and without a
+    // baseline default Zig compiles for that machine's CPU: the published
+    // manylinux wheel carried AVX2, BMI and MOVBE, so it would raise SIGILL on
+    // anything older than Haswell. Which instructions it needed depended on the
+    // runner. `-Dcpu=native` is still there for a build meant for one machine.
+    const target = b.standardTargetOptions(.{ .default_target = .{ .cpu_model = .baseline } });
     const optimize = b.standardOptimizeOption(.{});
 
     // hatch-ziglang passes the building interpreter through the environment, so a


### PR DESCRIPTION
The manylinux x86-64 wheel on PyPI raises `SIGILL` on any CPU older than Haswell (2013).

## What is wrong

`build.zig` asks for `b.standardTargetOptions(.{})`, which resolves to the host's *native* CPU when no target is given. On macOS `hatch-ziglang` passes `-Dtarget` so that `delocate` accepts the wheel, which incidentally pins the CPU too - but on Linux it passes nothing, so the extension is compiled for whichever machine the release job happened to land on.

Disassembling the published `zuvloop-0.0.1-cp314-cp314-manylinux_2_28_x86_64.whl`:

| | count | needs |
| --- | --- | --- |
| AVX | 3669 | Sandy Bridge, 2011 |
| AVX2 | 13 | Haswell, 2013 |
| BMI | 110 | Haswell, 2013 |
| MOVBE | 152 | Haswell, 2013 |
| POPCNT | 9 | Nehalem, 2008 |

None are in the x86-64 baseline. Building this source with `-Dcpu=x86_64_v3` reproduces those counts closely (AVX 3376, AVX2 15, BMI 110, MOVBE 124), which is what a native build on a current runner produces.

It is also not reproducible: the minimum CPU a release requires depends on the runner GitHub allocated that day.

## The fix

Default the CPU to `baseline` when no target is given:

```zig
const target = b.standardTargetOptions(.{ .default_target = .{ .cpu_model = .baseline } });
```

A default build is now byte-identical to `-Dcpu=baseline`, and `-Dcpu=native` still overrides for a build meant for one machine. macOS is unaffected - `-Dtarget` already wins there.

## Cost

None measurable. `benchmarks/compare.py` on an M3 Max, baseline against native:

| | baseline | native |
| --- | --- | --- |
| `call_soon` wall min | 0.978 ms | 0.971 ms |
| `echo` wall min | 27.505 ms | 27.439 ms |

Both inside run-to-run noise, as expected of a loop that spends its time in syscalls rather than arithmetic.

## Not regressing again

CI builds twice and compares the two binaries, so a default that stops being the baseline fails the `test` job rather than a user's import. Verified it passes on this change and fails when the build is forced back to `-Dcpu=native`.

Suite green, 100% coverage, ruff, mypy strict, and 88/92 conformance unchanged.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build Linux wheels for the x86-64 baseline CPU instead of the build machine’s, preventing SIGILL on older CPUs and making builds reproducible.

- **Bug Fixes**
  - Default Zig CPU to baseline when no target is set; Linux wheels are portable; `-Dcpu=native` still works; macOS builds via `hatch-ziglang` unchanged.
  - CI builds twice and compares outputs to ensure the default build matches `-Dcpu=baseline`.

<sup>Written for commit 14319053d319cd38e35410ef5bf8db5158acc8de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/37?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Builds now target a baseline CPU by default, improving compatibility across supported hardware.
  * Manual native builds continue to use the host CPU for optimized performance.

* **Quality Assurance**
  * Automated checks now compare baseline and default CPU builds to detect hardware-specific differences before release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->