### PR TITLE
Skip DNS GC traversal while the reaper owns requests

### DIFF
--- a/zig/loop.zig
+++ b/zig/loop.zig
@@ -904,7 +904,7 @@ fn dealloc(obj: ?*py.Object) callconv(.c) void {
         if (needs_close) {
             st.ready.deinit();
             st.timers.deinit();
-            }
+        }
         // The flush list owns one Python reference per transport regardless of
         // how the loop reached deallocation, including partially completed
         // explicit close paths.
@@ -951,8 +951,12 @@ fn traverse(obj: ?*py.Object, visitproc: c.visitproc, arg: ?*anyopaque) callconv
             if (r != 0) return r;
             transport = owned.owner_next;
         }
-        r = dns.traverse(st, visitproc, arg);
-        if (r != 0) return r;
+        // Once close hands resolver requests to the native reaper, their
+        // futures are gone and the request list mutates without the GIL.
+        if (!isReaping(st)) {
+            r = dns.traverse(st, visitproc, arg);
+            if (r != 0) return r;
+        }
         r = pollermod.traverse(st, visitproc, arg);
         if (r != 0) return r;
     }


### PR DESCRIPTION
Once loop shutdown transfers uncancellable DNS requests to the detached native reaper, their Python futures have already been cleared and their linked list is no longer GIL-owned. Skip that unnecessary GC traversal while reap_state is active so tp_traverse cannot race nodes being unlinked and freed.

Finding: https://chatgpt.com/codex/cloud/security/findings/dcf0978b448c81919264e93efe3ad16e

Tests: zig fmt --check zig/loop.zig; uv run pytest tests/test_lifecycle.py::test_loop_close_releases_pending_dns_requests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip DNS GC traversal once the native reaper owns resolver requests after loop close. This prevents tp_traverse from racing with reaper-side unlink/free and avoids potential crashes.

- **Bug Fixes**
  - Call `dns.traverse` only when `!isReaping(st)` in `zig/loop.zig::traverse`.
  - Small formatting fix in `dealloc`.

<sup>Written for commit ceb16f45a6328108c541e83ea3960ed82a51387a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/60?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

