### PR TITLE
Guard process signal state by loop ownership

### DIFF
--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -13,7 +13,7 @@ import pytest
 
 import zuvloop
 from conftest import running_loop
-from zuvloop._base import _finish_deferred_signal_cleanup, _signal_owners
+from zuvloop._base import SignalOwner, _finish_deferred_signal_cleanup, _signal_owners
 from zuvloop._loop import _noop_signal_handler
 
 pytestmark = pytest.mark.anyio
@@ -90,7 +90,7 @@ def test_failed_wakeup_attach_rolls_back_signal_ownership(monkeypatch: pytest.Mo
         with pytest.raises(RuntimeError, match="cannot be caught"):
             loop.add_signal_handler(signal.SIGUSR1, print)
         assert signal.SIGUSR1 not in loop._signal_handlers
-        assert _signal_owners.get(signal.SIGUSR1) is not loop._signal_owner
+        assert signal.SIGUSR1 not in _signal_owners
         assert signal.getsignal(signal.SIGUSR1) is original
         assert siginterrupt_calls == []
     finally:
@@ -258,7 +258,7 @@ def test_rollback_revalidates_an_owner_finalized_at_commit(monkeypatch: pytest.M
     real_signal = signal.signal
     first_signal_call = True
     finalized_checks = 0
-    real_is_finalized = old._signal_owner.is_finalized
+    real_is_finalized = SignalOwner.is_finalized
 
     def fail_registration_once(
         sig: int, handler: int | Callable[[int, FrameType | None], object]
@@ -269,15 +269,16 @@ def test_rollback_revalidates_an_owner_finalized_at_commit(monkeypatch: pytest.M
             raise OSError("cannot install")
         return real_signal(sig, handler)
 
-    def finalize_on_commit_check() -> bool:
+    def finalize_on_commit_check(token: SignalOwner) -> bool:
         nonlocal finalized_checks
-        finalized_checks += 1
-        if finalized_checks == 2:
-            _finish_deferred_signal_cleanup((signal.SIGUSR1,), cleanup_fd, old._signal_owner)
-        return real_is_finalized()
+        if token is old._signal_owner:  # pragma: no branch - this scenario queries only the old token
+            finalized_checks += 1
+            if finalized_checks == 2:
+                _finish_deferred_signal_cleanup((signal.SIGUSR1,), cleanup_fd, token)
+        return real_is_finalized(token)
 
     monkeypatch.setattr(signal, "signal", fail_registration_once)
-    monkeypatch.setattr(old._signal_owner, "is_finalized", finalize_on_commit_check)
+    monkeypatch.setattr(SignalOwner, "is_finalized", finalize_on_commit_check)
     try:
         with pytest.raises(RuntimeError, match="cannot be caught"):
             owner.add_signal_handler(signal.SIGUSR1, print)

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -81,10 +81,10 @@ def test_failed_wakeup_attach_rolls_back_signal_ownership(monkeypatch: pytest.Mo
     loop = zuvloop.new_event_loop()
     siginterrupt_calls: list[tuple[int, bool]] = []
 
-    def fail_to_attach() -> None:
+    def fail_to_attach(_fd: int) -> int:
         raise OSError("cannot attach")
 
-    monkeypatch.setattr(loop, "_attach_wakeup_fd", fail_to_attach)
+    monkeypatch.setattr(signal, "set_wakeup_fd", fail_to_attach)
     monkeypatch.setattr(signal, "siginterrupt", lambda sig, flag: siginterrupt_calls.append((sig, flag)))
     try:
         with pytest.raises(RuntimeError, match="cannot be caught"):
@@ -96,6 +96,36 @@ def test_failed_wakeup_attach_rolls_back_signal_ownership(monkeypatch: pytest.Mo
     finally:
         loop.close()
         signal.signal(signal.SIGUSR1, original)
+
+
+def test_failed_wakeup_attach_does_not_restore_another_loops_owner(monkeypatch: pytest.MonkeyPatch) -> None:
+    originals = {sig: signal.getsignal(sig) for sig in (signal.SIGUSR1, signal.SIGUSR2)}
+    old = zuvloop.new_event_loop()
+    owner = zuvloop.new_event_loop()
+    old.add_signal_handler(signal.SIGUSR1, print)
+    real_set_wakeup_fd = signal.set_wakeup_fd
+    first_call = True
+
+    def fail_once(fd: int) -> int:
+        nonlocal first_call
+        if first_call:
+            first_call = False
+            raise OSError("cannot attach")
+        return real_set_wakeup_fd(fd)
+
+    monkeypatch.setattr(signal, "set_wakeup_fd", fail_once)
+    try:
+        with pytest.raises(RuntimeError, match="cannot be caught"):
+            owner.add_signal_handler(signal.SIGUSR2, print)
+        assert signal.SIGUSR2 not in _signal_owners
+        assert real_set_wakeup_fd(-1) == -1
+    finally:
+        old.remove_signal_handler(signal.SIGUSR1)
+        old.close()
+        owner.close()
+        real_set_wakeup_fd(-1)
+        for sig, handler in originals.items():
+            signal.signal(sig, handler)
 
 
 def test_failed_signal_reregistration_restores_the_existing_entry(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -119,23 +149,31 @@ def test_failed_signal_reregistration_restores_the_existing_entry(monkeypatch: p
         signal.signal(signal.SIGUSR1, original)
 
 
-def test_stale_pending_cleanup_cannot_reset_a_registration_in_progress(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_stale_cleanup_cannot_disable_a_wakeup_fd_during_attachment(monkeypatch: pytest.MonkeyPatch) -> None:
     original = signal.getsignal(signal.SIGUSR1)
     old = zuvloop.new_event_loop()
     owner = zuvloop.new_event_loop()
     cleanup_fd = os.dup(old._csock.fileno())
     old.add_signal_handler(signal.SIGUSR1, print)
-    real_siginterrupt = signal.siginterrupt
+    real_set_wakeup_fd = signal.set_wakeup_fd
+    cleanup_ran = False
 
-    def run_pending_cleanup(sig: int, flag: bool) -> None:
-        _finish_deferred_signal_cleanup((signal.SIGUSR1,), cleanup_fd, old._signal_owner)
-        real_siginterrupt(sig, flag)
+    def run_cleanup_after_install(fd: int) -> int:
+        nonlocal cleanup_ran
+        previous = real_set_wakeup_fd(fd)
+        if not cleanup_ran:
+            cleanup_ran = True
+            _finish_deferred_signal_cleanup((signal.SIGUSR1,), cleanup_fd, old._signal_owner)
+        return previous
 
-    monkeypatch.setattr(signal, "siginterrupt", run_pending_cleanup)
+    monkeypatch.setattr(signal, "set_wakeup_fd", run_cleanup_after_install)
     try:
         owner.add_signal_handler(signal.SIGUSR1, print)
         assert _signal_owners[signal.SIGUSR1] is owner._signal_owner
         assert signal.getsignal(signal.SIGUSR1) is _noop_signal_handler
+        installed = real_set_wakeup_fd(-1)
+        assert installed == owner._csock.fileno()
+        real_set_wakeup_fd(installed)
     finally:
         owner.remove_signal_handler(signal.SIGUSR1)
         old.close()
@@ -172,6 +210,42 @@ def test_failed_registration_does_not_resurrect_a_finalized_owner(monkeypatch: p
         old.close()
         owner.close()
         real_signal(signal.SIGUSR1, original)
+
+
+def test_failed_registration_abandons_a_finalized_wakeup_owner_for_another_signal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    originals = {sig: signal.getsignal(sig) for sig in (signal.SIGUSR1, signal.SIGUSR2)}
+    old = zuvloop.new_event_loop()
+    owner = zuvloop.new_event_loop()
+    cleanup_fd = os.dup(old._csock.fileno())
+    old.add_signal_handler(signal.SIGUSR1, print)
+    real_signal = signal.signal
+    first_call = True
+
+    def fail_after_other_signal_cleanup(
+        sig: int, handler: int | Callable[[int, FrameType | None], object]
+    ) -> int | Callable[[int, FrameType | None], object] | None:
+        nonlocal first_call
+        if first_call:
+            first_call = False
+            _finish_deferred_signal_cleanup((signal.SIGUSR1,), cleanup_fd, old._signal_owner)
+            raise OSError("cannot install")
+        return real_signal(sig, handler)
+
+    monkeypatch.setattr(signal, "signal", fail_after_other_signal_cleanup)
+    try:
+        with pytest.raises(RuntimeError, match="cannot be caught"):
+            owner.add_signal_handler(signal.SIGUSR2, print)
+        assert signal.SIGUSR1 not in _signal_owners
+        assert signal.SIGUSR2 not in _signal_owners
+        assert signal.set_wakeup_fd(-1) == -1
+    finally:
+        old.close()
+        owner.close()
+        signal.set_wakeup_fd(-1)
+        for sig, handler in originals.items():
+            real_signal(sig, handler)
 
 
 def test_signal_handlers_require_the_main_thread() -> None:

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -11,6 +11,8 @@ import pytest
 
 import zuvloop
 from conftest import running_loop
+from zuvloop._base import _finish_deferred_signal_cleanup, _signal_owners
+from zuvloop._loop import _noop_signal_handler
 
 pytestmark = pytest.mark.anyio
 
@@ -70,6 +72,70 @@ async def test_uncatchable_signals_are_rejected() -> None:
     loop = running_loop()
     with pytest.raises(RuntimeError, match="cannot be caught"):
         loop.add_signal_handler(signal.SIGKILL, print)
+
+
+def test_failed_wakeup_attach_rolls_back_signal_ownership(monkeypatch: pytest.MonkeyPatch) -> None:
+    original = signal.getsignal(signal.SIGUSR1)
+    loop = zuvloop.new_event_loop()
+
+    def fail_to_attach() -> None:
+        raise OSError("cannot attach")
+
+    monkeypatch.setattr(loop, "_attach_wakeup_fd", fail_to_attach)
+    try:
+        with pytest.raises(RuntimeError, match="cannot be caught"):
+            loop.add_signal_handler(signal.SIGUSR1, print)
+        assert signal.SIGUSR1 not in loop._signal_handlers
+        assert _signal_owners.get(signal.SIGUSR1) is not loop._signal_owner
+        assert signal.getsignal(signal.SIGUSR1) is original
+    finally:
+        loop.close()
+        signal.signal(signal.SIGUSR1, original)
+
+
+def test_failed_signal_reregistration_restores_the_existing_entry(monkeypatch: pytest.MonkeyPatch) -> None:
+    original = signal.getsignal(signal.SIGUSR1)
+    loop = zuvloop.new_event_loop()
+    loop.add_signal_handler(signal.SIGUSR1, print, "original")
+    previous = loop._signal_handlers[signal.SIGUSR1]
+
+    def fail_to_attach() -> None:
+        raise OSError("cannot attach")
+
+    monkeypatch.setattr(loop, "_attach_wakeup_fd", fail_to_attach)
+    try:
+        with pytest.raises(RuntimeError, match="cannot be caught"):
+            loop.add_signal_handler(signal.SIGUSR1, print, "replacement")
+        assert loop._signal_handlers[signal.SIGUSR1] is previous
+        assert _signal_owners[signal.SIGUSR1] is loop._signal_owner
+    finally:
+        loop.remove_signal_handler(signal.SIGUSR1)
+        loop.close()
+        signal.signal(signal.SIGUSR1, original)
+
+
+def test_stale_pending_cleanup_cannot_reset_a_registration_in_progress(monkeypatch: pytest.MonkeyPatch) -> None:
+    original = signal.getsignal(signal.SIGUSR1)
+    old = zuvloop.new_event_loop()
+    owner = zuvloop.new_event_loop()
+    cleanup_fd = os.dup(old._csock.fileno())
+    old.add_signal_handler(signal.SIGUSR1, print)
+    real_siginterrupt = signal.siginterrupt
+
+    def run_pending_cleanup(sig: int, flag: bool) -> None:
+        _finish_deferred_signal_cleanup((signal.SIGUSR1,), cleanup_fd, old._signal_owner)
+        real_siginterrupt(sig, flag)
+
+    monkeypatch.setattr(signal, "siginterrupt", run_pending_cleanup)
+    try:
+        owner.add_signal_handler(signal.SIGUSR1, print)
+        assert _signal_owners[signal.SIGUSR1] is owner._signal_owner
+        assert signal.getsignal(signal.SIGUSR1) is _noop_signal_handler
+    finally:
+        owner.remove_signal_handler(signal.SIGUSR1)
+        old.close()
+        owner.close()
+        signal.signal(signal.SIGUSR1, original)
 
 
 def test_signal_handlers_require_the_main_thread() -> None:

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -206,6 +206,28 @@ def test_finalizing_a_running_loop_leaves_it_running() -> None:
         loop.close()
 
 
+def test_an_old_loop_finalizer_does_not_clobber_a_new_signal_owner() -> None:
+    original = signal.getsignal(signal.SIGUSR1)
+    old = zuvloop.new_event_loop()
+    owner = zuvloop.new_event_loop()
+    received: list[str] = []
+    try:
+        old.add_signal_handler(signal.SIGUSR1, print)
+        owner.add_signal_handler(signal.SIGUSR1, received.append, "delivered")
+
+        with pytest.warns(ResourceWarning, match="unclosed event loop"):
+            del old
+            gc.collect()
+
+        os.kill(os.getpid(), signal.SIGUSR1)
+        owner.run_until_complete(asyncio.sleep(0.01))
+        assert received == ["delivered"]
+    finally:
+        owner.remove_signal_handler(signal.SIGUSR1)
+        owner.close()
+        signal.signal(signal.SIGUSR1, original)
+
+
 def test_a_loop_without_handlers_does_not_disable_another_loops_signals() -> None:
     original = signal.getsignal(signal.SIGUSR1)
     owner = zuvloop.new_event_loop()

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -214,10 +214,21 @@ def test_an_old_loop_finalizer_does_not_clobber_a_new_signal_owner() -> None:
     try:
         old.add_signal_handler(signal.SIGUSR1, print)
         owner.add_signal_handler(signal.SIGUSR1, received.append, "delivered")
+        held = [old]
+        del old
+
+        def finalize_old_owner() -> None:
+            abandoned = held.pop()
+            del abandoned
+            gc.collect()
 
         with pytest.warns(ResourceWarning, match="unclosed event loop"):
-            del old
-            gc.collect()
+            thread = threading.Thread(target=finalize_old_owner)
+            thread.start()
+            thread.join()
+        # Run the pending main-thread cleanup after the replacement owns both
+        # global resources; neither one may be reset by the old token.
+        gc.collect()
 
         os.kill(os.getpid(), signal.SIGUSR1)
         owner.run_until_complete(asyncio.sleep(0.01))

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -257,7 +257,7 @@ def test_rollback_revalidates_an_owner_finalized_at_commit(monkeypatch: pytest.M
     old.add_signal_handler(signal.SIGUSR1, print)
     real_signal = signal.signal
     first_signal_call = True
-    finalized_checks = 0
+    cleanup_ran = False
     real_is_finalized = SignalOwner.is_finalized
 
     def fail_registration_once(
@@ -270,11 +270,10 @@ def test_rollback_revalidates_an_owner_finalized_at_commit(monkeypatch: pytest.M
         return real_signal(sig, handler)
 
     def finalize_on_commit_check(token: SignalOwner) -> bool:
-        nonlocal finalized_checks
-        if token is old._signal_owner:  # pragma: no branch - this scenario queries only the old token
-            finalized_checks += 1
-            if finalized_checks == 2:
-                _finish_deferred_signal_cleanup((signal.SIGUSR1,), cleanup_fd, token)
+        nonlocal cleanup_ran
+        if token is old._signal_owner and _signal_owners.get(signal.SIGUSR1) is token:
+            cleanup_ran = True
+            _finish_deferred_signal_cleanup((signal.SIGUSR1,), cleanup_fd, token)
         return real_is_finalized(token)
 
     monkeypatch.setattr(signal, "signal", fail_registration_once)
@@ -282,6 +281,7 @@ def test_rollback_revalidates_an_owner_finalized_at_commit(monkeypatch: pytest.M
     try:
         with pytest.raises(RuntimeError, match="cannot be caught"):
             owner.add_signal_handler(signal.SIGUSR1, print)
+        assert cleanup_ran
         assert signal.SIGUSR1 not in _signal_owners
         assert signal.getsignal(signal.SIGUSR1) is signal.SIG_DFL
         assert signal.set_wakeup_fd(-1) == -1

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -206,6 +206,26 @@ def test_finalizing_a_running_loop_leaves_it_running() -> None:
         loop.close()
 
 
+def test_closing_an_old_loop_does_not_clobber_a_new_signal_owner() -> None:
+    original = signal.getsignal(signal.SIGUSR1)
+    old = zuvloop.new_event_loop()
+    owner = zuvloop.new_event_loop()
+    received: list[str] = []
+    try:
+        old.add_signal_handler(signal.SIGUSR1, print)
+        owner.add_signal_handler(signal.SIGUSR1, received.append, "delivered")
+        old.close()
+
+        os.kill(os.getpid(), signal.SIGUSR1)
+        owner.run_until_complete(asyncio.sleep(0.01))
+        assert received == ["delivered"]
+    finally:
+        old.close()
+        owner.remove_signal_handler(signal.SIGUSR1)
+        owner.close()
+        signal.signal(signal.SIGUSR1, original)
+
+
 def test_an_old_loop_finalizer_does_not_clobber_a_new_signal_owner() -> None:
     original = signal.getsignal(signal.SIGUSR1)
     old = zuvloop.new_event_loop()

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -249,6 +249,48 @@ def test_failed_registration_does_not_resurrect_a_finalized_owner(monkeypatch: p
         real_signal(signal.SIGUSR1, original)
 
 
+def test_rollback_revalidates_an_owner_finalized_at_commit(monkeypatch: pytest.MonkeyPatch) -> None:
+    original = signal.getsignal(signal.SIGUSR1)
+    old = zuvloop.new_event_loop()
+    owner = zuvloop.new_event_loop()
+    cleanup_fd = os.dup(old._csock.fileno())
+    old.add_signal_handler(signal.SIGUSR1, print)
+    real_signal = signal.signal
+    first_signal_call = True
+    finalized_checks = 0
+    real_is_finalized = old._signal_owner.is_finalized
+
+    def fail_registration_once(
+        sig: int, handler: int | Callable[[int, FrameType | None], object]
+    ) -> int | Callable[[int, FrameType | None], object] | None:
+        nonlocal first_signal_call
+        if first_signal_call:
+            first_signal_call = False
+            raise OSError("cannot install")
+        return real_signal(sig, handler)
+
+    def finalize_on_commit_check() -> bool:
+        nonlocal finalized_checks
+        finalized_checks += 1
+        if finalized_checks == 2:
+            _finish_deferred_signal_cleanup((signal.SIGUSR1,), cleanup_fd, old._signal_owner)
+        return real_is_finalized()
+
+    monkeypatch.setattr(signal, "signal", fail_registration_once)
+    monkeypatch.setattr(old._signal_owner, "is_finalized", finalize_on_commit_check)
+    try:
+        with pytest.raises(RuntimeError, match="cannot be caught"):
+            owner.add_signal_handler(signal.SIGUSR1, print)
+        assert signal.SIGUSR1 not in _signal_owners
+        assert signal.getsignal(signal.SIGUSR1) is signal.SIG_DFL
+        assert signal.set_wakeup_fd(-1) == -1
+    finally:
+        old.close()
+        owner.close()
+        signal.set_wakeup_fd(-1)
+        real_signal(signal.SIGUSR1, original)
+
+
 def test_failed_registration_abandons_a_finalized_wakeup_owner_for_another_signal(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -98,7 +98,7 @@ def test_failed_wakeup_attach_rolls_back_signal_ownership(monkeypatch: pytest.Mo
         signal.signal(signal.SIGUSR1, original)
 
 
-def test_failed_wakeup_attach_does_not_restore_another_loops_owner(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_failed_wakeup_attach_restores_another_live_loops_owner(monkeypatch: pytest.MonkeyPatch) -> None:
     originals = {sig: signal.getsignal(sig) for sig in (signal.SIGUSR1, signal.SIGUSR2)}
     old = zuvloop.new_event_loop()
     owner = zuvloop.new_event_loop()
@@ -118,9 +118,46 @@ def test_failed_wakeup_attach_does_not_restore_another_loops_owner(monkeypatch: 
         with pytest.raises(RuntimeError, match="cannot be caught"):
             owner.add_signal_handler(signal.SIGUSR2, print)
         assert signal.SIGUSR2 not in _signal_owners
-        assert real_set_wakeup_fd(-1) == -1
+        assert _signal_owners[signal.SIGUSR1] is old._signal_owner
+        installed = real_set_wakeup_fd(-1)
+        assert installed == old._csock.fileno()
+        real_set_wakeup_fd(installed)
     finally:
         old.remove_signal_handler(signal.SIGUSR1)
+        old.close()
+        owner.close()
+        real_set_wakeup_fd(-1)
+        for sig, handler in originals.items():
+            signal.signal(sig, handler)
+
+
+def test_failed_wakeup_attach_abandons_an_owner_finalized_during_the_syscall(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    originals = {sig: signal.getsignal(sig) for sig in (signal.SIGUSR1, signal.SIGUSR2)}
+    old = zuvloop.new_event_loop()
+    owner = zuvloop.new_event_loop()
+    cleanup_fd = os.dup(old._csock.fileno())
+    old.add_signal_handler(signal.SIGUSR1, print)
+    real_set_wakeup_fd = signal.set_wakeup_fd
+    first_call = True
+
+    def finalize_then_fail(fd: int) -> int:
+        nonlocal first_call
+        if first_call:
+            first_call = False
+            _finish_deferred_signal_cleanup((signal.SIGUSR1,), cleanup_fd, old._signal_owner)
+            raise OSError("cannot attach")
+        return real_set_wakeup_fd(fd)
+
+    monkeypatch.setattr(signal, "set_wakeup_fd", finalize_then_fail)
+    try:
+        with pytest.raises(RuntimeError, match="cannot be caught"):
+            owner.add_signal_handler(signal.SIGUSR2, print)
+        assert signal.SIGUSR1 not in _signal_owners
+        assert signal.SIGUSR2 not in _signal_owners
+        assert real_set_wakeup_fd(-1) == -1
+    finally:
         old.close()
         owner.close()
         real_set_wakeup_fd(-1)

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -19,6 +19,13 @@ from zuvloop._loop import _noop_signal_handler
 pytestmark = pytest.mark.anyio
 
 
+def test_signal_owner_tokens_use_identity() -> None:
+    first = SignalOwner()
+    second = SignalOwner()
+    assert first != second
+    assert len({first, second}) == 2
+
+
 async def test_a_signal_reaches_its_handler() -> None:
     loop = running_loop()
     received = loop.create_future()

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -6,6 +6,8 @@ import os
 import signal
 import threading
 import weakref
+from collections.abc import Callable
+from types import FrameType
 
 import pytest
 
@@ -77,17 +79,20 @@ async def test_uncatchable_signals_are_rejected() -> None:
 def test_failed_wakeup_attach_rolls_back_signal_ownership(monkeypatch: pytest.MonkeyPatch) -> None:
     original = signal.getsignal(signal.SIGUSR1)
     loop = zuvloop.new_event_loop()
+    siginterrupt_calls: list[tuple[int, bool]] = []
 
     def fail_to_attach() -> None:
         raise OSError("cannot attach")
 
     monkeypatch.setattr(loop, "_attach_wakeup_fd", fail_to_attach)
+    monkeypatch.setattr(signal, "siginterrupt", lambda sig, flag: siginterrupt_calls.append((sig, flag)))
     try:
         with pytest.raises(RuntimeError, match="cannot be caught"):
             loop.add_signal_handler(signal.SIGUSR1, print)
         assert signal.SIGUSR1 not in loop._signal_handlers
         assert _signal_owners.get(signal.SIGUSR1) is not loop._signal_owner
         assert signal.getsignal(signal.SIGUSR1) is original
+        assert siginterrupt_calls == []
     finally:
         loop.close()
         signal.signal(signal.SIGUSR1, original)
@@ -136,6 +141,37 @@ def test_stale_pending_cleanup_cannot_reset_a_registration_in_progress(monkeypat
         old.close()
         owner.close()
         signal.signal(signal.SIGUSR1, original)
+
+
+def test_failed_registration_does_not_resurrect_a_finalized_owner(monkeypatch: pytest.MonkeyPatch) -> None:
+    original = signal.getsignal(signal.SIGUSR1)
+    old = zuvloop.new_event_loop()
+    owner = zuvloop.new_event_loop()
+    cleanup_fd = os.dup(old._csock.fileno())
+    old.add_signal_handler(signal.SIGUSR1, print)
+    real_signal = signal.signal
+    first_call = True
+
+    def fail_after_stale_cleanup(
+        sig: int, handler: int | Callable[[int, FrameType | None], object]
+    ) -> int | Callable[[int, FrameType | None], object] | None:
+        nonlocal first_call
+        if first_call:
+            first_call = False
+            _finish_deferred_signal_cleanup((signal.SIGUSR1,), cleanup_fd, old._signal_owner)
+            raise OSError("cannot install")
+        return real_signal(sig, handler)
+
+    monkeypatch.setattr(signal, "signal", fail_after_stale_cleanup)
+    try:
+        with pytest.raises(RuntimeError, match="cannot be caught"):
+            owner.add_signal_handler(signal.SIGUSR1, print)
+        assert signal.SIGUSR1 not in _signal_owners
+        assert signal.getsignal(signal.SIGUSR1) is signal.SIG_DFL
+    finally:
+        old.close()
+        owner.close()
+        real_signal(signal.SIGUSR1, original)
 
 
 def test_signal_handlers_require_the_main_thread() -> None:

--- a/zuvloop/_base.py
+++ b/zuvloop/_base.py
@@ -38,6 +38,15 @@ class SignalOwner:
         return self.finalized
 
 
+class WakeupState:
+    __slots__ = ("fd", "owner", "was_attached")
+
+    def __init__(self, fd: int, owner: SignalOwner | None, was_attached: bool) -> None:
+        self.fd = fd
+        self.owner = owner
+        self.was_attached = was_attached
+
+
 _signal_owners: dict[int, SignalOwner] = {}
 _wakeup_fd_owner: SignalOwner | None = None
 
@@ -324,7 +333,7 @@ class LoopBase(_zuvloop.Loop, asyncio.AbstractEventLoop):  # type: ignore[misc]
         self._ssock.close()
         self._csock.close()
 
-    def _attach_wakeup_fd(self) -> tuple[int, SignalOwner | None, bool] | None:
+    def _attach_wakeup_fd(self) -> WakeupState | None:
         # Only the main thread may own the wakeup fd, and only it runs Python
         # signal handlers - so a loop on any other thread simply skips this.
         if threading.current_thread() is threading.main_thread() and self._signal_handlers:
@@ -347,30 +356,29 @@ class LoopBase(_zuvloop.Loop, asyncio.AbstractEventLoop):  # type: ignore[misc]
                     _wakeup_fd_owner = None
                 raise
             self._wakeup_fd_attached = True
-            return (previous_fd, previous_owner, previous_attached)
+            return WakeupState(previous_fd, previous_owner, previous_attached)
         return None
 
-    def _restore_wakeup_fd(self, previous: tuple[int, SignalOwner | None, bool] | None) -> None:
+    def _restore_wakeup_fd(self, previous: WakeupState | None) -> None:
         if previous is None:
             return
         global _wakeup_fd_owner
         # Stale cleanup skips a replacement token, so this transaction remains
         # the wakeup owner until it either commits or restores this snapshot.
         assert _wakeup_fd_owner is self._signal_owner
-        fd, owner, was_attached = previous
-        abandon = owner is not None and owner.is_finalized()
+        abandon = previous.owner is not None and previous.owner.is_finalized()
         try:
-            signal.set_wakeup_fd(-1 if abandon else fd)
+            signal.set_wakeup_fd(-1 if abandon else previous.fd)
         except OSError:  # pragma: no cover - fd closed between check and syscall
             # Finalization may close fd after the check but before the syscall.
             signal.set_wakeup_fd(-1)
             abandon = True
-        _wakeup_fd_owner = None if abandon else owner
-        self._wakeup_fd_attached = False if abandon else was_attached
+        _wakeup_fd_owner = None if abandon else previous.owner
+        self._wakeup_fd_attached = False if abandon else previous.was_attached
         # Revalidate after publishing: cleanup can run between any two Python
         # operations above. If it did, never leave its closed fd reinstalled.
         if (  # pragma: no cover - defensive recheck after deferred cleanup
-            owner is not None and owner.is_finalized() and _wakeup_fd_owner is owner
+            previous.owner is not None and previous.owner.is_finalized() and _wakeup_fd_owner is previous.owner
         ):
             signal.set_wakeup_fd(-1)
             _wakeup_fd_owner = None

--- a/zuvloop/_base.py
+++ b/zuvloop/_base.py
@@ -29,7 +29,7 @@ _ExceptionHandler = Callable[[asyncio.AbstractEventLoop, dict[str, Any]], object
 
 # Signal dispositions and the wakeup fd are process-global. Tokens let delayed
 # finalization tell whether another loop has replaced the state it installed.
-@dataclass(slots=True)
+@dataclass(eq=False, slots=True)
 class SignalOwner:
     finalized: bool = False
 

--- a/zuvloop/_base.py
+++ b/zuvloop/_base.py
@@ -29,10 +29,6 @@ _ExceptionHandler = Callable[[asyncio.AbstractEventLoop, dict[str, Any]], object
 # finalization tell whether another loop has replaced the state it installed.
 _signal_owners: dict[int, object] = {}
 _wakeup_fd_owner: object | None = None
-# A stale deferred cleanup can observe a provisional replacement owner and skip
-# its reset. Registration rollback consumes this marker instead of resurrecting
-# the finalized owner.
-_finished_signal_cleanups: set[tuple[object, int]] = set()
 
 
 # The native methods are stricter than typeshed's AbstractEventLoop, which
@@ -322,10 +318,25 @@ class LoopBase(_zuvloop.Loop, asyncio.AbstractEventLoop):  # type: ignore[misc]
         # signal handlers - so a loop on any other thread simply skips this.
         if threading.current_thread() is threading.main_thread() and self._signal_handlers:
             global _wakeup_fd_owner
-            previous = (signal.set_wakeup_fd(self._csock.fileno()), _wakeup_fd_owner, self._wakeup_fd_attached)
+            previous_owner = _wakeup_fd_owner
+            previous_attached = self._wakeup_fd_attached
+            # Publish the provisional token before the syscall. A pending old
+            # cleanup can run as soon as the C call returns; it must already see
+            # that the descriptor has changed hands.
             _wakeup_fd_owner = self._signal_owner
+            try:
+                previous_fd = signal.set_wakeup_fd(self._csock.fileno())
+            except OSError:
+                if previous_owner is self._signal_owner or previous_owner is None:
+                    _wakeup_fd_owner = previous_owner
+                else:
+                    # A skipped stale cleanup may have closed its descriptor;
+                    # never put that possibly invalid owner back.
+                    signal.set_wakeup_fd(-1)
+                    _wakeup_fd_owner = None
+                raise
             self._wakeup_fd_attached = True
-            return previous
+            return (previous_fd, previous_owner, previous_attached)
         return None
 
     def _restore_wakeup_fd(self, previous: tuple[int, object | None, bool] | None, *, abandon: bool) -> None:
@@ -405,8 +416,6 @@ def _finish_deferred_signal_cleanup(signals: tuple[int, ...], wakeup_fd: int, ow
                 del _signal_owners[sig]
                 handler = signal.default_int_handler if sig == signal.SIGINT else signal.SIG_DFL
                 signal.signal(sig, handler)
-            else:
-                _finished_signal_cleanups.add((owner, sig))
     finally:
         os.close(wakeup_fd)
 

--- a/zuvloop/_base.py
+++ b/zuvloop/_base.py
@@ -12,6 +12,7 @@ import weakref
 from asyncio import events as _events
 from collections.abc import Callable, Coroutine
 from contextvars import Context
+from dataclasses import dataclass
 from functools import partial
 from typing import Any
 
@@ -28,23 +29,19 @@ _ExceptionHandler = Callable[[asyncio.AbstractEventLoop, dict[str, Any]], object
 
 # Signal dispositions and the wakeup fd are process-global. Tokens let delayed
 # finalization tell whether another loop has replaced the state it installed.
+@dataclass(slots=True)
 class SignalOwner:
-    __slots__ = ("finalized",)
-
-    def __init__(self) -> None:
-        self.finalized = False
+    finalized: bool = False
 
     def is_finalized(self) -> bool:
         return self.finalized
 
 
+@dataclass(frozen=True, slots=True)
 class WakeupState:
-    __slots__ = ("fd", "owner", "was_attached")
-
-    def __init__(self, fd: int, owner: SignalOwner | None, was_attached: bool) -> None:
-        self.fd = fd
-        self.owner = owner
-        self.was_attached = was_attached
+    fd: int
+    owner: SignalOwner | None
+    was_attached: bool
 
 
 _signal_owners: dict[int, SignalOwner] = {}

--- a/zuvloop/_base.py
+++ b/zuvloop/_base.py
@@ -25,6 +25,11 @@ from ._instrumentation import (
 
 _ExceptionHandler = Callable[[asyncio.AbstractEventLoop, dict[str, Any]], object]
 
+# Signal dispositions and the wakeup fd are process-global. Tokens let delayed
+# finalization tell whether another loop has replaced the state it installed.
+_signal_owners: dict[int, object] = {}
+_wakeup_fd_owner: object | None = None
+
 
 # The native methods are stricter than typeshed's AbstractEventLoop, which
 # types several of them with TypeVarTuples this class cannot reproduce.
@@ -53,6 +58,7 @@ class LoopBase(_zuvloop.Loop, asyncio.AbstractEventLoop):  # type: ignore[misc]
         # Which `sock_*` call owns the watcher currently on each (fd, write).
         self._sock_watchers: dict[tuple[int, bool], object] = {}
         self._wakeup_fd_attached = False
+        self._signal_owner = object()
         self._instrumentation = Instrumentation()
         self._monitoring_armed = False
         self._metrics_armed = False
@@ -71,7 +77,12 @@ class LoopBase(_zuvloop.Loop, asyncio.AbstractEventLoop):  # type: ignore[misc]
                     wakeup_fd = self._csock.fileno()
                     try:
                         self._defer_close(
-                            partial(_finish_deferred_signal_cleanup, tuple(self._signal_handlers), wakeup_fd)
+                            partial(
+                                _finish_deferred_signal_cleanup,
+                                tuple(self._signal_handlers),
+                                wakeup_fd,
+                                self._signal_owner,
+                            )
                         )
                     except BaseException:  # pragma: no cover - CPython pending-call queue exhaustion
                         try:
@@ -306,7 +317,9 @@ class LoopBase(_zuvloop.Loop, asyncio.AbstractEventLoop):  # type: ignore[misc]
         # Only the main thread may own the wakeup fd, and only it runs Python
         # signal handlers - so a loop on any other thread simply skips this.
         if threading.current_thread() is threading.main_thread() and self._signal_handlers:
+            global _wakeup_fd_owner
             signal.set_wakeup_fd(self._csock.fileno())
+            _wakeup_fd_owner = self._signal_owner
             self._wakeup_fd_attached = True
 
     def _detach_wakeup_fd(self) -> None:
@@ -318,7 +331,10 @@ class LoopBase(_zuvloop.Loop, asyncio.AbstractEventLoop):  # type: ignore[misc]
             and self._wakeup_fd_attached
             and not self._signal_handlers
         ):
-            signal.set_wakeup_fd(-1)
+            global _wakeup_fd_owner
+            if _wakeup_fd_owner is self._signal_owner:
+                signal.set_wakeup_fd(-1)
+                _wakeup_fd_owner = None
             self._wakeup_fd_attached = False
 
     def _add_reader(self, fd: int, callback: Callable[..., object], *args: object) -> None:
@@ -360,12 +376,17 @@ def _stop_when_done(future: asyncio.Future[Any]) -> None:
     asyncio.futures._get_loop(future).stop()  # type: ignore[attr-defined]
 
 
-def _finish_deferred_signal_cleanup(signals: tuple[int, ...], wakeup_fd: int) -> None:
-    signal.set_wakeup_fd(-1)
+def _finish_deferred_signal_cleanup(signals: tuple[int, ...], wakeup_fd: int, owner: object) -> None:
+    global _wakeup_fd_owner
+    if _wakeup_fd_owner is owner:
+        signal.set_wakeup_fd(-1)
+        _wakeup_fd_owner = None
     try:
         for sig in signals:
-            handler = signal.default_int_handler if sig == signal.SIGINT else signal.SIG_DFL
-            signal.signal(sig, handler)
+            if _signal_owners.get(sig) is owner:
+                del _signal_owners[sig]
+                handler = signal.default_int_handler if sig == signal.SIGINT else signal.SIG_DFL
+                signal.signal(sig, handler)
     finally:
         os.close(wakeup_fd)
 

--- a/zuvloop/_base.py
+++ b/zuvloop/_base.py
@@ -29,6 +29,8 @@ _ExceptionHandler = Callable[[asyncio.AbstractEventLoop, dict[str, Any]], object
 # Signal dispositions and the wakeup fd are process-global. Tokens let delayed
 # finalization tell whether another loop has replaced the state it installed.
 class SignalOwner:
+    __slots__ = ("finalized",)
+
     def __init__(self) -> None:
         self.finalized = False
 

--- a/zuvloop/_base.py
+++ b/zuvloop/_base.py
@@ -29,6 +29,10 @@ _ExceptionHandler = Callable[[asyncio.AbstractEventLoop, dict[str, Any]], object
 # finalization tell whether another loop has replaced the state it installed.
 _signal_owners: dict[int, object] = {}
 _wakeup_fd_owner: object | None = None
+# A stale deferred cleanup can observe a provisional replacement owner and skip
+# its reset. Registration rollback consumes this marker instead of resurrecting
+# the finalized owner.
+_finished_signal_cleanups: set[tuple[object, int]] = set()
 
 
 # The native methods are stricter than typeshed's AbstractEventLoop, which
@@ -313,14 +317,28 @@ class LoopBase(_zuvloop.Loop, asyncio.AbstractEventLoop):  # type: ignore[misc]
         self._ssock.close()
         self._csock.close()
 
-    def _attach_wakeup_fd(self) -> None:
+    def _attach_wakeup_fd(self) -> tuple[int, object | None, bool] | None:
         # Only the main thread may own the wakeup fd, and only it runs Python
         # signal handlers - so a loop on any other thread simply skips this.
         if threading.current_thread() is threading.main_thread() and self._signal_handlers:
             global _wakeup_fd_owner
-            signal.set_wakeup_fd(self._csock.fileno())
+            previous = (signal.set_wakeup_fd(self._csock.fileno()), _wakeup_fd_owner, self._wakeup_fd_attached)
             _wakeup_fd_owner = self._signal_owner
             self._wakeup_fd_attached = True
+            return previous
+        return None
+
+    def _restore_wakeup_fd(self, previous: tuple[int, object | None, bool] | None, *, abandon: bool) -> None:
+        if previous is None:
+            return
+        global _wakeup_fd_owner
+        # Stale cleanup skips a replacement token, so this transaction remains
+        # the wakeup owner until it either commits or restores this snapshot.
+        assert _wakeup_fd_owner is self._signal_owner
+        fd, owner, was_attached = previous
+        signal.set_wakeup_fd(-1 if abandon else fd)
+        _wakeup_fd_owner = None if abandon else owner
+        self._wakeup_fd_attached = False if abandon else was_attached
 
     def _detach_wakeup_fd(self) -> None:
         # Registered handlers must keep the fd active between separate calls
@@ -387,6 +405,8 @@ def _finish_deferred_signal_cleanup(signals: tuple[int, ...], wakeup_fd: int, ow
                 del _signal_owners[sig]
                 handler = signal.default_int_handler if sig == signal.SIGINT else signal.SIG_DFL
                 signal.signal(sig, handler)
+            else:
+                _finished_signal_cleanups.add((owner, sig))
     finally:
         os.close(wakeup_fd)
 

--- a/zuvloop/_base.py
+++ b/zuvloop/_base.py
@@ -32,6 +32,9 @@ class SignalOwner:
     def __init__(self) -> None:
         self.finalized = False
 
+    def is_finalized(self) -> bool:
+        return self.finalized
+
 
 _signal_owners: dict[int, SignalOwner] = {}
 _wakeup_fd_owner: SignalOwner | None = None
@@ -333,7 +336,7 @@ class LoopBase(_zuvloop.Loop, asyncio.AbstractEventLoop):  # type: ignore[misc]
             try:
                 previous_fd = signal.set_wakeup_fd(self._csock.fileno())
             except OSError:
-                if previous_owner is None or not previous_owner.finalized:
+                if previous_owner is None or not previous_owner.is_finalized():
                     _wakeup_fd_owner = previous_owner
                 else:
                     # A skipped stale cleanup may have closed its descriptor;
@@ -345,7 +348,7 @@ class LoopBase(_zuvloop.Loop, asyncio.AbstractEventLoop):  # type: ignore[misc]
             return (previous_fd, previous_owner, previous_attached)
         return None
 
-    def _restore_wakeup_fd(self, previous: tuple[int, SignalOwner | None, bool] | None, *, abandon: bool) -> None:
+    def _restore_wakeup_fd(self, previous: tuple[int, SignalOwner | None, bool] | None) -> None:
         if previous is None:
             return
         global _wakeup_fd_owner
@@ -353,9 +356,23 @@ class LoopBase(_zuvloop.Loop, asyncio.AbstractEventLoop):  # type: ignore[misc]
         # the wakeup owner until it either commits or restores this snapshot.
         assert _wakeup_fd_owner is self._signal_owner
         fd, owner, was_attached = previous
-        signal.set_wakeup_fd(-1 if abandon else fd)
+        abandon = owner is not None and owner.is_finalized()
+        try:
+            signal.set_wakeup_fd(-1 if abandon else fd)
+        except OSError:  # pragma: no cover - fd closed between check and syscall
+            # Finalization may close fd after the check but before the syscall.
+            signal.set_wakeup_fd(-1)
+            abandon = True
         _wakeup_fd_owner = None if abandon else owner
         self._wakeup_fd_attached = False if abandon else was_attached
+        # Revalidate after publishing: cleanup can run between any two Python
+        # operations above. If it did, never leave its closed fd reinstalled.
+        if (  # pragma: no cover - defensive recheck after deferred cleanup
+            owner is not None and owner.is_finalized() and _wakeup_fd_owner is owner
+        ):
+            signal.set_wakeup_fd(-1)
+            _wakeup_fd_owner = None
+            self._wakeup_fd_attached = False
 
     def _detach_wakeup_fd(self) -> None:
         # Registered handlers must keep the fd active between separate calls

--- a/zuvloop/_base.py
+++ b/zuvloop/_base.py
@@ -25,10 +25,16 @@ from ._instrumentation import (
 
 _ExceptionHandler = Callable[[asyncio.AbstractEventLoop, dict[str, Any]], object]
 
+
 # Signal dispositions and the wakeup fd are process-global. Tokens let delayed
 # finalization tell whether another loop has replaced the state it installed.
-_signal_owners: dict[int, object] = {}
-_wakeup_fd_owner: object | None = None
+class SignalOwner:
+    def __init__(self) -> None:
+        self.finalized = False
+
+
+_signal_owners: dict[int, SignalOwner] = {}
+_wakeup_fd_owner: SignalOwner | None = None
 
 
 # The native methods are stricter than typeshed's AbstractEventLoop, which
@@ -58,7 +64,7 @@ class LoopBase(_zuvloop.Loop, asyncio.AbstractEventLoop):  # type: ignore[misc]
         # Which `sock_*` call owns the watcher currently on each (fd, write).
         self._sock_watchers: dict[tuple[int, bool], object] = {}
         self._wakeup_fd_attached = False
-        self._signal_owner = object()
+        self._signal_owner = SignalOwner()
         self._instrumentation = Instrumentation()
         self._monitoring_armed = False
         self._metrics_armed = False
@@ -313,7 +319,7 @@ class LoopBase(_zuvloop.Loop, asyncio.AbstractEventLoop):  # type: ignore[misc]
         self._ssock.close()
         self._csock.close()
 
-    def _attach_wakeup_fd(self) -> tuple[int, object | None, bool] | None:
+    def _attach_wakeup_fd(self) -> tuple[int, SignalOwner | None, bool] | None:
         # Only the main thread may own the wakeup fd, and only it runs Python
         # signal handlers - so a loop on any other thread simply skips this.
         if threading.current_thread() is threading.main_thread() and self._signal_handlers:
@@ -327,11 +333,11 @@ class LoopBase(_zuvloop.Loop, asyncio.AbstractEventLoop):  # type: ignore[misc]
             try:
                 previous_fd = signal.set_wakeup_fd(self._csock.fileno())
             except OSError:
-                if previous_owner is self._signal_owner or previous_owner is None:
+                if previous_owner is None or not previous_owner.finalized:
                     _wakeup_fd_owner = previous_owner
                 else:
                     # A skipped stale cleanup may have closed its descriptor;
-                    # never put that possibly invalid owner back.
+                    # never put that invalid owner back.
                     signal.set_wakeup_fd(-1)
                     _wakeup_fd_owner = None
                 raise
@@ -339,7 +345,7 @@ class LoopBase(_zuvloop.Loop, asyncio.AbstractEventLoop):  # type: ignore[misc]
             return (previous_fd, previous_owner, previous_attached)
         return None
 
-    def _restore_wakeup_fd(self, previous: tuple[int, object | None, bool] | None, *, abandon: bool) -> None:
+    def _restore_wakeup_fd(self, previous: tuple[int, SignalOwner | None, bool] | None, *, abandon: bool) -> None:
         if previous is None:
             return
         global _wakeup_fd_owner
@@ -405,8 +411,9 @@ def _stop_when_done(future: asyncio.Future[Any]) -> None:
     asyncio.futures._get_loop(future).stop()  # type: ignore[attr-defined]
 
 
-def _finish_deferred_signal_cleanup(signals: tuple[int, ...], wakeup_fd: int, owner: object) -> None:
+def _finish_deferred_signal_cleanup(signals: tuple[int, ...], wakeup_fd: int, owner: SignalOwner) -> None:
     global _wakeup_fd_owner
+    owner.finalized = True
     if _wakeup_fd_owner is owner:
         signal.set_wakeup_fd(-1)
         _wakeup_fd_owner = None

--- a/zuvloop/_loop.py
+++ b/zuvloop/_loop.py
@@ -12,6 +12,8 @@ from typing import Any
 from ._base import _signal_owners
 from ._connect import ConnectionOperations
 
+_MISSING_SIGNAL_OWNER = object()
+
 
 class EventLoop(ConnectionOperations):
     """An asyncio event loop backed by libuv.
@@ -33,16 +35,35 @@ class EventLoop(ConnectionOperations):
         _check_signal(sig)
         if threading.current_thread() is not threading.main_thread():
             raise RuntimeError("signal handlers can only be added from the main thread")
-        self._signal_handlers[sig] = (callback, args, contextvars.copy_context())
+        entry = (callback, args, contextvars.copy_context())
+        previous_entry = self._signal_handlers.get(sig)
+        previous_owner = _signal_owners.get(sig, _MISSING_SIGNAL_OWNER)
+        previous_disposition = signal.getsignal(sig)
+
+        # Publish ownership before touching process-global state. A pending
+        # cleanup from an older loop can run between any two Python calls below;
+        # seeing the new token makes it leave this registration alone.
+        self._signal_handlers[sig] = entry
+        _signal_owners[sig] = self._signal_owner
+        installed = False
         try:
             # Installing any Python handler is what makes CPython write the
             # signal number to the wakeup fd; the loop dispatches from there.
             signal.signal(sig, _noop_signal_handler)
+            installed = True
             signal.siginterrupt(sig, False)
-            _signal_owners[sig] = self._signal_owner
             self._attach_wakeup_fd()
         except OSError as exc:
-            del self._signal_handlers[sig]
+            if installed:
+                signal.signal(sig, previous_disposition)
+            if previous_entry is None:
+                del self._signal_handlers[sig]
+            else:
+                self._signal_handlers[sig] = previous_entry
+            if previous_owner is _MISSING_SIGNAL_OWNER:
+                _signal_owners.pop(sig, None)
+            else:
+                _signal_owners[sig] = previous_owner
             raise RuntimeError(f"sig {sig} cannot be caught") from exc
 
     def remove_signal_handler(self, sig: int) -> bool:

--- a/zuvloop/_loop.py
+++ b/zuvloop/_loop.py
@@ -55,8 +55,7 @@ class EventLoop(ConnectionOperations):
             signal.signal(sig, _noop_signal_handler)
         except OSError as exc:
             cleanup_finished = (
-                previous_owner is not _MISSING_SIGNAL_OWNER
-                and (previous_owner, sig) in _finished_signal_cleanups
+                previous_owner is not _MISSING_SIGNAL_OWNER and (previous_owner, sig) in _finished_signal_cleanups
             )
             if cleanup_finished:
                 _finished_signal_cleanups.discard((previous_owner, sig))

--- a/zuvloop/_loop.py
+++ b/zuvloop/_loop.py
@@ -54,7 +54,7 @@ class EventLoop(ConnectionOperations):
             # signal number to the wakeup fd; the loop dispatches from there.
             signal.signal(sig, _noop_signal_handler)
         except OSError as exc:
-            previous_finalized = isinstance(previous_owner, SignalOwner) and previous_owner.finalized
+            previous_finalized = isinstance(previous_owner, SignalOwner) and previous_owner.is_finalized()
             if previous_finalized:
                 # A pending finalizer already skipped this provisional owner.
                 # Complete its reset instead of resurrecting that loop.
@@ -67,12 +67,19 @@ class EventLoop(ConnectionOperations):
                 self._signal_handlers[sig] = previous_entry
             if isinstance(previous_owner, SignalOwner) and not previous_finalized:
                 _signal_owners[sig] = previous_owner
+                # Finalization can run after the snapshot but before this dict
+                # assignment. Revalidate the token at the commit point; if it
+                # raced us, cleanup either removed it already or we do so now.
+                if (  # pragma: no cover - defensive recheck after deferred cleanup
+                    previous_owner.is_finalized() and _signal_owners.get(sig) is previous_owner
+                ):
+                    _signal_owners.pop(sig, None)
+                    handler = signal.default_int_handler if sig == signal.SIGINT else signal.SIG_DFL
+                    signal.signal(sig, handler)
             else:
                 _signal_owners.pop(sig, None)
 
-            previous_wakeup_owner = wakeup_state[1] if wakeup_state is not None else None
-            abandon_wakeup = previous_wakeup_owner is not None and previous_wakeup_owner.finalized
-            self._restore_wakeup_fd(wakeup_state, abandon=abandon_wakeup)
+            self._restore_wakeup_fd(wakeup_state)
             raise RuntimeError(f"sig {sig} cannot be caught") from exc
 
         signal.siginterrupt(sig, False)

--- a/zuvloop/_loop.py
+++ b/zuvloop/_loop.py
@@ -9,7 +9,7 @@ from collections.abc import Callable
 from types import FrameType
 from typing import Any
 
-from ._base import _finished_signal_cleanups, _signal_owners
+from ._base import _signal_owners
 from ._connect import ConnectionOperations
 
 _MISSING_SIGNAL_OWNER = object()
@@ -54,27 +54,27 @@ class EventLoop(ConnectionOperations):
             # signal number to the wakeup fd; the loop dispatches from there.
             signal.signal(sig, _noop_signal_handler)
         except OSError as exc:
-            cleanup_finished = (
-                previous_owner is not _MISSING_SIGNAL_OWNER and (previous_owner, sig) in _finished_signal_cleanups
-            )
-            if cleanup_finished:
-                _finished_signal_cleanups.discard((previous_owner, sig))
+            if previous_owner is not _MISSING_SIGNAL_OWNER and previous_owner is not self._signal_owner:
+                # A pending finalizer may already have skipped this provisional
+                # owner. Complete its reset instead of resurrecting that loop.
                 handler = signal.default_int_handler if sig == signal.SIGINT else signal.SIG_DFL
                 signal.signal(sig, handler)
+
             if previous_entry is None:
                 del self._signal_handlers[sig]
             else:
                 self._signal_handlers[sig] = previous_entry
-            if previous_owner is _MISSING_SIGNAL_OWNER or cleanup_finished:
-                _signal_owners.pop(sig, None)
-            else:
+            if previous_owner is self._signal_owner:
                 _signal_owners[sig] = previous_owner
-            self._restore_wakeup_fd(wakeup_state, abandon=cleanup_finished)
+            else:
+                _signal_owners.pop(sig, None)
+
+            previous_wakeup_owner = wakeup_state[1] if wakeup_state is not None else None
+            abandon_wakeup = previous_wakeup_owner is not None and previous_wakeup_owner is not self._signal_owner
+            self._restore_wakeup_fd(wakeup_state, abandon=abandon_wakeup)
             raise RuntimeError(f"sig {sig} cannot be caught") from exc
 
         signal.siginterrupt(sig, False)
-        if previous_owner is not _MISSING_SIGNAL_OWNER:
-            _finished_signal_cleanups.discard((previous_owner, sig))
 
     def remove_signal_handler(self, sig: int) -> bool:
         _check_signal(sig)

--- a/zuvloop/_loop.py
+++ b/zuvloop/_loop.py
@@ -9,7 +9,7 @@ from collections.abc import Callable
 from types import FrameType
 from typing import Any
 
-from ._base import _signal_owners
+from ._base import SignalOwner, _signal_owners
 from ._connect import ConnectionOperations
 
 _MISSING_SIGNAL_OWNER = object()
@@ -44,7 +44,7 @@ class EventLoop(ConnectionOperations):
         # seeing the new token makes it leave this registration alone.
         self._signal_handlers[sig] = entry
         _signal_owners[sig] = self._signal_owner
-        wakeup_state: tuple[int, object | None, bool] | None = None
+        wakeup_state: tuple[int, SignalOwner | None, bool] | None = None
         try:
             # Attach before signal.signal(), which implicitly enables syscall
             # interruption. If attachment fails, rollback has no siginterrupt
@@ -54,9 +54,10 @@ class EventLoop(ConnectionOperations):
             # signal number to the wakeup fd; the loop dispatches from there.
             signal.signal(sig, _noop_signal_handler)
         except OSError as exc:
-            if previous_owner is not _MISSING_SIGNAL_OWNER and previous_owner is not self._signal_owner:
-                # A pending finalizer may already have skipped this provisional
-                # owner. Complete its reset instead of resurrecting that loop.
+            previous_finalized = isinstance(previous_owner, SignalOwner) and previous_owner.finalized
+            if previous_finalized:
+                # A pending finalizer already skipped this provisional owner.
+                # Complete its reset instead of resurrecting that loop.
                 handler = signal.default_int_handler if sig == signal.SIGINT else signal.SIG_DFL
                 signal.signal(sig, handler)
 
@@ -64,13 +65,13 @@ class EventLoop(ConnectionOperations):
                 del self._signal_handlers[sig]
             else:
                 self._signal_handlers[sig] = previous_entry
-            if previous_owner is self._signal_owner:
+            if isinstance(previous_owner, SignalOwner) and not previous_finalized:
                 _signal_owners[sig] = previous_owner
             else:
                 _signal_owners.pop(sig, None)
 
             previous_wakeup_owner = wakeup_state[1] if wakeup_state is not None else None
-            abandon_wakeup = previous_wakeup_owner is not None and previous_wakeup_owner is not self._signal_owner
+            abandon_wakeup = previous_wakeup_owner is not None and previous_wakeup_owner.finalized
             self._restore_wakeup_fd(wakeup_state, abandon=abandon_wakeup)
             raise RuntimeError(f"sig {sig} cannot be caught") from exc
 

--- a/zuvloop/_loop.py
+++ b/zuvloop/_loop.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 from types import FrameType
 from typing import Any
 
+from ._base import _signal_owners
 from ._connect import ConnectionOperations
 
 
@@ -38,6 +39,7 @@ class EventLoop(ConnectionOperations):
             # signal number to the wakeup fd; the loop dispatches from there.
             signal.signal(sig, _noop_signal_handler)
             signal.siginterrupt(sig, False)
+            _signal_owners[sig] = self._signal_owner
             self._attach_wakeup_fd()
         except OSError as exc:
             del self._signal_handlers[sig]
@@ -47,8 +49,10 @@ class EventLoop(ConnectionOperations):
         _check_signal(sig)
         if self._signal_handlers.pop(sig, None) is None:
             return False
-        handler = signal.default_int_handler if sig == signal.SIGINT else signal.SIG_DFL
-        signal.signal(sig, handler)
+        if _signal_owners.get(sig) is self._signal_owner:
+            del _signal_owners[sig]
+            handler = signal.default_int_handler if sig == signal.SIGINT else signal.SIG_DFL
+            signal.signal(sig, handler)
         self._detach_wakeup_fd()
         return True
 

--- a/zuvloop/_loop.py
+++ b/zuvloop/_loop.py
@@ -12,8 +12,6 @@ from typing import Any
 from ._base import SignalOwner, _signal_owners
 from ._connect import ConnectionOperations
 
-_MISSING_SIGNAL_OWNER = object()
-
 
 class EventLoop(ConnectionOperations):
     """An asyncio event loop backed by libuv.
@@ -37,7 +35,7 @@ class EventLoop(ConnectionOperations):
             raise RuntimeError("signal handlers can only be added from the main thread")
         entry = (callback, args, contextvars.copy_context())
         previous_entry = self._signal_handlers.get(sig)
-        previous_owner = _signal_owners.get(sig, _MISSING_SIGNAL_OWNER)
+        previous_owner: SignalOwner | None = _signal_owners.get(sig)
 
         # Publish ownership before touching process-global state. A pending
         # cleanup from an older loop can run between any two Python calls below;
@@ -54,7 +52,7 @@ class EventLoop(ConnectionOperations):
             # signal number to the wakeup fd; the loop dispatches from there.
             signal.signal(sig, _noop_signal_handler)
         except OSError as exc:
-            previous_finalized = isinstance(previous_owner, SignalOwner) and previous_owner.is_finalized()
+            previous_finalized = previous_owner is not None and previous_owner.is_finalized()
             if previous_finalized:
                 # A pending finalizer already skipped this provisional owner.
                 # Complete its reset instead of resurrecting that loop.
@@ -65,7 +63,7 @@ class EventLoop(ConnectionOperations):
                 del self._signal_handlers[sig]
             else:
                 self._signal_handlers[sig] = previous_entry
-            if isinstance(previous_owner, SignalOwner) and not previous_finalized:
+            if previous_owner is not None and not previous_finalized:
                 _signal_owners[sig] = previous_owner
                 # Finalization can run after the snapshot but before this dict
                 # assignment. Revalidate the token at the commit point; if it

--- a/zuvloop/_loop.py
+++ b/zuvloop/_loop.py
@@ -9,7 +9,7 @@ from collections.abc import Callable
 from types import FrameType
 from typing import Any
 
-from ._base import _signal_owners
+from ._base import _finished_signal_cleanups, _signal_owners
 from ._connect import ConnectionOperations
 
 _MISSING_SIGNAL_OWNER = object()
@@ -38,33 +38,44 @@ class EventLoop(ConnectionOperations):
         entry = (callback, args, contextvars.copy_context())
         previous_entry = self._signal_handlers.get(sig)
         previous_owner = _signal_owners.get(sig, _MISSING_SIGNAL_OWNER)
-        previous_disposition = signal.getsignal(sig)
 
         # Publish ownership before touching process-global state. A pending
         # cleanup from an older loop can run between any two Python calls below;
         # seeing the new token makes it leave this registration alone.
         self._signal_handlers[sig] = entry
         _signal_owners[sig] = self._signal_owner
-        installed = False
+        wakeup_state: tuple[int, object | None, bool] | None = None
         try:
+            # Attach before signal.signal(), which implicitly enables syscall
+            # interruption. If attachment fails, rollback has no siginterrupt
+            # state to reconstruct (Python exposes a setter but no getter).
+            wakeup_state = self._attach_wakeup_fd()
             # Installing any Python handler is what makes CPython write the
             # signal number to the wakeup fd; the loop dispatches from there.
             signal.signal(sig, _noop_signal_handler)
-            installed = True
-            signal.siginterrupt(sig, False)
-            self._attach_wakeup_fd()
         except OSError as exc:
-            if installed:
-                signal.signal(sig, previous_disposition)
+            cleanup_finished = (
+                previous_owner is not _MISSING_SIGNAL_OWNER
+                and (previous_owner, sig) in _finished_signal_cleanups
+            )
+            if cleanup_finished:
+                _finished_signal_cleanups.discard((previous_owner, sig))
+                handler = signal.default_int_handler if sig == signal.SIGINT else signal.SIG_DFL
+                signal.signal(sig, handler)
             if previous_entry is None:
                 del self._signal_handlers[sig]
             else:
                 self._signal_handlers[sig] = previous_entry
-            if previous_owner is _MISSING_SIGNAL_OWNER:
+            if previous_owner is _MISSING_SIGNAL_OWNER or cleanup_finished:
                 _signal_owners.pop(sig, None)
             else:
                 _signal_owners[sig] = previous_owner
+            self._restore_wakeup_fd(wakeup_state, abandon=cleanup_finished)
             raise RuntimeError(f"sig {sig} cannot be caught") from exc
+
+        signal.siginterrupt(sig, False)
+        if previous_owner is not _MISSING_SIGNAL_OWNER:
+            _finished_signal_cleanups.discard((previous_owner, sig))
 
     def remove_signal_handler(self, sig: int) -> bool:
         _check_signal(sig)

--- a/zuvloop/_loop.py
+++ b/zuvloop/_loop.py
@@ -9,7 +9,7 @@ from collections.abc import Callable
 from types import FrameType
 from typing import Any
 
-from ._base import SignalOwner, _signal_owners
+from ._base import SignalOwner, WakeupState, _signal_owners
 from ._connect import ConnectionOperations
 
 
@@ -42,7 +42,7 @@ class EventLoop(ConnectionOperations):
         # seeing the new token makes it leave this registration alone.
         self._signal_handlers[sig] = entry
         _signal_owners[sig] = self._signal_owner
-        wakeup_state: tuple[int, SignalOwner | None, bool] | None = None
+        wakeup_state: WakeupState | None = None
         try:
             # Attach before signal.signal(), which implicitly enables syscall
             # interruption. If attachment fails, rollback has no siginterrupt


### PR DESCRIPTION
Track process-global signal dispositions and the wakeup fd with per-loop ownership tokens. Explicit close and delayed finalization now restore only state still owned by that loop, so collecting an older loop cannot reset a newer loop’s handlers or disable its wakeup fd. The same guard covers cleanup deferred from a worker thread.

Finding: https://chatgpt.com/codex/cloud/security/findings/5c9c7f36c5dc8191a1fbfb755b66f41b

Tests: uv run pytest tests/test_signals.py; uv run ruff check zuvloop/_base.py zuvloop/_loop.py tests/test_signals.py; uv run mypy zuvloop/_base.py zuvloop/_loop.py tests/test_signals.py

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guard process-wide signal handlers and the wakeup fd with per-loop SignalOwner tokens. We publish ownership before global changes, transfer the wakeup fd atomically, and revalidate/finalize tokens during cleanup or rollback so stale work can’t restore closed state or clobber a newer loop.

- **Bug Fixes**
  - Publish per-signal ownership in `_signal_owners` before `signal.signal`; attach the wakeup fd first and claim it atomically via `_wakeup_fd_owner`. On failure, restore a saved `WakeupState` with `_restore_wakeup_fd`, abandoning closed owners and rechecking after publish so stale finalizers can’t reinstall a dead fd or token.
  - Make registration transactional and owner-aware: on failure, restore the prior entry/handler/owner only if that owner is still live; if it’s finalized or finalizes at commit, complete the reset instead. Deferred cleanup (`_finish_deferred_signal_cleanup`) now takes the token, marks it finalized, and only resets wakeup/handlers still owned. Detach and removal also only reset when this loop owns the signal or wakeup fd.

- **Refactors**
  - Use slotted dataclasses for `SignalOwner` and `WakeupState`; make `SignalOwner` identity-based (no eq/hash) to avoid accidental token collisions.

<sup>Written for commit 56d6c32e3a1041efce861677578257d72b856b91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/62?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved signal handling reliability when event-loop setup or registration fails.
  * Prevented failed operations from leaving stale signal handlers or wakeup state behind.
  * Fixed cleanup behavior so closing or finalizing an older event loop cannot disrupt a newer loop’s signal handling.
  * Ensured signal ownership is restored safely when setup is interrupted or another loop is finalized during the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->