### PR TITLE
Report a datagram whose sender address will not convert

### DIFF
--- a/zig/datagram.zig
+++ b/zig/datagram.zig
@@ -215,7 +215,11 @@ fn onRecv(
     };
     defer py.decref(data);
     const sender = addr.toPython(from.?) catch {
-        c.PyErr_Clear();
+        // The datagram cannot be delivered without naming its sender, and a
+        // receive failure is what `error_received` exists to report.
+        const exc = c.PyErr_GetRaisedException() orelse return;
+        defer py.decref(exc);
+        callInContext(self, self.cb_error_received, &.{exc});
         return;
     };
     defer py.decref(sender);


### PR DESCRIPTION
`onRecv` cleared the address-conversion error and dropped the datagram with it: no `error_received`, nothing unraisable, a loss no observer could see. The failure now reaches `error_received` like any other receive failure, mirroring the `nread < 0` path - the datagram cannot be delivered without naming its sender, and a protocol that hears about the loss can decide what it costs.

There is no test because the path is unreachable from Python today: only a sockaddr that `uv_ip_name` rejects takes it - an exotic address family already converts to `None` rather than failing - and the kernel does not deliver malformed sockaddrs for AF_INET/AF_INET6. The change is what the silence turns into if one ever arrives; the existing `error_received` suite covers the delivery mechanics it reuses.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deliver datagram receive failures when the sender address cannot be converted to Python via `error_received` instead of silently dropping the packet. This aligns with other receive failures so protocols can observe and react.

- **Bug Fixes**
  - In `onRecv`, forward the raised conversion exception to `error_received` instead of clearing it.
  - Matches the existing `nread < 0` failure path; no API changes.

<sup>Written for commit 77186cbb6f59078cbad3ac52f2f2e5c9715af04e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/46?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

