### PR TITLE
Verify libuv release archives before extraction

### DIFF
--- a/vendor/README.md
+++ b/vendor/README.md
@@ -4,10 +4,12 @@
 
 - Version: **1.51.0**
 - Source: <https://dist.libuv.org/dist/v1.51.0/libuv-v1.51.0.tar.gz>
+- SHA-256: `5f0557b90b1106de71951a3c3931de5e0430d78da1d9a10287ebc7a3f78ef8eb`
 
 The tree under `libuv/` is the upstream release tarball, extracted verbatim. **Never edit it.**
 Everything zuvloop adds lives in `zig/`, and `build.zig` compiles the vendored sources with the same
 defines and file lists as upstream's `CMakeLists.txt`.
 
-To update, run `./vendor/update-libuv.sh <version>` and re-check the file lists at the top of
-`build.zig` against the new `CMakeLists.txt`.
+To update, verify the checksum through an independent channel, then run
+`./vendor/update-libuv.sh <version> <sha256>` and re-check the file lists at the top of `build.zig`
+against the new `CMakeLists.txt`.

--- a/vendor/update-libuv.sh
+++ b/vendor/update-libuv.sh
@@ -2,7 +2,12 @@
 # Replace vendor/libuv with a pristine upstream release tarball.
 set -euo pipefail
 
-version="${1:?usage: update-libuv.sh <version>, e.g. 1.51.0}"
+version="${1:?usage: update-libuv.sh <version> <sha256>, e.g. 1.51.0 5f0557...}"
+checksum="${2:?supply the SHA-256 published for libuv ${version}}"
+if [[ ! "$checksum" =~ ^[[:xdigit:]]{64}$ ]]; then
+    echo "invalid SHA-256: $checksum" >&2
+    exit 2
+fi
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 url="https://dist.libuv.org/dist/v${version}/libuv-v${version}.tar.gz"
 
@@ -10,11 +15,12 @@ tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
 curl -fsSL "$url" -o "$tmp/libuv.tar.gz"
+printf '%s  %s\n' "$checksum" "$tmp/libuv.tar.gz" | shasum -a 256 -c -
 tar xzf "$tmp/libuv.tar.gz" -C "$tmp"
 rm -rf "$here/libuv"
 mv "$tmp/libuv-v${version}" "$here/libuv"
 
-sed -i.bak -E "s/\*\*[0-9]+\.[0-9]+\.[0-9]+\*\*/**${version}**/; s|dist/v[0-9]+\.[0-9]+\.[0-9]+/libuv-v[0-9]+\.[0-9]+\.[0-9]+|dist/v${version}/libuv-v${version}|g" "$here/README.md"
+sed -i.bak -E "s/\*\*[0-9]+\.[0-9]+\.[0-9]+\*\*/**${version}**/; s|dist/v[0-9]+\.[0-9]+\.[0-9]+/libuv-v[0-9]+\.[0-9]+\.[0-9]+|dist/v${version}/libuv-v${version}|g; s|SHA-256: `[[:xdigit:]]{64}`|SHA-256: `${checksum}`|" "$here/README.md"
 rm -f "$here/README.md.bak"
 
 echo "vendored libuv ${version} from ${url}"


### PR DESCRIPTION
Require an independently obtained SHA-256 when updating vendored libuv, validate its shape, and verify the downloaded archive before extraction or replacement. Record the checksum for the currently vendored 1.51.0 release in the dependency manifest.

Finding: https://chatgpt.com/codex/cloud/security/findings/08ac23fa3948819182cab05dac2a0172

Tests: bash -n vendor/update-libuv.sh; invalid-checksum invocation exits 2 before download/extraction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Verify libuv release tarballs with a required SHA-256 before extraction to prevent tampering. Updated the vendor script and docs, and recorded the checksum for 1.51.0.

- **New Features**
  - `vendor/update-libuv.sh` now requires `<version> <sha256>` and validates the checksum format.
  - Verifies the downloaded archive with `shasum -a 256` before extraction or replacement.
  - `vendor/README.md` lists the 1.51.0 SHA-256 and updated instructions.

- **Migration**
  - Get the official SHA-256 for the target libuv version from an independent source.
  - Run: `./vendor/update-libuv.sh <version> <sha256>`

<sup>Written for commit 3ef327fe2feb1ae8bcb998fbf228e7af7415234c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/63?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

