### PR TITLE
Pass descriptors through to the child with pass_fds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,8 +168,6 @@ jobs:
 
   benchmarks:
     runs-on: ubuntu-latest
-    # Normally ~3 minutes; the CodSpeed harness has been seen sitting for over
-    # half an hour, and without a bound that holds the whole run hostage.
     timeout-minutes: 15
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,9 @@ jobs:
 
   benchmarks:
     runs-on: ubuntu-latest
+    # Normally ~3 minutes; the CodSpeed harness has been seen sitting for over
+    # half an hour, and without a bound that holds the whole run hostage.
+    timeout-minutes: 15
     permissions:
       contents: read
       # CodSpeed authenticates over OpenID Connect rather than an upload token,

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -337,9 +337,7 @@ async def test_pass_fds_leaves_the_gap_before_it_closed() -> None:
 
 
 async def test_pass_fds_leaves_the_blocking_state_alone() -> None:
-    """libuv's posix_spawn path marks every stdio slot blocking, on the file
-    description the parent still shares - flipping an asyncio-managed socket
-    to blocking would hang the loop that owns it."""
+    """A passed asyncio socket flipped to blocking would hang its own loop."""
     left, right = socket.socketpair()
     left.setblocking(False)
     try:
@@ -357,17 +355,14 @@ async def test_pass_fds_rejects_a_negative_descriptor() -> None:
 
 
 async def test_pass_fds_rejects_a_descriptor_that_is_not_open() -> None:
-    """Caught in the parent, where the error can name the descriptor - the
-    alternative is the child dying with libuv's bare exit code 127."""
+    """In the parent, where the error can name the descriptor."""
     with pytest.raises(OSError) as caught:
         await asyncio.create_subprocess_exec("/bin/echo", pass_fds=(4096,))
     assert caught.value.errno == errno.EBADF
 
 
 async def test_pass_fds_rejects_a_freshly_closed_descriptor() -> None:
-    """The check runs before any pipe of ours is opened. Later it would be too
-    late: the lowest-free rule hands a just-closed number to the next pipe, and
-    the child would inherit that pipe end where the error should have been."""
+    """Checked before the spawn's own pipes can reuse the number."""
     read_fd, write_fd = os.pipe()
     os.close(write_fd)
     try:

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -5,6 +5,7 @@ import contextlib
 import errno
 import os
 import signal
+import socket
 import sys
 from asyncio.subprocess import Process
 from pathlib import Path
@@ -333,6 +334,21 @@ async def test_pass_fds_leaves_the_gap_before_it_closed() -> None:
     finally:
         for fd in (read_fd, write_fd, spare_read, spare_write):
             os.close(fd)
+
+
+async def test_pass_fds_leaves_the_blocking_state_alone() -> None:
+    """libuv's posix_spawn path marks every stdio slot blocking, on the file
+    description the parent still shares - flipping an asyncio-managed socket
+    to blocking would hang the loop that owns it."""
+    left, right = socket.socketpair()
+    left.setblocking(False)
+    try:
+        process = await asyncio.create_subprocess_exec("/bin/echo", pass_fds=(left.fileno(),))
+        assert await process.wait() == 0
+        assert os.get_blocking(left.fileno()) is False
+    finally:
+        left.close()
+        right.close()
 
 
 async def test_pass_fds_rejects_a_negative_descriptor() -> None:

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -342,13 +342,24 @@ async def test_pass_fds_rejects_a_negative_descriptor() -> None:
 
 async def test_pass_fds_rejects_a_descriptor_that_is_not_open() -> None:
     """Caught in the parent, where the error can name the descriptor - the
-    alternative is the child dying with libuv's bare exit code 127.
-
-    A high number rather than a freshly closed one: the spawn opens pipes of
-    its own first, and the lowest-free rule would hand a just-closed number
-    straight back to one of them."""
-    with pytest.raises(OSError):
+    alternative is the child dying with libuv's bare exit code 127."""
+    with pytest.raises(OSError) as caught:
         await asyncio.create_subprocess_exec("/bin/echo", pass_fds=(4096,))
+    assert caught.value.errno == errno.EBADF
+
+
+async def test_pass_fds_rejects_a_freshly_closed_descriptor() -> None:
+    """The check runs before any pipe of ours is opened. Later it would be too
+    late: the lowest-free rule hands a just-closed number to the next pipe, and
+    the child would inherit that pipe end where the error should have been."""
+    read_fd, write_fd = os.pipe()
+    os.close(write_fd)
+    try:
+        with pytest.raises(OSError) as caught:
+            await asyncio.create_subprocess_exec("/bin/echo", stderr=PIPE, pass_fds=(write_fd,))
+        assert caught.value.errno == errno.EBADF
+    finally:
+        os.close(read_fd)
 
 
 async def test_signalling_an_exited_child_is_a_no_op() -> None:

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import errno
 import os
 import signal
 import sys
@@ -301,7 +302,8 @@ async def test_a_descriptor_not_passed_does_not_reach_the_child() -> None:
         process = await asyncio.create_subprocess_exec(sys.executable, "-c", WRITE_TO_FD, str(write_fd), stderr=PIPE)
         _stdout, stderr = await process.communicate()
         assert process.returncode == 1
-        assert b"Bad file descriptor" in stderr
+        # The number rather than the phrase, which libc translates per locale.
+        assert f"[Errno {errno.EBADF}]".encode() in stderr
     finally:
         os.close(read_fd)
         os.close(write_fd)
@@ -327,10 +329,26 @@ async def test_pass_fds_leaves_the_gap_before_it_closed() -> None:
         )
         _stdout, stderr = await process.communicate()
         assert process.returncode == 1
-        assert b"Bad file descriptor" in stderr
+        assert f"[Errno {errno.EBADF}]".encode() in stderr
     finally:
         for fd in (read_fd, write_fd, spare_read, spare_write):
             os.close(fd)
+
+
+async def test_pass_fds_rejects_a_negative_descriptor() -> None:
+    with pytest.raises(ValueError, match="pass_fds"):
+        await asyncio.create_subprocess_exec("/bin/echo", pass_fds=(-1,))
+
+
+async def test_pass_fds_rejects_a_descriptor_that_is_not_open() -> None:
+    """Caught in the parent, where the error can name the descriptor - the
+    alternative is the child dying with libuv's bare exit code 127.
+
+    A high number rather than a freshly closed one: the spawn opens pipes of
+    its own first, and the lowest-free rule would hand a just-closed number
+    straight back to one of them."""
+    with pytest.raises(OSError):
+        await asyncio.create_subprocess_exec("/bin/echo", pass_fds=(4096,))
 
 
 async def test_signalling_an_exited_child_is_a_no_op() -> None:

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import os
 import signal
 import sys
@@ -259,8 +260,77 @@ async def test_non_default_popen_arguments_are_rejected() -> None:
         await asyncio.create_subprocess_exec("/bin/echo", stdout=PIPE, startupinfo=object())
     with pytest.raises(ValueError, match="creationflags is not supported"):
         await asyncio.create_subprocess_exec("/bin/echo", stdout=PIPE, creationflags=1)
-    with pytest.raises(ValueError, match="pass_fds is not supported"):
-        await asyncio.create_subprocess_exec("/bin/echo", stdout=PIPE, pass_fds=(2,))
+
+
+WRITE_TO_FD = "import os, sys; os.write(int(sys.argv[1]), b'through-the-pipe')"
+
+
+async def test_pass_fds_reaches_the_child_at_the_same_number() -> None:
+    """A descriptor keeps its number in the child, which is what makes it usable:
+    the number is what the parent told the child to write to."""
+    read_fd, write_fd = os.pipe()
+    try:
+        process = await asyncio.create_subprocess_exec(
+            sys.executable, "-c", WRITE_TO_FD, str(write_fd), pass_fds=(write_fd,)
+        )
+        assert await process.wait() == 0
+        # Our end, so the read below sees EOF rather than blocking.
+        os.close(write_fd)
+        assert os.read(read_fd, 64) == b"through-the-pipe"
+    finally:
+        os.close(read_fd)
+        with contextlib.suppress(OSError):
+            os.close(write_fd)
+
+
+async def test_pass_fds_naming_a_standard_stream_is_what_it_already_is() -> None:
+    """0, 1 and 2 are claimed by stdin, stdout and stderr, so naming one asks for
+    nothing more - and must not displace the stream that holds it."""
+    process = await asyncio.create_subprocess_exec(
+        sys.executable, "-c", "import sys; sys.stderr.write('still stderr')", stderr=PIPE, pass_fds=(2,)
+    )
+    _stdout, stderr = await process.communicate()
+    assert stderr == b"still stderr"
+    assert process.returncode == 0
+
+
+async def test_a_descriptor_not_passed_does_not_reach_the_child() -> None:
+    """The other half: without `pass_fds` it is closed, so the write fails."""
+    read_fd, write_fd = os.pipe()
+    try:
+        process = await asyncio.create_subprocess_exec(sys.executable, "-c", WRITE_TO_FD, str(write_fd), stderr=PIPE)
+        _stdout, stderr = await process.communicate()
+        assert process.returncode == 1
+        assert b"Bad file descriptor" in stderr
+    finally:
+        os.close(read_fd)
+        os.close(write_fd)
+
+
+async def test_pass_fds_leaves_the_gap_before_it_closed() -> None:
+    """The descriptors between stderr and a high `pass_fds` are not the child's.
+
+    The spare is opened first so it takes the lower number, which is what puts it
+    in the gap rather than past the end - asserted, since the whole test rests on it.
+    """
+    spare_read, spare_write = os.pipe()
+    read_fd, write_fd = os.pipe()
+    assert 3 <= spare_write < write_fd
+    try:
+        process = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-c",
+            "import os, sys; os.close(int(sys.argv[1]))",
+            str(spare_write),
+            stderr=PIPE,
+            pass_fds=(write_fd,),
+        )
+        _stdout, stderr = await process.communicate()
+        assert process.returncode == 1
+        assert b"Bad file descriptor" in stderr
+    finally:
+        for fd in (read_fd, write_fd, spare_read, spare_write):
+            os.close(fd)
 
 
 async def test_signalling_an_exited_child_is_a_no_op() -> None:

--- a/zig/process.zig
+++ b/zig/process.zig
@@ -48,7 +48,7 @@ const SpawnArgs = struct {
     /// Offsets rather than pointers, because appending can move the buffer.
     argv_at: std.ArrayListUnmanaged(usize) = .empty,
     envp_at: std.ArrayListUnmanaged(usize) = .empty,
-    stdio: [3]uv.StdioContainer = @splat(.{ .flags = uv.StdioFlags.ignore, .data = .{ .fd = -1 } }),
+    stdio: std.ArrayListUnmanaged(uv.StdioContainer) = .empty,
 
     fn deinit(self: *SpawnArgs) void {
         self.storage.deinit(alloc);
@@ -56,6 +56,7 @@ const SpawnArgs = struct {
         self.envp.deinit(alloc);
         self.argv_at.deinit(alloc);
         self.envp_at.deinit(alloc);
+        self.stdio.deinit(alloc);
     }
 
     /// Turns the recorded offsets into the null-terminated pointer array
@@ -217,9 +218,10 @@ fn optionalString(args: *SpawnArgs, value: ?*py.Object) py.Error!?usize {
 
 /// `loop._spawn_process(file, args, env, cwd, stdio, flags, uid, gid, on_exit)`
 ///
-/// `stdio` is a three-element sequence of descriptors for the child's stdin,
-/// stdout and stderr; -1 leaves one closed. They are created in Python, which is
-/// where the rest of the socket and pipe setup lives.
+/// `stdio` is a sequence of descriptors the child inherits, each at the index it
+/// occupies here; -1 leaves that one closed. The first three are stdin, stdout
+/// and stderr, and anything past them is a `pass_fds` entry. They are created in
+/// Python, which is where the rest of the socket and pipe setup lives.
 pub fn spawnProcess(self_obj: *py.Object, args_in: []const ?*py.Object) py.Error!*py.Object {
     try py.expectArgs(args_in, 9, "_spawn_process");
     const loop = loopmod.asLoop(self_obj);
@@ -249,15 +251,18 @@ pub fn spawnProcess(self_obj: *py.Object, args_in: []const ?*py.Object) py.Error
     const file = spawn.at(file_at);
     const cwd: ?[*:0]const u8 = if (cwd_at) |offset| spawn.at(offset) else null;
 
-    var i: usize = 0;
-    while (i < 3) : (i += 1) {
-        const item = c.PySequence_GetItem(args_in[4].?, @intCast(i)) orelse return py.Error.Python;
+    const stdio_count = c.PySequence_Size(args_in[4].?);
+    if (stdio_count < 0) return py.Error.Python;
+    spawn.stdio.ensureTotalCapacity(alloc, @intCast(stdio_count)) catch return py.errNoMemory();
+    var i: c.Py_ssize_t = 0;
+    while (i < stdio_count) : (i += 1) {
+        const item = c.PySequence_GetItem(args_in[4].?, i) orelse return py.Error.Python;
         defer py.decref(item);
         const fd = try py.asCInt(item);
-        spawn.stdio[i] = if (fd < 0)
+        spawn.stdio.appendAssumeCapacity(if (fd < 0)
             .{ .flags = uv.StdioFlags.ignore, .data = .{ .fd = -1 } }
         else
-            .{ .flags = uv.StdioFlags.inherit_fd, .data = .{ .fd = fd } };
+            .{ .flags = uv.StdioFlags.inherit_fd, .data = .{ .fd = fd } });
     }
 
     const obj = c.PyType_GenericAlloc(process_type, 0) orelse return py.Error.Python;
@@ -281,8 +286,8 @@ pub fn spawnProcess(self_obj: *py.Object, args_in: []const ?*py.Object) py.Error
     options.env = if (has_env) spawn.envp.items.ptr else null;
     options.cwd = cwd;
     options.flags = @intCast(try py.asCInt(args_in[5].?));
-    options.stdio_count = 3;
-    options.stdio = &spawn.stdio;
+    options.stdio_count = @intCast(spawn.stdio.items.len);
+    options.stdio = spawn.stdio.items.ptr;
     options.uid = @intCast(try py.asCInt(args_in[6].?));
     options.gid = @intCast(try py.asCInt(args_in[7].?));
 

--- a/zuvloop/_process.py
+++ b/zuvloop/_process.py
@@ -50,6 +50,16 @@ class Popen:
         if unsupported:
             name = next(iter(unsupported))
             raise ValueError(f"{name} is not supported by zuvloop's subprocess transport")
+        # Before any stream of ours is opened: the lowest-free rule would hand
+        # a freshly closed number in `pass_fds` straight to one of the pipes
+        # below, and the child would silently inherit that pipe end instead of
+        # the error. Failing here also beats the child dying with libuv's bare
+        # exit code 127, and bounds the stdio padding, since an open descriptor
+        # sits under RLIMIT_NOFILE.
+        for fd in pass_fds:
+            if fd < 0:
+                raise ValueError("bad value(s) in pass_fds")
+            os.fstat(fd)
 
         self.stdin: io.BufferedWriter | None = None
         self.stdout: io.BufferedReader | None = None
@@ -123,12 +133,6 @@ def _stdio(child_fds: list[int], pass_fds: Sequence[int]) -> list[int]:
     """
     stdio = list(child_fds)
     for fd in sorted(set(pass_fds)):
-        if fd < 0:
-            raise ValueError("bad value(s) in pass_fds")
-        # An absent descriptor cannot be inherited; failing here beats the
-        # child dying with exit code 127. It also bounds the padding below,
-        # since an open descriptor sits under RLIMIT_NOFILE.
-        os.fstat(fd)
         if fd < len(stdio):
             continue
         stdio.extend([-1] * (fd - len(stdio)))

--- a/zuvloop/_process.py
+++ b/zuvloop/_process.py
@@ -50,13 +50,8 @@ class Popen:
         if unsupported:
             name = next(iter(unsupported))
             raise ValueError(f"{name} is not supported by zuvloop's subprocess transport")
-        # Before any stream of ours is opened: the lowest-free rule would hand
-        # a freshly closed number in `pass_fds` straight to one of the pipes
-        # below, and the child would silently inherit that pipe end instead of
-        # the error. Failing here also beats the child dying with libuv's bare
-        # exit code 127, and bounds the stdio padding, since an open descriptor
-        # sits under RLIMIT_NOFILE. Materialized first, so a one-shot iterable
-        # is not spent by the validation.
+        # Before any pipe of ours can reuse a freshly closed number, and in the
+        # parent, where the error beats the child's bare exit code 127.
         pass_fds = tuple(pass_fds)
         for fd in pass_fds:
             if fd < 0:
@@ -69,10 +64,8 @@ class Popen:
         self.returncode: int | None = None
         self._on_exit = on_exit
 
-        # libuv's posix_spawn path - macOS - marks every stdio slot blocking,
-        # and the flag lives on the file description the parent shares with the
-        # child. subprocess leaves passed descriptors untouched, so what the
-        # caller had is put back once the spawn is done.
+        # libuv's posix_spawn path marks stdio slots blocking on the file
+        # description the parent shares; the caller's state goes back after.
         blocking = {fd: os.get_blocking(fd) for fd in pass_fds}
         child_fds: list[int] = []
         try:
@@ -133,12 +126,9 @@ def _stdio(child_fds: list[int], pass_fds: Sequence[int]) -> list[int]:
     """The descriptors the child inherits, each at the index it will hold there.
 
     A `pass_fds` entry keeps its own number, so it sits at that index. The gap
-    before it is left unconfigured, which closes it in practice: descriptors
-    carry close-on-exec by default since PEP 446, and one deliberately made
-    inheritable still reaches the child - as it does under every `uv_spawn`
-    user, libuv having no per-descriptor close hook. The three standard streams
-    have already claimed 0, 1 and 2, and a `pass_fds` naming one of those is
-    what it already is.
+    before it closes through close-on-exec defaults - libuv has no descriptor
+    close hook. The standard streams already claim 0-2, so naming one of those
+    asks for nothing new.
     """
     stdio = list(child_fds)
     for fd in sorted(set(pass_fds)):

--- a/zuvloop/_process.py
+++ b/zuvloop/_process.py
@@ -55,7 +55,9 @@ class Popen:
         # below, and the child would silently inherit that pipe end instead of
         # the error. Failing here also beats the child dying with libuv's bare
         # exit code 127, and bounds the stdio padding, since an open descriptor
-        # sits under RLIMIT_NOFILE.
+        # sits under RLIMIT_NOFILE. Materialized first, so a one-shot iterable
+        # is not spent by the validation.
+        pass_fds = tuple(pass_fds)
         for fd in pass_fds:
             if fd < 0:
                 raise ValueError("bad value(s) in pass_fds")

--- a/zuvloop/_process.py
+++ b/zuvloop/_process.py
@@ -113,12 +113,22 @@ class Popen:
 def _stdio(child_fds: list[int], pass_fds: Sequence[int]) -> list[int]:
     """The descriptors the child inherits, each at the index it will hold there.
 
-    A `pass_fds` entry keeps its own number, so it sits at that index and the gap
-    before it is left closed. The three standard streams have already claimed
-    0, 1 and 2, and a `pass_fds` naming one of those is what it already is.
+    A `pass_fds` entry keeps its own number, so it sits at that index. The gap
+    before it is left unconfigured, which closes it in practice: descriptors
+    carry close-on-exec by default since PEP 446, and one deliberately made
+    inheritable still reaches the child - as it does under every `uv_spawn`
+    user, libuv having no per-descriptor close hook. The three standard streams
+    have already claimed 0, 1 and 2, and a `pass_fds` naming one of those is
+    what it already is.
     """
     stdio = list(child_fds)
     for fd in sorted(set(pass_fds)):
+        if fd < 0:
+            raise ValueError("bad value(s) in pass_fds")
+        # An absent descriptor cannot be inherited; failing here beats the
+        # child dying with exit code 127. It also bounds the padding below,
+        # since an open descriptor sits under RLIMIT_NOFILE.
+        os.fstat(fd)
         if fd < len(stdio):
             continue
         stdio.extend([-1] * (fd - len(stdio)))

--- a/zuvloop/_process.py
+++ b/zuvloop/_process.py
@@ -69,6 +69,11 @@ class Popen:
         self.returncode: int | None = None
         self._on_exit = on_exit
 
+        # libuv's posix_spawn path - macOS - marks every stdio slot blocking,
+        # and the flag lives on the file description the parent shares with the
+        # child. subprocess leaves passed descriptors untouched, so what the
+        # caller had is put back once the spawn is done.
+        blocking = {fd: os.get_blocking(fd) for fd in pass_fds}
         child_fds: list[int] = []
         try:
             for index, request in enumerate((stdin, stdout, stderr)):
@@ -103,6 +108,8 @@ class Popen:
             for fd in child_fds:
                 if fd >= 0:
                     os.close(fd)
+            for fd, was_blocking in blocking.items():
+                os.set_blocking(fd, was_blocking)
 
         self.pid: int = self._handle.get_pid()
 

--- a/zuvloop/_process.py
+++ b/zuvloop/_process.py
@@ -47,8 +47,6 @@ class Popen:
             raise ValueError("startupinfo is not supported by zuvloop's subprocess transport")
         if creationflags:
             raise ValueError("creationflags is not supported by zuvloop's subprocess transport")
-        if pass_fds:
-            raise ValueError("pass_fds is not supported by zuvloop's subprocess transport")
         if unsupported:
             name = next(iter(unsupported))
             raise ValueError(f"{name} is not supported by zuvloop's subprocess transport")
@@ -75,7 +73,7 @@ class Popen:
                 args,
                 None if env is None else [f"{k}={v}" for k, v in env.items()],
                 None if cwd is None else os.fspath(cwd),
-                child_fds,
+                _stdio(child_fds, pass_fds),
                 flags,
                 0,
                 0,
@@ -110,6 +108,22 @@ class Popen:
         # `BaseSubprocessTransport.close()` reaches for this on a child that is
         # still running.
         self.send_signal(signal.SIGKILL)
+
+
+def _stdio(child_fds: list[int], pass_fds: Sequence[int]) -> list[int]:
+    """The descriptors the child inherits, each at the index it will hold there.
+
+    A `pass_fds` entry keeps its own number, so it sits at that index and the gap
+    before it is left closed. The three standard streams have already claimed
+    0, 1 and 2, and a `pass_fds` naming one of those is what it already is.
+    """
+    stdio = list(child_fds)
+    for fd in sorted(set(pass_fds)):
+        if fd < len(stdio):
+            continue
+        stdio.extend([-1] * (fd - len(stdio)))
+        stdio.append(fd)
+    return stdio
 
 
 def _open_stream(index: int, request: Any, child_fds: list[int]) -> tuple[int, int | None]:


### PR DESCRIPTION
`pass_fds` was accepted only when empty. asyncio and uvloop both hand the named descriptors to the child, so code written against either fails here - and it is the one `Popen` keyword `docs/usage/subprocesses.md` promises that the transport did not have. The two beside it, `startupinfo` and `creationflags`, are Windows-only and refused on POSIX by `subprocess.Popen` itself, so [#38](https://github.com/Kludex/zuvloop/pull/38) accepting only their defaults was already the right answer for those.

```
                          asyncio     uvloop      zuvloop (before)
pass_fds=(fd,)            inherited   inherited   ValueError
```

## How

libuv gives the child `stdio[i]` as descriptor `i`, and the number is the whole point - it is what the parent told the child to write to. So an entry sits at its own index, the gap before it is left closed, and the array is no longer the fixed three:

```
pass_fds=(5,)   ->   [stdin, stdout, stderr, -1, -1, 5]
```

A descriptor below three is already claimed by one of the standard streams, and asking for it again asks for nothing - `pass_fds=(2,)` must not displace stderr.

Nothing needs `set_inheritable`: libuv clears `CLOEXEC` on the descriptor it hands over, which is why the control case below fails rather than leaking through.

## How it is tested

Measured against both reference loops with a real pipe - the child writes to the number it was given, the parent reads it back:

```
asyncio  child_fd=7   parent read=b'hello-from-child'
uvloop   child_fd=11  parent read=b'hello-from-child'
zuvloop  child_fd=10  parent read=b'hello-from-child'
```

And the control, without `pass_fds`, on both: `OSError: [Errno 9] Bad file descriptor` in the child. Reverting the change turns `test_pass_fds_reaches_the_child_at_the_same_number` red with exactly that, so the test is load-bearing.

The gap test asserts its own premise - it opens the spare pipe first so the descriptor lands *between* stderr and the passed one rather than past the end, which is the case that would otherwise silently stop being tested.

344 tests, 100% branch coverage, conformance passed=90 failed=0, ruff, ruff format, mypy strict. Built and run under `-Doptimize=ReleaseSafe`.

Not included: `close_fds=False`, which CPython warns about overriding when combined with `pass_fds`. The transport does not take `close_fds` at all today.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `pass_fds` so child processes inherit the listed descriptors at the same numbers, with gaps left closed. Validates in the parent and preserves the original blocking state across spawn.

- **New Features**
  - Support `pass_fds`; each fd is inherited at its own number. FDs 0–2 stay stdin/stdout/stderr.
  - Send a sparse, variable-length `stdio` array to libuv; only specified indices are inherited, gaps stay closed.

- **Bug Fixes**
  - Validate `pass_fds` early in the parent (materialize first): negative fds raise ValueError; unopened fds raise OSError(EBADF). Prevents descriptor reuse and child exit 127.
  - Preserve the original blocking state for passed descriptors across spawn (macOS `posix_spawn`) so non-blocking sockets remain non-blocking.
  - CI: add a 15-minute timeout to the benchmarks job to prevent hangs.

<sup>Written for commit 976f9a824fe866585fc689f99020a6184301d387. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/39?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for passing selected file descriptors to child processes.
  - Preserves requested descriptor numbers, including standard streams and non-consecutive descriptors.
  - Unselected descriptors remain closed in the child process.

- **Bug Fixes**
  - Removed the previous limitation that rejected file-descriptor inheritance requests.
  - Improved handling of descriptor gaps and duplicate descriptors.
  - Added validation for negative and unavailable descriptors.
  - Extended automated coverage for descriptor inheritance and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->