### PR TITLE
Keep polling a registered descriptor after a poll error

### DIFF
--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1372,7 +1372,7 @@ async def test_a_poll_error_does_not_unregister_the_reader() -> None:
         def on_readable() -> None:
             try:
                 data = sock.recv(1024)
-            except (BlockingIOError, ConnectionRefusedError):
+            except BlockingIOError, ConnectionRefusedError:
                 return  # the rejection, consumed, or a bare error wake; the registration stays
             if not received.done():  # pragma: no cover - whether a duplicate wake arrives is the platform's choice
                 received.set_result(data)

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1352,6 +1352,46 @@ async def test_the_asyncio_server_hook_unregisters_and_closes() -> None:
     assert sock.fileno() == -1
 
 
+async def test_a_poll_error_does_not_unregister_the_reader() -> None:
+    """An ICMP rejection reaches epoll as POLLERR, on which libuv stops the
+    poll handle; the registration survives the error, so the polling must too.
+    macOS never delivers the POLLERR, which makes this a plain delivery test
+    there; the teeth are in the Linux run."""
+    loop = running_loop()
+    received: asyncio.Future[bytes] = loop.create_future()
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    peer = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        sock.bind(("127.0.0.1", 0))
+        sock.setblocking(False)
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as probe:
+            probe.bind(("127.0.0.1", 0))
+            dead = probe.getsockname()
+        sock.connect(dead)
+
+        def on_readable() -> None:
+            try:
+                data = sock.recv(1024)
+            except OSError:
+                return  # the rejection, consumed; the registration stays
+            if not received.done():
+                received.set_result(data)
+
+        loop.add_reader(sock.fileno(), on_readable)
+        try:
+            sock.send(b"ping")  # nothing listens on `dead`: the rejection comes back
+        except OSError:
+            pass
+        await asyncio.sleep(0.1)
+        peer.bind(dead)
+        peer.sendto(b"pong", sock.getsockname())
+        assert await asyncio.wait_for(received, 2) == b"pong"
+    finally:
+        loop.remove_reader(sock.fileno())
+        sock.close()
+        peer.close()
+
+
 async def test_a_raising_read_callback_closes_the_connection() -> None:
     """asyncio treats it as fatal, and the exception is what `connection_lost` is for."""
     loop = running_loop()

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1372,15 +1372,15 @@ async def test_a_poll_error_does_not_unregister_the_reader() -> None:
         def on_readable() -> None:
             try:
                 data = sock.recv(1024)
-            except OSError:
-                return  # the rejection, consumed; the registration stays
-            if not received.done():
+            except (BlockingIOError, ConnectionRefusedError):
+                return  # the rejection, consumed, or a bare error wake; the registration stays
+            if not received.done():  # pragma: no cover - whether a duplicate wake arrives is the platform's choice
                 received.set_result(data)
 
         loop.add_reader(sock.fileno(), on_readable)
         try:
             sock.send(b"ping")  # nothing listens on `dead`: the rejection comes back
-        except OSError:
+        except OSError:  # pragma: no cover - whether the send itself raises is the platform's choice
             pass
         await asyncio.sleep(0.1)
         peer.bind(dead)

--- a/zig/poller.zig
+++ b/zig/poller.zig
@@ -39,6 +39,19 @@ fn onPoll(handle: ?*uv.Poll, status: c_int, events: c_int) callconv(.c) void {
     const fire_write = status < 0 or events & uv.WRITABLE != 0;
     if (fire_read) schedule(st, self.reader);
     if (fire_write) schedule(st, self.writer);
+    if (status < 0) {
+        // libuv stopped the handle before reporting the error, so the cache
+        // must stop claiming the descriptor is polled - `rearm` compares
+        // against it. What stays registered wants the poll running again: a
+        // selector keeps polling a registered descriptor through an error,
+        // once per turn, until a callback consumes it or removes the
+        // registration. The woken callbacks run before the restarted poll is
+        // submitted to the kernel, so a callback that consumes the error - a
+        // datagram endpoint eating an ICMP rejection - leaves a clean
+        // descriptor behind, not a spin.
+        self.events = 0;
+        rearm(st, self) catch py.writeUnraisable(@ptrCast(self.loop));
+    }
     loopmod.startIdle(st);
 }
 


### PR DESCRIPTION
epoll reports `POLLERR` whether or not it was asked for - an ICMP rejection on a connected datagram socket is enough - and libuv stops the `uv_poll_t` before reporting it (`uv__poll_io` in `src/unix/poll.c`). The `events` cache in the poller still claimed the descriptor was polled, so `rearm` compared equal and declined to restart: the reader stayed registered, consumed the error on its next `recv`, and then waited forever for datagrams the loop was no longer polling for.

`onPoll` now resets the cache when libuv reports an error and re-arms whatever is still registered, which is what a selector does: a registered descriptor stays level-triggered through an error, once per turn, until a callback consumes it or removes the registration. The woken callbacks run in the idle phase before the restarted poll is submitted to the kernel, so a callback that consumes the error leaves a clean descriptor behind, not a spin.

The first commit is the test alone, so the ubuntu run on it demonstrates the failure; the fix follows. macOS never delivers the `POLLERR`, which makes the test a plain delivery check there - the teeth are in the Linux run.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Linux behavior where a `POLLERR` from `epoll` silently stopped polling a registered socket. We now reset state and re-arm on error so readers stay registered and don’t hang.

- **Bug Fixes**
  - In `onPoll`, when `libuv` reports an error, clear the events cache, re-arm registered interests, and run callbacks before re-submitting the poll to avoid spins and preserve level-triggered behavior until the error is consumed.
  - Added a UDP test that triggers an ICMP rejection: confirms the reader stays registered and receives data after the error; on macOS (no `POLLERR`), it acts as a delivery check.
  - Tightened the test’s exception handling to only ignore the rejection and bare error wake, marked platform-chosen branches to avoid masking unrelated failures, and aligned the except clause with the formatter.

<sup>Written for commit 8e13c75d78c4abc96fc886f643778a6797b242f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/45?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage confirming UDP connections continue receiving data after an initial polling error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->