### PR TITLE
Say what the empty-host path really costs the loop

### DIFF
--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -81,11 +81,15 @@ async def test_getaddrinfo_reports_failures() -> None:
         # What `""` means is the platform's business, and the platforms disagree:
         # BSD reads it as the null host and resolves the wildcard address, glibc
         # calls it a name it cannot find. libuv reaches neither, because it runs
-        # every hostname through IDNA first and that rejects an empty one.
+        # every hostname through IDNA first and that rejects an empty one. Each
+        # service form reaches libc differently, and the null one is what CPython
+        # carries a macOS workaround for.
         ("", "http"),
+        ("", "80"),
+        ("", None),
     ],
 )
-async def test_getaddrinfo_answers_as_the_stdlib_does(host: str, port: str) -> None:
+async def test_getaddrinfo_answers_as_the_stdlib_does(host: str, port: str | None) -> None:
     loop = running_loop()
     kwargs = {"family": socket.AF_INET, "type": socket.SOCK_STREAM}
     try:

--- a/zig/dns.zig
+++ b/zig/dns.zig
@@ -441,7 +441,14 @@ pub fn getaddrinfo(self_obj: *py.Object, args: []const ?*py.Object) py.Error!*py
     // can never reach a resolver that way. The platforms disagree about what it
     // means - BSD reads it as the null host, glibc as a name it cannot find - and
     // matching `socket.getaddrinfo` means letting the platform answer rather than
-    // picking one. Neither looks anything up, so this cannot block the loop.
+    // picking one.
+    //
+    // Nothing is resolved here, but this does enter libc on the loop thread, and
+    // the first call in a process pays for the resolver's own initialization:
+    // measured on macOS at 1.5ms for a numeric service and 2.3ms for a name,
+    // then under a microsecond for every call after it. `resolveNumeric` pays the
+    // same initialization on the main path, so moving this one to a threadpool
+    // would not buy a loop that never waits for the resolver to wake up.
     if (host) |name| if (name[0] == 0) {
         var res: ?*std.c.addrinfo = null;
         const rc = std.c.getaddrinfo(name, service, &hints, &res);


### PR DESCRIPTION
Two follow-ons from [#14](https://github.com/Kludex/zuvloop/pull/14)'s empty-host path were open. I measured both; one is real and differently shaped than recorded, the other does not reproduce on any platform we ship to.

**The blocking claim is real, but it is not about service names.** The comment said "Neither looks anything up, so this cannot block the loop." Nothing *is* looked up, but the call still enters libc on the loop thread, and the first one in a process pays for the resolver's own initialization:

| first call in a fresh process | macOS 26, M3 Max |
| --- | ---: |
| `getaddrinfo("", "80")` - numeric service | 1.546 ms |
| `getaddrinfo("", "http")` | 1.783 ms |
| `getaddrinfo("", "ldap")` | 2.313 ms |
| every call after the first | < 0.001 ms |

So a *numeric* service costs 1.5ms too - it is resolver initialization, not a service-name lookup. `resolveNumeric` pays the same initialization on the main path, so moving only this call to a threadpool would buy a loop that still waits for the resolver to wake up, just somewhere else. The comment now says that instead of denying it.

I did consider fixing it properly. On macOS `""` and `None` are exactly equivalent - verified across every combination of 4 service forms, 3 flag sets and 3 families - so `""` could be rewritten to `NULL` and handed to libuv's threadpool. But glibc and musl read `""` as a name that does not resolve, and I cannot verify either from this machine. Platform-conditional resolver behaviour, unverifiable on two of the three libcs we ship, is not worth removing a one-time cost from a path that only a direct `loop.getaddrinfo("", ...)` reaches - `create_server` normalizes `""` to `None` before it ever gets here.

**The macOS `AI_NUMERICSERV` defect does not reproduce.** CPython substitutes `"00"` when `AI_NUMERICSERV` is set with a null or `"0"` service, for a libsystem crash its comment dates to "OSX up to at least OSX 10.8". On macOS 26 all three forms return normally, in C and through this resolver, and Python 3.14 already floors us above that. Adding the workaround would be carrying a 2012 bug fix for platforms we do not ship to, so this does not.

The parity test covered one service form; it now covers the numeric and null forms too, since each reaches libc differently and the null one is exactly what that workaround guards.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the empty-host `getaddrinfo` path: the first call enters libc and pays a one-time resolver init (~1.5–2.3 ms on macOS), so moving only this call to a threadpool won’t avoid the wait. Expands parity tests to include numeric and null services and omits the legacy macOS `AI_NUMERICSERV` workaround, which no longer reproduces.

<sup>Written for commit b84007895d8d554782630f1ae86609b06c66ce9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/48?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

