### PR TITLE
Notice OpenTelemetry providers installed after the loop starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ zuvloop.run(main())
 
 That's all — there is no zuvloop-specific setup. Spans and counters are emitted
 as events happen, and the loop gauges are sampled automatically while the loop
-runs (only when a real provider is installed, so an uninstrumented program never
-pays for sampling).
+runs (published only once a real provider is installed; without one the
+snapshot is dropped).
 
 You get:
 

--- a/README.md
+++ b/README.md
@@ -98,9 +98,11 @@ That's it. That's the migration. 🎉
 ## Observability
 
 zuvloop emits plain OpenTelemetry. The only runtime dependency is `opentelemetry-api` — not the
-SDK, nothing vendor-specific. Configure providers before starting the loop; zuvloop checks for them
-at each `run_forever()` entry. Until then the instruments are no-ops and slow-callback timing stays
-off.
+SDK, nothing vendor-specific. Providers can be configured before the loop starts or from inside
+it — `logfire.configure()` in `main()` works: zuvloop checks at each `run_forever()` entry and
+re-checks on its sampling interval (`loop.metrics_interval`, 10 seconds by default) while the
+loop runs. Until a provider is installed the instruments are no-ops and slow-callback timing
+stays off.
 
 Anything that speaks OpenTelemetry can collect it. For example, with
 <a href="https://logfire.pydantic.dev" target="_blank">Logfire</a>:

--- a/docs/usage/instrumentation.md
+++ b/docs/usage/instrumentation.md
@@ -4,9 +4,12 @@ zuvloop emits plain [OpenTelemetry](https://opentelemetry.io). Its only runtime
 dependency is `opentelemetry-api` — not the SDK, and nothing vendor-specific.
 
 Until an application installs a provider, OpenTelemetry hands back proxy
-instruments whose methods do nothing and slow-callback timing stays off. Install
-providers before starting the loop; zuvloop checks for them at each
-`run_forever()` entry.
+instruments whose methods do nothing and slow-callback timing stays off.
+Providers can be installed before the loop starts or from inside it —
+`logfire.configure()` in `main()` works: zuvloop checks at each `run_forever()`
+entry and re-checks every `metrics_interval` seconds (10 by default) while the
+loop runs, so a provider configured after start arms slow-callback timing
+within one interval.
 
 **The measurement happens in Zig. Python only records it.**
 
@@ -39,9 +42,10 @@ zuvloop.run(main())
 ```
 
 Spans and counters are emitted as the events happen. The gauges are sampled
-automatically while the loop runs, but only when a real meter provider is
-installed - without one there would be nowhere for the numbers to go, so the
-sampler never starts. The default interval is 10 seconds; set
+automatically while the loop runs and published when a real meter provider is
+installed - without one the snapshot is dropped, since there is nowhere for
+the numbers to go. The same timer is what notices a provider configured after
+the loop started. The default interval is 10 seconds; set
 `loop.metrics_interval` before running the loop to change it:
 
 ```python
@@ -59,10 +63,16 @@ The span's duration is reconstructed backwards from the loop's own monotonic
 measurement, so it covers the callback itself rather than the moment it was
 reported.
 
-Slow callbacks are monitored when the loop run begins with an OpenTelemetry
-tracing or metrics provider installed; asyncio debug mode does not need to be
-enabled. Metrics-only configurations skip span and call-graph construction. Set
-the threshold as you would on any loop:
+Slow callbacks are monitored whenever an OpenTelemetry tracing or metrics
+provider is installed - whether it was there when the loop started or appeared
+up to `metrics_interval` seconds ago; asyncio debug mode does not need to be
+enabled. Metrics-only configurations skip span and call-graph construction.
+
+A slow callback is reported as a warning, not an error: the span's status is
+left unset - OpenTelemetry has no warning status - and the severity travels as
+a `logfire.level_num` attribute, which backends that do not know it ignore.
+
+Set the threshold as you would on any loop:
 
 ```python
 loop.slow_callback_duration = 0.05

--- a/tests/test_instrumentation.py
+++ b/tests/test_instrumentation.py
@@ -39,7 +39,10 @@ async def test_slow_callbacks_are_reported_without_debug_mode(telemetry: Telemet
         for span in telemetry.spans("zuvloop.slow_callback")
         if "slow_callback" in str(attribute(span, "code.callback"))
     )
-    assert span.status.status_code is StatusCode.ERROR
+    # A slow callback is a warning, not an error: the span status stays unset
+    # and the severity is carried as Logfire's numeric level.
+    assert span.status.status_code is StatusCode.UNSET
+    assert numeric_attribute(span, "logfire.level_num") == 13
     assert numeric_attribute(span, "duration") >= 0.01
     assert "Handle" in str(attribute(span, "code.callback"))
     assert telemetry.counted("zuvloop.slow_callbacks") >= 1
@@ -210,6 +213,63 @@ async def test_gauges_sample_on_a_native_timer(monkeypatch: pytest.MonkeyPatch) 
     before = len(snapshots)
     await asyncio.sleep(0.05)
     assert len(snapshots) == before
+
+
+async def test_monitoring_arms_when_a_provider_appears_mid_run(
+    telemetry: Telemetry, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Providers configured from inside the loop - logfire.configure() in
+    main() - must still arm slow-callback monitoring."""
+    installed = False
+    monkeypatch.setattr("zuvloop._base.instrumentation_provider_installed", lambda: installed)
+
+    def main() -> None:
+        loop = zuvloop.new_event_loop()
+        loop.metrics_interval = 0.02
+        loop.slow_callback_duration = 0.01
+
+        def blocks_before_provider() -> None:
+            time.sleep(0.02)
+
+        def blocks_after_provider() -> None:
+            time.sleep(0.02)
+
+        async def scenario() -> None:
+            nonlocal installed
+            loop.call_soon(blocks_before_provider)
+            await asyncio.sleep(0.01)
+            installed = True
+            # More than metrics_interval, so the sampler has re-checked.
+            await asyncio.sleep(0.06)
+            loop.call_soon(blocks_after_provider)
+            await asyncio.sleep(0.05)
+
+        try:
+            loop.run_until_complete(scenario())
+        finally:
+            loop.close()
+
+    await asyncio.to_thread(main)
+    callbacks = [str(attribute(span, "code.callback")) for span in telemetry.spans("zuvloop.slow_callback")]
+    assert not any("blocks_before_provider" in callback for callback in callbacks)
+    assert any("blocks_after_provider" in callback for callback in callbacks)
+
+
+async def test_gauges_stay_unpublished_without_a_meter_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    snapshots: list[dict[str, int]] = []
+    monkeypatch.setattr("zuvloop._base.publish_metrics", snapshots.append)
+    monkeypatch.setattr("zuvloop._base.metrics_provider_installed", lambda: False)
+
+    def main() -> None:
+        loop = zuvloop.new_event_loop()
+        loop.metrics_interval = 0.02
+        try:
+            loop.run_until_complete(asyncio.sleep(0.07))
+        finally:
+            loop.close()
+
+    await asyncio.to_thread(main)
+    assert snapshots == []
 
 
 async def test_gauges_reach_the_exporter(telemetry: Telemetry) -> None:

--- a/tests/test_instrumentation.py
+++ b/tests/test_instrumentation.py
@@ -255,6 +255,46 @@ async def test_monitoring_arms_when_a_provider_appears_mid_run(
     assert any("blocks_after_provider" in callback for callback in callbacks)
 
 
+async def test_provider_checks_stop_once_a_provider_is_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The armed flags are latches: after a provider says yes, later sampler
+    ticks publish without asking again."""
+    snapshots: list[dict[str, int]] = []
+    checks = 0
+    installed = False
+
+    def probe() -> bool:
+        nonlocal checks
+        checks += 1
+        return installed
+
+    monkeypatch.setattr("zuvloop._base.publish_metrics", snapshots.append)
+    monkeypatch.setattr("zuvloop._base.metrics_provider_installed", probe)
+
+    def main() -> None:
+        loop = zuvloop.new_event_loop()
+        loop.metrics_interval = 0.02
+
+        async def scenario() -> None:
+            nonlocal installed
+            await asyncio.sleep(0.05)
+            assert not snapshots
+            installed = True
+            await asyncio.sleep(0.05)
+            assert snapshots
+            checks_when_armed = checks
+            published = len(snapshots)
+            await asyncio.sleep(0.05)
+            assert len(snapshots) > published
+            assert checks == checks_when_armed
+
+        try:
+            loop.run_until_complete(scenario())
+        finally:
+            loop.close()
+
+    await asyncio.to_thread(main)
+
+
 async def test_gauges_stay_unpublished_without_a_meter_provider(monkeypatch: pytest.MonkeyPatch) -> None:
     snapshots: list[dict[str, int]] = []
     monkeypatch.setattr("zuvloop._base.publish_metrics", snapshots.append)

--- a/zuvloop/_base.py
+++ b/zuvloop/_base.py
@@ -36,8 +36,10 @@ class LoopBase(_zuvloop.Loop, asyncio.AbstractEventLoop):  # type: ignore[misc]
     orchestration that runs once per loop or once per connection.
     """
 
-    # How often the loop gauges are sampled while a real OpenTelemetry meter
-    # provider is installed. Assign before running the loop to change it.
+    # How often the native sampler fires while the loop runs. It publishes the
+    # loop gauges when a meter provider is installed, and it is also how quickly
+    # a provider configured after the loop started is noticed. Assign before
+    # running the loop to change it.
     metrics_interval: float = 10.0
 
     def __init__(self) -> None:
@@ -52,6 +54,7 @@ class LoopBase(_zuvloop.Loop, asyncio.AbstractEventLoop):  # type: ignore[misc]
         self._sock_watchers: dict[tuple[int, bool], object] = {}
         self._wakeup_fd_attached = False
         self._instrumentation = Instrumentation()
+        self._monitoring_armed = False
         self._setup_self_pipe()
 
     def __del__(self, _warn: Callable[..., object] = warnings.warn) -> None:
@@ -100,11 +103,13 @@ class LoopBase(_zuvloop.Loop, asyncio.AbstractEventLoop):  # type: ignore[misc]
         self._attach_wakeup_fd()
         _events._set_running_loop(self)
         sys.set_asyncgen_hooks(firstiter=self._asyncgen_firstiter, finalizer=self._asyncgen_finalizer)
-        # Gauges cost nothing to skip and something to sample, so the sampler
-        # runs exactly when there is somewhere for the numbers to go.
-        if metrics_provider_installed():
-            self._start_metrics(self.metrics_interval, publish_metrics)
-        self._set_slow_callback_monitoring(instrumentation_provider_installed())
+        # Providers are commonly installed from inside the loop - logfire's
+        # configure() in main(), for instance - so the decision cannot be
+        # latched here. The sampler doubles as the re-check: each interval it
+        # arms slow-callback timing if a provider has appeared since.
+        self._monitoring_armed = instrumentation_provider_installed()
+        self._set_slow_callback_monitoring(self._monitoring_armed)
+        self._start_metrics(self.metrics_interval, self._on_sample)
         try:
             self._run()
         finally:
@@ -252,6 +257,13 @@ class LoopBase(_zuvloop.Loop, asyncio.AbstractEventLoop):  # type: ignore[misc]
 
     def _on_slow_callback(self, handle: object, duration: float) -> None:
         self._instrumentation.report_slow_callback(handle, duration)
+
+    def _on_sample(self, snapshot: dict[str, int]) -> None:
+        if not self._monitoring_armed and instrumentation_provider_installed():
+            self._monitoring_armed = True
+            self._set_slow_callback_monitoring(True)
+        if metrics_provider_installed():
+            publish_metrics(snapshot)
 
     # -- internals ---------------------------------------------------------
 

--- a/zuvloop/_base.py
+++ b/zuvloop/_base.py
@@ -55,6 +55,7 @@ class LoopBase(_zuvloop.Loop, asyncio.AbstractEventLoop):  # type: ignore[misc]
         self._wakeup_fd_attached = False
         self._instrumentation = Instrumentation()
         self._monitoring_armed = False
+        self._metrics_armed = False
         self._setup_self_pipe()
 
     def __del__(self, _warn: Callable[..., object] = warnings.warn) -> None:
@@ -104,10 +105,13 @@ class LoopBase(_zuvloop.Loop, asyncio.AbstractEventLoop):  # type: ignore[misc]
         _events._set_running_loop(self)
         sys.set_asyncgen_hooks(firstiter=self._asyncgen_firstiter, finalizer=self._asyncgen_finalizer)
         # Providers are commonly installed from inside the loop - logfire's
-        # configure() in main(), for instance - so the decision cannot be
-        # latched here. The sampler doubles as the re-check: each interval it
-        # arms slow-callback timing if a provider has appeared since.
+        # configure() in main(), for instance - so the decision cannot be made
+        # only here. The sampler doubles as the re-check: each interval it arms
+        # whatever a newly appeared provider serves. Installation is one-way in
+        # OpenTelemetry, so each armed flag is a latch and the provider lookup
+        # stops once it has said yes.
         self._monitoring_armed = instrumentation_provider_installed()
+        self._metrics_armed = metrics_provider_installed()
         self._set_slow_callback_monitoring(self._monitoring_armed)
         self._start_metrics(self.metrics_interval, self._on_sample)
         try:
@@ -262,7 +266,9 @@ class LoopBase(_zuvloop.Loop, asyncio.AbstractEventLoop):  # type: ignore[misc]
         if not self._monitoring_armed and instrumentation_provider_installed():
             self._monitoring_armed = True
             self._set_slow_callback_monitoring(True)
-        if metrics_provider_installed():
+        if not self._metrics_armed:
+            self._metrics_armed = metrics_provider_installed()
+        if self._metrics_armed:
             publish_metrics(snapshot)
 
     # -- internals ---------------------------------------------------------

--- a/zuvloop/_base.py
+++ b/zuvloop/_base.py
@@ -104,12 +104,6 @@ class LoopBase(_zuvloop.Loop, asyncio.AbstractEventLoop):  # type: ignore[misc]
         self._attach_wakeup_fd()
         _events._set_running_loop(self)
         sys.set_asyncgen_hooks(firstiter=self._asyncgen_firstiter, finalizer=self._asyncgen_finalizer)
-        # Providers are commonly installed from inside the loop - logfire's
-        # configure() in main(), for instance - so the decision cannot be made
-        # only here. The sampler doubles as the re-check: each interval it arms
-        # whatever a newly appeared provider serves. Installation is one-way in
-        # OpenTelemetry, so each armed flag is a latch and the provider lookup
-        # stops once it has said yes.
         self._monitoring_armed = instrumentation_provider_installed()
         self._metrics_armed = metrics_provider_installed()
         self._set_slow_callback_monitoring(self._monitoring_armed)

--- a/zuvloop/_instrumentation.py
+++ b/zuvloop/_instrumentation.py
@@ -64,10 +64,6 @@ class Instrumentation:
                     "code.callback": repr(handle),
                     "duration": duration,
                     "asyncio.call_graph": capture_call_graph(handle),
-                    # A slow callback is a warning, which span status cannot
-                    # say - OpenTelemetry has only OK, ERROR and UNSET. The
-                    # status stays unset; this is Logfire's severity scale,
-                    # and backends that do not know it ignore the attribute.
                     "logfire.level_num": 13,
                 }
             ),

--- a/zuvloop/_instrumentation.py
+++ b/zuvloop/_instrumentation.py
@@ -64,10 +64,14 @@ class Instrumentation:
                     "code.callback": repr(handle),
                     "duration": duration,
                     "asyncio.call_graph": capture_call_graph(handle),
+                    # A slow callback is a warning, which span status cannot
+                    # say - OpenTelemetry has only OK, ERROR and UNSET. The
+                    # status stays unset; this is Logfire's severity scale,
+                    # and backends that do not know it ignore the attribute.
+                    "logfire.level_num": 13,
                 }
             ),
         )
-        span.set_status(Status(StatusCode.ERROR, "callback exceeded slow_callback_duration"))
         span.end(end_time=ended)
 
     def report_exception(self, context: dict[str, Any]) -> None:


### PR DESCRIPTION
Slow-callback monitoring and the loop gauges were armed once, at `run_forever()` entry, based on `instrumentation_provider_installed()`. An application that configures OpenTelemetry from inside the loop - `logfire.configure()` in `main()` is the common shape - silently lost both for the life of the process. Spans emitted through the API's lazy proxies (`zuvloop.unhandled_exception`) still arrived, which made the gap look like an absence of slow callbacks rather than a disabled feature.

## What changed

- **The decision is no longer latched.** The native sampler - already on an unreferenced `uv_timer_t`, so it never enters the callback queue or keeps the loop alive - now always runs. Each tick re-checks the providers: slow-callback timing arms and the gauges start publishing within one `metrics_interval` (10s by default) of a provider appearing. The check could not simply be dropped: it gates two `uv_hrtime` reads around *every* callback, on a path that runs millions of callbacks per second, so uninstrumented programs keep the native fast path until a provider exists.
- **The gauges had the identical latch** (`metrics_provider_installed()` at entry) and are fixed the same way: sampled always, published when a meter provider exists, dropped otherwise.
- **Slow-callback spans are warnings now, not errors.** OpenTelemetry span status has no warning level, so the `ERROR` status is dropped (status stays unset) and the severity travels as a `logfire.level_num: 13` attribute - Logfire renders it as a warning, backends that do not know the attribute ignore it. `zuvloop.unhandled_exception` keeps its `ERROR` status.

## Testing

- New regression tests: a provider appearing mid-run arms monitoring (callbacks blocking before it stay unreported, callbacks after it are reported), and gauges stay unpublished without a meter provider.
- Full suite 372 passed, 100% branch coverage, strict mypy and ruff clean; the timing-sensitive test is stable across repeated runs.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects OpenTelemetry providers configured after the loop starts, arming slow-callback monitoring and publishing gauges within one `metrics_interval`. The sampler runs continuously but drops gauge snapshots until a meter provider exists; per-callback timing stays off until then.

- **Bug Fixes**
  - Re-checks providers every `metrics_interval` until one appears (e.g., `logfire.configure()` in `main()`); after that, monitoring and gauges latch and later ticks publish without re-checking.
  - Gauges are sampled continuously and published only when a meter provider exists; snapshots are dropped otherwise.
  - Keeps the fast path for uninstrumented apps by gating per-callback timing until a provider is present.
  - Marks slow callbacks as warnings: span status stays unset and severity is carried via `logfire.level_num: 13`; docs updated to reflect mid-run detection and publishing behavior.

<sup>Written for commit 253c5e2cfc88a4446e9633059f87f4ab2eeadc99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/54?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that OpenTelemetry providers can be configured before or after loop startup.
  * Documented periodic provider detection and gauge sampling behavior.

* **Bug Fixes**
  * Slow-callback monitoring now activates when a provider is added during execution.
  * Prevented metric publication when no meter provider is available.
  * Slow callbacks are reported as warnings with the appropriate severity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->