### PR TITLE
Keep OIDC out of pull request benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,9 @@ jobs:
 
 
   benchmarks:
+    # Pull-request code must never execute in a job that can mint an OIDC token.
+    # Pushes record the trusted benchmark after a change lands.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:


### PR DESCRIPTION
Do not start the CodSpeed benchmark job for pull_request events. That job installs and executes the submitted checkout while carrying id-token: write; restricting it to push/workflow_dispatch keeps untrusted PR code outside the OIDC boundary.

Finding: https://chatgpt.com/codex/cloud/security/findings/22d9c87f08f08191a625e7590913f3e3

No runtime tests needed; this changes only job event selection.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable the CodSpeed benchmarks job for pull_request events to keep untrusted PR code from running with OIDC (`id-token: write`) permissions. Benchmarks now run only on push and `workflow_dispatch`, enforced via `if: github.event_name != 'pull_request'`.

<sup>Written for commit 19c878eaabfa187f4619a036f02d72c44d02338f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/58?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

