### PR TITLE
Release 0.0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zuvloop"
-version = "0.0.1"
+version = "0.0.2"
 description = "A libuv event loop for asyncio, written in Zig."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -883,7 +883,7 @@ wheels = [
 
 [[package]]
 name = "zuvloop"
-version = "0.0.1"
+version = "0.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-api" },


### PR DESCRIPTION
Thirty-one commits since 0.0.1. The version lives in `pyproject.toml` and is mirrored in `uv.lock`, so both move together - see [#24](https://github.com/Kludex/zuvloop/pull/24), which is what happens when they do not.

This has to land before the tag: `publish.yml` builds and uploads on `refs/tags/*`, and wheels built at 0.0.1 would be rejected by PyPI as an existing version.

Verified locally: the extension rebuilds, `importlib.metadata.version("zuvloop")` reports 0.0.2, and the suite passes.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `zuvloop` version to 0.0.2 in `pyproject.toml` and `uv.lock`. Preps the release so the tag-triggered `publish.yml` uploads new wheels without PyPI version conflicts.

<sup>Written for commit 7d2a909788afefc91eee05d839b8be11a5a834b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/51?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

