### PR TITLE
Reject NULs in subprocess strings

### DIFF
--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -34,6 +34,19 @@ async def test_a_shell_command_reports_its_exit_status() -> None:
     assert process.returncode == 3
 
 
+async def test_subprocess_strings_reject_embedded_nuls() -> None:
+    calls = (
+        asyncio.create_subprocess_exec("/bin/echo", "before\0after"),
+        asyncio.create_subprocess_exec("/bin/echo", executable="/bin/echo\0other"),
+        asyncio.create_subprocess_exec("/bin/echo", cwd="/tmp\0other"),
+        asyncio.create_subprocess_exec("/bin/echo", env={"VALUE": "before\0after"}),
+        asyncio.create_subprocess_exec("/bin/echo", env={"BEFORE\0AFTER": "value"}),
+    )
+    for call in calls:
+        with pytest.raises(ValueError, match="embedded null byte"):
+            await call
+
+
 async def test_stdin_reaches_the_child() -> None:
     process = await asyncio.create_subprocess_exec("/bin/cat", stdin=PIPE, stdout=PIPE)
     stdout, _stderr = await process.communicate(b"round trip")

--- a/zuvloop/_process.py
+++ b/zuvloop/_process.py
@@ -50,6 +50,14 @@ class Popen:
         if unsupported:
             name = next(iter(unsupported))
             raise ValueError(f"{name} is not supported by zuvloop's subprocess transport")
+
+        file = executable or args[0]
+        cwd_text = None if cwd is None else os.fsdecode(cwd)
+        env_items = None if env is None else [f"{key}={value}" for key, value in env.items()]
+        for value in (file, *args, cwd_text, *(env_items or ())):
+            if value is not None and "\0" in value:
+                raise ValueError("embedded null byte")
+
         # Before any pipe of ours can reuse a freshly closed number, and in the
         # parent, where the error beats the child's bare exit code 127.
         pass_fds = tuple(pass_fds)
@@ -79,10 +87,10 @@ class Popen:
 
             flags = _zuvloop.PROCESS_DETACHED if start_new_session else 0
             self._handle = loop._spawn_process(
-                executable or args[0],
+                file,
                 args,
-                None if env is None else [f"{k}={v}" for k, v in env.items()],
-                None if cwd is None else os.fspath(cwd),
+                env_items,
+                cwd_text,
                 _stdio(child_fds, pass_fds),
                 flags,
                 0,


### PR DESCRIPTION
Reject embedded NULs before subprocess strings cross into libuv C-string APIs. The check covers the executable, argv, cwd, and rendered environment entries, preserving subprocess.Popen semantics instead of silently truncating inputs.

The separate STDERR=STDOUT observation in the finding is already fixed on main and covered by test_stderr_can_be_merged_into_stdout.

Finding: https://chatgpt.com/codex/cloud/security/findings/990d36c5c3408191a89c82cf8fe761b8

Tests: uv run pytest tests/test_subprocess.py::test_subprocess_strings_reject_embedded_nuls; uv run mypy zuvloop/_process.py tests/test_subprocess.py; uv run ruff check zuvloop/_process.py tests/test_subprocess.py

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject embedded NUL bytes in subprocess inputs before calling libuv to prevent silent C-string truncation. Raises ValueError("embedded null byte") for executable, args, cwd, and env to match CPython subprocess semantics.

- **Bug Fixes**
  - Validate `file` (`executable` or first arg), each `arg`, decoded `cwd`, and rendered `env` entries; reject if any contain "\0".
  - Precompute and pass `file`, `env_items`, and `cwd_text` to `_spawn_process`; add `test_subprocess_strings_reject_embedded_nuls` to cover all cases.

<sup>Written for commit f36e4b9cd815e9543fd19d864bdde52831e13bde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/59?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

