### PR TITLE
Publish only version tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish
 on:
   push:
     branches: ["main"]
-    tags: ["*"]
+    tags: ["v*"]
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
Restore the release namespace gate from the replaced workflow. Only v* tags now enter the build-and-publish workflow, so arbitrary repository tags cannot reach PyPI trusted publishing.

Finding: https://chatgpt.com/codex/cloud/security/findings/e738b4da26108191804d62da7fcda294

No runtime tests needed; this changes only the workflow trigger.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the Publish workflow only for version tags (`v*`). This restores the release namespace gate and prevents arbitrary tags from triggering PyPI trusted publishing.

<sup>Written for commit 9ff2de6059b4f90dd06d8aa99c9407d7048db85a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/57?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

