### PR TITLE
Pin hatch-vcs in release builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # invokes the native compiler, so a future version resolved from a lower bound
 # could execute unreviewed code into the wheels the publish job trusts. The
 # compiler is pinned for the same reason. Bump both deliberately.
-requires = ["hatchling", "hatch-vcs", "hatch-ziglang==0.2.1", "ziglang==0.16.0"]
+requires = ["hatchling", "hatch-vcs==0.5.0", "hatch-ziglang==0.2.1", "ziglang==0.16.0"]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
Pin the version provider that executes inside isolated release builds. This gives hatch-vcs the same supply-chain treatment as the native build hook and compiler beside it.

Finding: https://chatgpt.com/codex/cloud/security/findings/35d4de0e625c81918bfd01538f90404a

No runtime tests needed; this only constrains build-system dependency resolution.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `hatch-vcs` to `0.5.0` in isolated release builds to harden the supply chain and ensure reproducible wheels. Aligns with existing pins for `hatch-ziglang` and `ziglang`; build-time only, no runtime changes.

<sup>Written for commit aa425c98838a3ab58b3c2a6eee5359a1f7793cca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/55?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

