### PR TITLE
Accept default subprocess options from AnyIO

### DIFF
--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -241,6 +241,19 @@ async def test_an_unsupported_popen_argument_is_rejected() -> None:
         await asyncio.create_subprocess_exec("/bin/echo", stdout=PIPE, preexec_fn=lambda: None)
 
 
+async def test_default_popen_arguments_are_accepted() -> None:
+    process = await asyncio.create_subprocess_exec(
+        "/bin/echo",
+        "defaults",
+        stdout=PIPE,
+        startupinfo=None,
+        creationflags=0,
+        pass_fds=(),
+    )
+    stdout, _stderr = await process.communicate()
+    assert stdout == b"defaults\n"
+
+
 async def test_signalling_an_exited_child_is_a_no_op() -> None:
     loop = running_loop()
 

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -254,6 +254,15 @@ async def test_default_popen_arguments_are_accepted() -> None:
     assert stdout == b"defaults\n"
 
 
+async def test_non_default_popen_arguments_are_rejected() -> None:
+    with pytest.raises(ValueError, match="startupinfo is not supported"):
+        await asyncio.create_subprocess_exec("/bin/echo", stdout=PIPE, startupinfo=object())
+    with pytest.raises(ValueError, match="creationflags is not supported"):
+        await asyncio.create_subprocess_exec("/bin/echo", stdout=PIPE, creationflags=1)
+    with pytest.raises(ValueError, match="pass_fds is not supported"):
+        await asyncio.create_subprocess_exec("/bin/echo", stdout=PIPE, pass_fds=(2,))
+
+
 async def test_signalling_an_exited_child_is_a_no_op() -> None:
     loop = running_loop()
 

--- a/zuvloop/_process.py
+++ b/zuvloop/_process.py
@@ -4,7 +4,7 @@ import io
 import os
 import signal
 import subprocess
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any
 
 from . import _zuvloop
@@ -37,9 +37,18 @@ class Popen:
         stdout: Any = None,
         stderr: Any = None,
         start_new_session: bool = False,
+        startupinfo: None = None,
+        creationflags: int = 0,
+        pass_fds: Sequence[int] = (),
         on_exit: Callable[[int], object],
         **unsupported: Any,
     ) -> None:
+        if startupinfo is not None:
+            raise ValueError("startupinfo is not supported by zuvloop's subprocess transport")
+        if creationflags:
+            raise ValueError("creationflags is not supported by zuvloop's subprocess transport")
+        if pass_fds:
+            raise ValueError("pass_fds is not supported by zuvloop's subprocess transport")
         if unsupported:
             name = next(iter(unsupported))
             raise ValueError(f"{name} is not supported by zuvloop's subprocess transport")


### PR DESCRIPTION
this PR begins accepting the default subprocess options AnyIO always forwards (`startupinfo=None`, `creationflags=0`, `pass_fds=()`). without this, every `anyio.run_process()`/`open_process()` call fails on zuvloop, shutting out anyio users entirely. non-default values are still rejected.

<details>
<summary>why AnyIO hits this</summary>

AnyIO's asyncio backend passes `startupinfo`, `creationflags`, and `pass_fds` to `subprocess_exec` unconditionally, even at their default values. zuvloop's `Popen` routed them into `**unsupported` and raised. This patch names the three parameters, accepts only their defaults, and keeps the existing rejection for anything else (including real `pass_fds`, which the transport genuinely doesn't support yet).

notably, `docs/usage/subprocesses.md` already promises this surface — "with every `Popen` keyword — `env`, `cwd`, `pass_fds`, `start_new_session` and the rest" — so this is a step toward the documented contract. real `pass_fds` support would close the remaining gap; happy to follow up there.

</details>

<details>
<summary>measured motivation (Prefect)</summary>

50 sequential `prefect.utilities.processutils.run_process(["uv", "--version"])` calls, two rounds per loop, macOS arm64:

| loop | min | median |
|---|---:|---:|
| asyncio | 289–312 ms | 297–324 ms |
| uvloop | 210–229 ms | 227–241 ms |
| zuvloop | 215–220 ms | 222–223 ms |

~30% less elapsed time than asyncio, parity with uvloop — none of it reachable without this change.

</details>

<details>
<summary>validation</summary>

- full test suite passes (315), including new tests covering accepted defaults and still-rejected non-defaults
- ruff, formatting, strict mypy clean
- real `prefect run_process()` call succeeds with GC enabled

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept default subprocess options that `anyio` forwards—`startupinfo=None`, `creationflags=0`, `pass_fds=()`—to restore `anyio.run_process()`/`open_process()` compatibility on `zuvloop`. Non-defaults and unknown kwargs still raise clear errors.

- **Bug Fixes**
  - Accept and validate `startupinfo`, `creationflags`, and `pass_fds` in the subprocess transport; reject any non-default values and any other unknown kwargs.
  - Added tests: defaults succeed; each non-default option is rejected with its own explicit error message, unblocking `prefect` and other `anyio` users.

<sup>Written for commit 515f71022b47fb7777ee060de6ce2a07438b5856. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/38?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Added support for accepting standard subprocess parameters: `startupinfo`, `creationflags`, and `pass_fds`.
  * Non-default values are clearly rejected with validation errors, while existing behavior for other unsupported options remains unchanged.

* **Tests**
  * Added coverage confirming accepted defaults and expected errors for unsupported values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->