### PR TITLE
Benchmark call_soon_threadsafe before changing it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,4 @@
 # Rules
 
 1. `Any` should be avoided in the Python type hints, and `object` is only marginally better — both are poor choices. Use the proper, most precise type possible.
+2. A performance change lands as two PRs: first the benchmark on its own, then the change itself, so the effect is visible against the recorded baseline.

--- a/benchmarks/compare.py
+++ b/benchmarks/compare.py
@@ -19,6 +19,7 @@ import os
 import socket
 import statistics
 import sys
+import threading
 import time
 from collections.abc import Callable, Coroutine
 
@@ -187,6 +188,26 @@ def call_soon(loop: asyncio.AbstractEventLoop) -> Callable[[], None]:
     return _driver(loop, once)
 
 
+def call_soon_threadsafe(loop: asyncio.AbstractEventLoop) -> Callable[[], None]:
+    """Cross-thread scheduling: 10000 callbacks issued from a worker thread."""
+    iterations = 10_000
+
+    async def once() -> None:
+        done = loop.create_future()
+
+        def worker() -> None:
+            for _ in range(iterations):
+                loop.call_soon_threadsafe(_noop)
+            loop.call_soon_threadsafe(done.set_result, None)
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        await done
+        thread.join()
+
+    return _driver(loop, once)
+
+
 def timers(loop: asyncio.AbstractEventLoop) -> Callable[[], None]:
     """Timer bookkeeping: schedule and cancel, never firing."""
     iterations = 10_000
@@ -229,6 +250,7 @@ WORKLOADS: dict[str, Workload] = {
     "split_write": split_write,
     "bulk": bulk,
     "call_soon": call_soon,
+    "call_soon_threadsafe": call_soon_threadsafe,
     "timers": timers,
     "getaddrinfo": getaddrinfo,
     "spawn": spawn,

--- a/benchmarks/test_benchmarks.py
+++ b/benchmarks/test_benchmarks.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import asyncio
 import os
 import socket
+import threading
 from collections.abc import Callable, Coroutine, Iterator
 
 import pytest
@@ -73,6 +74,27 @@ def test_call_soon(benchmark: BenchmarkFixture, loop: asyncio.AbstractEventLoop)
         for _ in range(iterations):
             loop.call_soon(step)
         await done
+
+    benchmark(drive(loop, work))
+
+
+@pytest.mark.benchmark
+def test_call_soon_threadsafe(benchmark: BenchmarkFixture, loop: asyncio.AbstractEventLoop) -> None:
+    """Cross-thread scheduling, where the 3.14 handle contract sets the price."""
+    iterations = 10_000
+
+    async def work() -> None:
+        done = loop.create_future()
+
+        def worker() -> None:
+            for _ in range(iterations):
+                loop.call_soon_threadsafe(_noop)
+            loop.call_soon_threadsafe(done.set_result, None)
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        await done
+        thread.join()
 
     benchmark(drive(loop, work))
 


### PR DESCRIPTION
`call_soon_threadsafe` is the one shape with a known deficit - 0.28x uvloop, measured by hand - and it had no benchmark, so nothing recorded the baseline a change would be judged against. This adds the cross-thread scheduling shape to both harnesses: `compare.py` for the interleaved uvloop ratio, and the CodSpeed suite for the per-commit record.

Baseline on this machine (M3 Max, interleaved): zuvloop 0.28x uvloop, 2.7x asyncio.

The change that moves the number is [#42](https://github.com/Kludex/zuvloop/pull/42), which follows this PR per the new `AGENTS.md` rule: a performance change lands as two PRs, benchmark first, so the effect is visible against the recorded baseline.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `call_soon_threadsafe` benchmark to establish a cross-thread scheduling baseline before changing it. This records interleaved ratios in `benchmarks/compare.py`, adds a CodSpeed benchmark for per-commit tracking, and updates `AGENTS.md` with a benchmark-first rule for performance changes.

<sup>Written for commit 120acf0664c080b017120f0dab4d4bb48f6cd245. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/43?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

