### PR TITLE
Snapshot mutable buffers accepted for writing

### DIFF
--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -151,6 +151,30 @@ async def test_queued_write_snapshots_a_mutable_buffer() -> None:
         await writer.wait_closed()
 
 
+async def test_queued_write_snapshots_a_bytes_subclass_buffer() -> None:
+    class MutableBytes(bytes):
+        payload: bytearray
+
+        def __new__(cls, payload: bytearray) -> MutableBytes:
+            instance = super().__new__(cls, b"immutable shell")
+            instance.payload = payload
+            return instance
+
+        def __buffer__(self, flags: int) -> memoryview:
+            return memoryview(self.payload)
+
+    server, port, _ = await start_echo()
+    payload = bytearray(b"custom buffer")
+    exporter = MutableBytes(payload)
+    async with server:
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        writer.write(exporter)
+        payload[:] = b"mutated later"
+        assert await reader.readexactly(13) == b"custom buffer"
+        writer.close()
+        await writer.wait_closed()
+
+
 async def test_queued_writelines_snapshot_mutable_buffers() -> None:
     server, port, _ = await start_echo()
     chunks = [bytearray(b"original "), bytearray(b"lines")]

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -139,6 +139,31 @@ async def test_large_payload_survives_partial_writes() -> None:
         await writer.wait_closed()
 
 
+async def test_queued_write_snapshots_a_mutable_buffer() -> None:
+    server, port, _ = await start_echo()
+    payload = bytearray(b"original write")
+    async with server:
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        writer.write(payload)
+        payload[:] = b"mutated later!"
+        assert await reader.readexactly(14) == b"original write"
+        writer.close()
+        await writer.wait_closed()
+
+
+async def test_queued_writelines_snapshot_mutable_buffers() -> None:
+    server, port, _ = await start_echo()
+    chunks = [bytearray(b"original "), bytearray(b"lines")]
+    async with server:
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        writer.writelines(chunks)
+        chunks[0][:] = b"mutated! "
+        chunks[1][:] = b"later"
+        assert await reader.readexactly(14) == b"original lines"
+        writer.close()
+        await writer.wait_closed()
+
+
 async def test_writelines_uses_scatter_gather() -> None:
     server, port, _ = await start_echo()
     chunks = [b"a" * 10, b"b" * 10, b"c" * 10]

--- a/zig/transport.zig
+++ b/zig/transport.zig
@@ -136,12 +136,12 @@ pub const Transport = extern struct {
 
 var handle_offset: usize = 0;
 
-/// A queued write: the libuv request, the buffer views keeping the caller's
-/// memory alive, and the vector libuv reads from - all in one allocation.
+/// A queued write: the libuv request, immutable buffer views, and the vector
+/// libuv reads from - all in one allocation.
 ///
-/// Retaining views rather than copying is what makes a large `write()` free:
-/// the exporter stays alive (and, for a bytearray, locked against resizing)
-/// until libuv reports the write complete.
+/// An exact `bytes` object is retained without copying. Every other exporter is
+/// snapshotted first, so its view owns immutable bytes rather than caller memory;
+/// either way the backing object stays alive until libuv reports completion.
 ///
 /// The request does not take another Python reference to `transport`. The
 /// loop-owned handle reference remains alive until `onClosed`, and libuv runs
@@ -181,7 +181,7 @@ fn releaseViews(views: []c.Py_buffer) void {
 /// Hold immutable bytes directly; snapshot every other exporter before write()
 /// returns so queued I/O cannot observe later mutations by the caller.
 fn acquireWriteView(data: *py.Object, view: *c.Py_buffer) py.Error!void {
-    if (c.PyBytes_Check(data) != 0) {
+    if (c.PyBytes_CheckExact(data) != 0) {
         if (c.PyObject_GetBuffer(data, view, c.PyBUF_SIMPLE) < 0) return py.Error.Python;
         return;
     }

--- a/zig/transport.zig
+++ b/zig/transport.zig
@@ -178,6 +178,22 @@ fn releaseViews(views: []c.Py_buffer) void {
     for (views) |*view| c.PyBuffer_Release(view);
 }
 
+/// Hold immutable bytes directly; snapshot every other exporter before write()
+/// returns so queued I/O cannot observe later mutations by the caller.
+fn acquireWriteView(data: *py.Object, view: *c.Py_buffer) py.Error!void {
+    if (c.PyBytes_Check(data) != 0) {
+        if (c.PyObject_GetBuffer(data, view, c.PyBUF_SIMPLE) < 0) return py.Error.Python;
+        return;
+    }
+
+    var source: c.Py_buffer = undefined;
+    if (c.PyObject_GetBuffer(data, &source, c.PyBUF_SIMPLE) < 0) return py.Error.Python;
+    defer c.PyBuffer_Release(&source);
+    const snapshot = c.PyBytes_FromStringAndSize(@ptrCast(source.buf), source.len) orelse return py.Error.Python;
+    defer py.decref(snapshot);
+    if (c.PyObject_GetBuffer(snapshot, view, c.PyBUF_SIMPLE) < 0) return py.Error.Python;
+}
+
 // ---------------------------------------------------------------------------
 // protocol dispatch
 
@@ -876,7 +892,7 @@ pub fn startReadingMethod(self_obj: *py.Object) py.Error!*py.Object {
 fn write(self_obj: *py.Object, data: *py.Object) py.Error!*py.Object {
     const self = asTransport(self_obj);
     var views = [_]c.Py_buffer{undefined};
-    if (c.PyObject_GetBuffer(data, &views[0], c.PyBUF_SIMPLE) < 0) return py.Error.Python;
+    try acquireWriteView(data, &views[0]);
     if (self.flags & EOF_WRITTEN != 0) {
         c.PyBuffer_Release(&views[0]);
         return py.errRuntime("Cannot call write() after write_eof()");
@@ -912,12 +928,12 @@ fn writelines(self_obj: *py.Object, data: *py.Object) py.Error!*py.Object {
             return py.Error.Python;
         };
         // The buffer view keeps the exporter alive, so the item reference can go.
-        const acquired = c.PyObject_GetBuffer(item, &views[filled], c.PyBUF_SIMPLE);
-        py.decref(item);
-        if (acquired < 0) {
+        acquireWriteView(item, &views[filled]) catch {
+            py.decref(item);
             releaseViews(views[0..filled]);
             return py.Error.Python;
-        }
+        };
+        py.decref(item);
         bufs[filled] = .{ .base = @ptrCast(views[filled].buf), .len = @intCast(views[filled].len) };
     }
     try submitWrite(self, bufs, views);


### PR DESCRIPTION
Preserve the zero-copy path for immutable bytes, but snapshot every other buffer exporter before write()/writelines() returns. Queued libuv writes therefore observe the bytes accepted by the transport rather than later mutations to bytearray, memoryview, mmap, or another exporter.

This leaves the common bytes benchmark path unchanged; the copy is limited to mutable-or-unknown exporters where asyncio snapshot semantics require it.

Finding: https://chatgpt.com/codex/cloud/security/findings/ee9c8560064881919e212a29a055555e

Tests: uv run python scripts/build.py; uv run pytest tests/test_network.py::test_queued_write_snapshots_a_mutable_buffer tests/test_network.py::test_queued_writelines_snapshot_mutable_buffers; uv run ruff check tests/test_network.py; uv run mypy tests/test_network.py

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Snapshot mutable buffers passed to transport writes so queued I/O sends the original bytes; zero-copy remains for immutable `bytes`. This prevents post-call mutations from changing data on the wire and matches `asyncio` snapshot semantics, including `bytes` subclasses that export custom buffers.

- **Bug Fixes**
  - Implemented `acquireWriteView()` to snapshot all non-exact `bytes` exporters before `write()`/`writelines()` return; `bytes` still use direct views.
  - Added tests for queued `write()`/`writelines()` verifying mutations to `bytearray` and `bytes` subclasses do not affect sent data.

<sup>Written for commit 20ef0ca18b7bda8a6a7d4f322287cc10c0e260ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/61?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

