### PR TITLE
Take the version from the tag rather than a file

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,10 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
+          # hatch-vcs reads the version off the tags, and the default shallow
+          # checkout fetches none of them: the build would stamp the fallback
+          # onto a wheel rather than fail, so this has to be the full history.
+          fetch-depth: 0
 
       # cibuildwheel's build[uv] frontend needs uv on PATH; the manylinux
       # containers ship it, the macOS runners do not.
@@ -61,6 +65,10 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
+          # hatch-vcs reads the version off the tags, and the default shallow
+          # checkout fetches none of them: the build would stamp the fallback
+          # onto a wheel rather than fail, so this has to be the full history.
+          fetch-depth: 0
 
       - uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,18 @@
 [build-system]
-requires = ["hatchling", "hatch-ziglang", "ziglang==0.16.0"]
+# hatch-ziglang is pinned exactly: it runs during the isolated wheel build and
+# invokes the native compiler, so a future version resolved from a lower bound
+# could execute unreviewed code into the wheels the publish job trusts. The
+# compiler is pinned for the same reason. Bump both deliberately.
+requires = ["hatchling", "hatch-vcs", "hatch-ziglang==0.2.1", "ziglang==0.16.0"]
 build-backend = "hatchling.build"
 
 [project]
 name = "zuvloop"
-version = "0.0.2"
 description = "A libuv event loop for asyncio, written in Zig."
 readme = "README.md"
 requires-python = ">=3.14"
 license = "MIT"
+dynamic = ["version"]
 # libuv is compiled into the extension, so its licence ships with the wheel.
 license-files = ["LICENSE", "vendor/libuv/LICENSE*"]
 authors = [{ name = "Marcelo Trylesinski", email = "marcelotryle@gmail.com" }]
@@ -39,6 +43,17 @@ dev = [
 ]
 bench = ["aiohttp", "httptools", "pytest-codspeed>=5", "uvicorn", "uvloop>=0.21"]
 docs = ["zensical"]
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.version.raw-options]
+# A tag is the version; commits after it are the next patch's dev builds, so an
+# untagged build can never claim to be the release. `no-local-version` drops the
+# `+<hash>` segment, which PyPI refuses on upload.
+version_scheme = "guess-next-dev"
+local_scheme = "no-local-version"
+fallback_version = "0.0.0"
 
 [tool.hatch.build.targets.wheel]
 packages = ["zuvloop"]

--- a/uv.lock
+++ b/uv.lock
@@ -883,7 +883,6 @@ wheels = [
 
 [[package]]
 name = "zuvloop"
-version = "0.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-api" },


### PR DESCRIPTION
Releasing 0.0.2 meant editing `pyproject.toml` and `uv.lock`, opening a PR, merging it, and only then tagging. Getting that order wrong builds wheels carrying the previous version, which PyPI rejects - and it did get got wrong: the first `v0.0.2` tag pointed at a commit still saying `0.0.1`, and only a cancelled workflow run kept it from being an upload failure.

`hatch-vcs` takes the version off git instead, the way [zttp](https://github.com/Kludex/zttp) does. A tag is the version exactly; a commit after one is a dev build of the next patch, so nothing untagged can claim to be a release:

```
at the tag exactly:        9.9.9          # throwaway tag on this branch
one commit past v0.0.2:    0.0.3.dev1
built wheel:               zuvloop-0.0.3.dev1-cp314-cp314-macosx_26_0_arm64.whl
```

Releasing becomes: tag, and publish the release.

Three things that come with it:

- **`uv.lock` no longer records a version**, so it cannot drift from the one it locks - which is what [#24](https://github.com/Kludex/zuvloop/pull/24) was.
- **Both publish checkouts fetch the full history.** `hatch-vcs` reads tags and the default shallow checkout fetches none, and the failure mode is silent: it stamps the fallback version onto a wheel rather than stopping. zttp carries the same comment for the same reason.
- **`hatch-ziglang` is pinned exactly** (0.2.1, its current release) rather than left on a lower bound, matching zttp. It runs inside the isolated build and invokes the native compiler, so an unpinned future release could put unreviewed code into the wheels the publish job uploads under trusted publishing.

Verified locally: a wheel builds and is named for the derived version, the suite passes, ruff and strict mypy are clean.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch versioning to git tags via `hatch-vcs` to prevent mismatched releases and make publishing as simple as tagging and pushing. Workflows now fetch full history for tags, and `hatch-ziglang` is pinned for safer builds.

- **Refactors**
  - Version comes from tags with `hatch-vcs` (dynamic with `guess-next-dev`, `no-local-version`, fallback `0.0.0`).
  - Removed hardcoded versions from `pyproject.toml` and `uv.lock`.
  - Publish jobs set `fetch-depth: 0` so tags are available.

- **Dependencies**
  - Added `hatch-vcs`; pinned `hatch-ziglang==0.2.1`; kept `ziglang==0.16.0`.

<sup>Written for commit 82153d2eaa908ab020ae873e2987c86e71823e02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/52?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

