### PR TITLE
Take libuv's posix_spawn path on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,12 @@ jobs:
       - name: Install
         run: uv sync --python ${{ matrix.python-version }} --group dev --group bench
 
+      # The posix_spawn path falls back to fork silently, so only the strace
+      # test can catch it regressing; make sure that test never skips here.
+      - name: Install strace
+        if: runner.os == 'Linux'
+        run: which strace || (sudo apt-get update -qq && sudo apt-get install -y -qq strace)
+
       # A wheel is compiled on whichever machine the job landed on, so a build
       # that defaults to that machine's CPU bakes its instruction set into a
       # published artifact - which then raises SIGILL on an older one. Asserted

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -316,3 +316,44 @@ async def test_a_raw_descriptor_number_can_be_handed_to_the_child(tmp_path: Path
     finally:
         os.close(fd)
     assert target.read_bytes() == b"by number\n"
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="the posix_spawn path is Linux-only")
+async def test_linux_spawns_without_copying_the_parent() -> None:
+    """The child must arrive by CLONE_VFORK, not a page-table-copying fork.
+
+    The posix_spawn path falls back to fork silently, so every other test in
+    this file passes either way; only tracing the syscall proves the fast path
+    is still taken. Requires strace and a glibc with addclosefrom_np (2.34).
+    """
+    import shutil
+
+    if shutil.which("strace") is None:
+        pytest.skip("strace is not installed")
+    libc = os.confstr("CS_GNU_LIBC_VERSION")
+    if libc is not None and libc.startswith("glibc"):
+        if tuple(int(part) for part in libc.split()[1].split(".")[:2]) < (2, 34):
+            pytest.skip("posix_spawn_file_actions_addclosefrom_np needs glibc 2.34")
+    else:
+        pytest.skip("not glibc, the posix_spawn path falls back to fork")
+
+    child = (
+        "import asyncio, zuvloop\n"
+        "async def main():\n"
+        "    p = await asyncio.create_subprocess_exec('/bin/true')\n"
+        "    await p.wait()\n"
+        "asyncio.run(main(), loop_factory=zuvloop.new_event_loop)\n"
+    )
+    traced = await asyncio.create_subprocess_exec(
+        "strace",
+        "-f",
+        "-e",
+        "trace=clone,clone3",
+        sys.executable,
+        "-c",
+        child,
+        stderr=PIPE,
+    )
+    _stdout, stderr = await asyncio.wait_for(traced.communicate(), 60)
+    assert traced.returncode == 0, stderr.decode()
+    assert b"CLONE_VFORK" in stderr, stderr.decode()

--- a/vendor/libuv/src/unix/process.c
+++ b/vendor/libuv/src/unix/process.c
@@ -35,13 +35,15 @@
 #include <fcntl.h>
 #include <poll.h>
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(__linux__)
 # include <spawn.h>
 # include <paths.h>
+# include <dlfcn.h>
+#endif
+#if defined(__APPLE__)
 # include <sys/kauth.h>
 # include <sys/types.h>
 # include <sys/sysctl.h>
-# include <dlfcn.h>
 # include <crt_externs.h>
 # include <xlocale.h>
 # define environ (*_NSGetEnviron())
@@ -417,10 +419,11 @@ static void uv__process_child_init(const uv_process_options_t* options,
 }
 
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(__linux__)
 typedef struct uv__posix_spawn_fncs_tag {
   struct {
     int (*addchdir_np)(const posix_spawn_file_actions_t *, const char *);
+    int (*addclosefrom_np)(posix_spawn_file_actions_t *, int);
   } file_actions;
 } uv__posix_spawn_fncs_t;
 
@@ -434,10 +437,18 @@ static void uv__spawn_init_posix_spawn_fncs(void) {
   /* Try to locate all non-portable functions at runtime */
   posix_spawn_fncs.file_actions.addchdir_np =
     dlsym(RTLD_DEFAULT, "posix_spawn_file_actions_addchdir_np");
+  posix_spawn_fncs.file_actions.addclosefrom_np =
+    dlsym(RTLD_DEFAULT, "posix_spawn_file_actions_addclosefrom_np");
 }
 
 
 static void uv__spawn_init_can_use_setsid(void) {
+#if defined(__linux__)
+#ifdef POSIX_SPAWN_SETSID
+  posix_spawn_can_use_setsid = 1;
+#endif
+}
+#else /* defined(__APPLE__) */
   int which[] = {CTL_KERN, KERN_OSRELEASE};
   unsigned major;
   unsigned minor;
@@ -455,6 +466,7 @@ static void uv__spawn_init_can_use_setsid(void) {
 
   posix_spawn_can_use_setsid = (major >= 19);  /* macOS Catalina */
 }
+#endif
 
 
 static void uv__spawn_init_posix_spawn(void) {
@@ -500,9 +512,11 @@ static int uv__spawn_set_posix_spawn_attrs(
    *    spawn-sigmask in attributes
    * 4) POSIX_SPAWN_SETSID: Make the process a new session leader if a detached
    *    session was requested. */
-  flags = POSIX_SPAWN_CLOEXEC_DEFAULT |
-          POSIX_SPAWN_SETSIGDEF |
+  flags = POSIX_SPAWN_SETSIGDEF |
           POSIX_SPAWN_SETSIGMASK;
+#if defined(__APPLE__)
+  flags |= POSIX_SPAWN_CLOEXEC_DEFAULT;
+#endif
   if (options->flags & UV_PROCESS_DETACHED) {
     /* If running on a version of macOS where this flag is not supported,
      * revert back to the fork/exec flow. Otherwise posix_spawn will
@@ -567,6 +581,17 @@ static int uv__spawn_set_posix_spawn_file_actions(
       goto error;
   }
 
+#if !defined(__APPLE__)
+  /* Without the Apple-only POSIX_SPAWN_CLOEXEC_DEFAULT, closing everything
+   * the child should not see needs posix_spawn_file_actions_addclosefrom_np
+   * (glibc 2.34). Requiring it up front also pins a glibc new enough (2.29)
+   * that adddup2 with equal descriptors clears FD_CLOEXEC in the child. */
+  if (posix_spawn_fncs->file_actions.addclosefrom_np == NULL) {
+    err = ENOSYS;
+    goto error;
+  }
+#endif
+
   /* Do not return ENOSYS after this point, as we may mutate pipes. */
 
   /* First duplicate low numbered fds, since it's not safe to duplicate them,
@@ -619,7 +644,11 @@ static int uv__spawn_set_posix_spawn_file_actions(
     }
 
     if (fd == use_fd)
+#if defined(__APPLE__)
         err = posix_spawn_file_actions_addinherit_np(actions, fd);
+#else
+        err = posix_spawn_file_actions_adddup2(actions, fd, fd);
+#endif
     else
         err = posix_spawn_file_actions_adddup2(actions, use_fd, fd);
     assert(err != ENOSYS);
@@ -650,6 +679,14 @@ static int uv__spawn_set_posix_spawn_file_actions(
     if (err != 0)
       goto error;
   }
+
+#if !defined(__APPLE__)
+  /* Everything past the child's stdio is closed here, standing in for the
+   * Apple-only POSIX_SPAWN_CLOEXEC_DEFAULT set in the spawn attributes. */
+  err = posix_spawn_fncs->file_actions.addclosefrom_np(actions, stdio_count);
+  if (err != 0)
+    goto error;
+#endif
 
   return 0;
 
@@ -869,7 +906,7 @@ static int uv__spawn_and_init_child(
   int exec_errorno;
   ssize_t r;
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(__linux__)
   uv_once(&posix_spawn_init_once, uv__spawn_init_posix_spawn);
 
   /* Special child process spawn case for macOS Big Sur (11.0) onwards
@@ -884,7 +921,15 @@ static int uv__spawn_and_init_child(
    * exhibit the problem. This block implements the forking and preparation
    * logic with posix_spawn and its related primitives. It also takes advantage of
    * the macOS extension POSIX_SPAWN_CLOEXEC_DEFAULT that makes impossible to
-   * leak descriptors to the child process. */
+   * leak descriptors to the child process.
+   *
+   * On Linux, glibc's posix_spawn is clone(CLONE_VM|CLONE_VFORK): no
+   * page-table copy, so spawning stays flat as the parent's heap grows,
+   * where fork reaches milliseconds per call from a multi-hundred-MiB
+   * parent. Descriptor hygiene comes from
+   * posix_spawn_file_actions_addclosefrom_np (glibc 2.34, resolved with
+   * dlsym) standing in for POSIX_SPAWN_CLOEXEC_DEFAULT; a libc without it
+   * falls back to fork below. */
   err = uv__spawn_and_init_child_posix_spawn(options,
                                              stdio_count,
                                              pipes,


### PR DESCRIPTION
this PR enables libuv's existing posix_spawn spawn strategy on Linux in the vendored copy. glibc's posix_spawn is `clone(CLONE_VM|CLONE_VFORK)` — no page-table copy — so spawn cost stays flat as the parent's heap grows, where `uv_spawn`'s fork path reaches ~16 ms per spawn from an 800 MiB parent. Linux is where the wheels ship, and it's the one platform where zuvloop currently loses to asyncio at spawning.

| ms/spawn (Linux, sequential `/bin/true`) | 0 MiB parent heap | 200 MiB | 800 MiB |
|---|---:|---:|---:|
| zuvloop before (fork) | 1.16 | 5.96 | 16.35 |
| zuvloop after (posix_spawn) | ~0.21 | ~0.21 | **~0.20** |
| asyncio (posix_spawn already) | 0.37 | 0.29 | 0.30 |

(uvloop, which also forks on Linux, measures ~3–4 ms/spawn at zero ballast on the same machine — I did not measure its heap scaling.)

the diff carries its own proof: because the posix_spawn path falls back to fork *silently*, every existing test passes identically either way — so a new Linux-only test straces a spawn and asserts the child arrives via `CLONE_VFORK`, and CI installs strace so it can never skip there. beyond that, all 340 existing tests pass on Linux and macOS; macOS behavior is unchanged; bad `cwd` and bad executables still raise synchronously.

<details>
<summary>what the diff is</summary>

libuv's posix_spawn implementation (added for macOS Big Sur's fork regression) is almost entirely portable; the patch is 59 lines in `vendor/libuv/src/unix/process.c` swapping the three Apple-isms:

- `POSIX_SPAWN_CLOEXEC_DEFAULT` (Apple extension) becomes a `posix_spawn_file_actions_addclosefrom_np` action past the child's stdio — resolved with `dlsym` exactly like `addchdir_np` already is, so a libc without it (glibc < 2.34, musl) falls back to the fork path at runtime and the musl wheels are unaffected.
- `addinherit_np` (Apple-only) becomes dup2-to-self, whose POSIX 2024 semantics clear `FD_CLOEXEC` in the child. requiring `addclosefrom_np` conveniently pins a glibc new enough (≥ 2.29) to honor that.
- the setsid capability probe reads the macOS version via sysctl; on Linux `POSIX_SPAWN_SETSID` is a compile-time question.

the design story is unchanged: `uv_process_t`, libuv reaping its own children, the exit callback — everything `docs/usage/subprocesses.md` says stays true. zuvloop's zig and python layers are untouched.

</details>

<details>
<summary>the tradeoff, stated plainly</summary>

the vendored libuv is currently pristine v1.51.0, and this would be the first floating patch against it — a real maintenance cost on vendor bumps. the mitigation is that the patch is written to be proposed to libuv upstream (where it would also fix uvloop and node's `child_process` on Linux); if it lands there, the vendor delta disappears on the next bump. happy to drive that upstream submission, or leave it with you — draft until you've weighed the precedent.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
