### PR TITLE
Stabilize vectorcall references during handle execution

### DIFF
--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -81,6 +81,22 @@ async def test_cancelled_callback_does_not_run() -> None:
     assert seen == []
 
 
+async def test_callback_can_cancel_its_own_handle_during_vectorcall() -> None:
+    loop = running_loop()
+    handles: list[asyncio.Handle] = []
+    seen: list[tuple[int, ...]] = []
+
+    def callback(*args: int) -> None:
+        handles[0].cancel()
+        seen.append(args)
+
+    handles.append(loop.call_soon(callback, 1, 2, 3, 4, 5, 6))
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert seen == [(1, 2, 3, 4, 5, 6)]
+    assert handles[0].cancelled()
+
+
 async def test_handle_repr_names_the_callback() -> None:
     loop = running_loop()
     handle = loop.call_soon(print)

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -81,19 +81,20 @@ async def test_cancelled_callback_does_not_run() -> None:
     assert seen == []
 
 
-async def test_callback_can_cancel_its_own_handle_during_vectorcall() -> None:
+@pytest.mark.parametrize("args", [(1, 2, 3), (1, 2, 3, 4, 5, 6)])
+async def test_callback_can_cancel_its_own_handle_during_vectorcall(args: tuple[int, ...]) -> None:
     loop = running_loop()
     handles: list[asyncio.Handle] = []
     seen: list[tuple[int, ...]] = []
 
-    def callback(*args: int) -> None:
+    def callback(*received: int) -> None:
         handles[0].cancel()
-        seen.append(args)
+        seen.append(received)
 
-    handles.append(loop.call_soon(callback, 1, 2, 3, 4, 5, 6))
+    handles.append(loop.call_soon(callback, *args))
     await asyncio.sleep(0)
     await asyncio.sleep(0)
-    assert seen == [(1, 2, 3, 4, 5, 6)]
+    assert seen == [args]
     assert handles[0].cancelled()
 
 

--- a/zig/handle.zig
+++ b/zig/handle.zig
@@ -17,6 +17,7 @@ const inline_args = 3;
 const arg_alloc = std.heap.c_allocator;
 
 pub const CANCELLED: u32 = 1 << 0;
+const RUNNING: u32 = 1 << 1;
 
 pub const Handle = extern struct {
     ob_base: c.PyObject,
@@ -86,28 +87,15 @@ pub fn create(
 pub fn run(self: *Handle) void {
     if (self.isCancelled()) return;
     const callback = self.callback orelse return;
-    py.incref(callback);
-    defer py.decref(callback);
-
-    // cancel() is allowed to run reentrantly from the callback. Vectorcall only
-    // borrows its input array, so hold a private reference to every argument
-    // until the call has returned rather than exposing the handle's clearable
-    // storage directly.
-    const nargs: usize = @intCast(self.nargs);
-    var inline_storage: [inline_args]?*py.Object = undefined;
-    const stable = if (nargs <= inline_args) inline_storage[0..nargs] else arg_alloc.alloc(?*py.Object, nargs) catch {
-        _ = c.PyErr_NoMemory();
-        loopmod.callbackFailed(self.loop, @ptrCast(self));
-        return;
-    };
-    defer if (nargs > inline_args) arg_alloc.free(stable);
-    for (self.argv()[0..nargs], 0..) |arg, i| {
-        py.incref(arg.?);
-        stable[i] = arg;
+    self.flags |= RUNNING;
+    defer {
+        self.flags &= ~RUNNING;
+        if (self.isCancelled()) {
+            clearArgs(self);
+            py.clear(&self.callback);
+        }
     }
-    defer for (stable) |arg| py.decref(arg.?);
-
-    invoke(@ptrCast(self), self.loop, callback, stable.ptr, @intCast(nargs), self.context.?);
+    invoke(@ptrCast(self), self.loop, callback, self.argv(), self.nargs, self.context.?);
 }
 
 /// Calls `callback(*argv)` inside `ctx`, routing failures to `loop` with
@@ -189,8 +177,12 @@ fn cancel(self_obj: *py.Object) py.Error!*py.Object {
     const self: *Handle = @ptrCast(@alignCast(self_obj));
     if (!self.isCancelled()) {
         self.flags |= CANCELLED;
-        clearArgs(self);
-        py.clear(&self.callback);
+        // Vectorcall borrows these references. A callback may cancel its own
+        // handle, so release them when run() regains control instead.
+        if (self.flags & RUNNING == 0) {
+            clearArgs(self);
+            py.clear(&self.callback);
+        }
     }
     return py.noneRef();
 }

--- a/zig/handle.zig
+++ b/zig/handle.zig
@@ -86,7 +86,28 @@ pub fn create(
 pub fn run(self: *Handle) void {
     if (self.isCancelled()) return;
     const callback = self.callback orelse return;
-    invoke(@ptrCast(self), self.loop, callback, self.argv(), self.nargs, self.context.?);
+    py.incref(callback);
+    defer py.decref(callback);
+
+    // cancel() is allowed to run reentrantly from the callback. Vectorcall only
+    // borrows its input array, so hold a private reference to every argument
+    // until the call has returned rather than exposing the handle's clearable
+    // storage directly.
+    const nargs: usize = @intCast(self.nargs);
+    var inline_storage: [inline_args]?*py.Object = undefined;
+    const stable = if (nargs <= inline_args) inline_storage[0..nargs] else arg_alloc.alloc(?*py.Object, nargs) catch {
+        _ = c.PyErr_NoMemory();
+        loopmod.callbackFailed(self.loop, @ptrCast(self));
+        return;
+    };
+    defer if (nargs > inline_args) arg_alloc.free(stable);
+    for (self.argv()[0..nargs], 0..) |arg, i| {
+        py.incref(arg.?);
+        stable[i] = arg;
+    }
+    defer for (stable) |arg| py.decref(arg.?);
+
+    invoke(@ptrCast(self), self.loop, callback, stable.ptr, @intCast(nargs), self.context.?);
 }
 
 /// Calls `callback(*argv)` inside `ctx`, routing failures to `loop` with
@@ -179,7 +200,6 @@ fn cancelled(self_obj: *py.Object) py.Error!*py.Object {
     return py.boolRef(self.isCancelled());
 }
 
-
 fn getCallback(self_obj: ?*py.Object, _: ?*anyopaque) callconv(.c) ?*py.Object {
     const self: *Handle = @ptrCast(@alignCast(self_obj.?));
     return py.newref(self.callback orelse py.none());
@@ -242,7 +262,6 @@ var handle_spec = c.PyType_Spec{
     .flags = flags,
     .slots = &handle_slots,
 };
-
 
 pub fn register(module: *py.Object) py.Error!void {
     handle_type = @ptrCast(c.PyType_FromModuleAndSpec(module, &handle_spec, null) orelse return py.Error.Python);


### PR DESCRIPTION
Mark a Handle as running around vectorcall and defer cancel()’s callback/argument cleanup until control returns. Reentrant cancellation still takes effect immediately, but the borrowed pointers passed to PyObject_Vectorcall remain owned by the Handle for the full call without copying references or allocating on the callback hot path.

Finding: https://chatgpt.com/codex/cloud/security/findings/7ce35300322c81919bcbcdc344e16258

Tests: uv run python scripts/build.py; uv run pytest tests/test_scheduling.py::test_callback_can_cancel_its_own_handle_during_vectorcall tests/test_scheduling.py::test_cancelled_callback_does_not_run; uv run ruff check tests/test_scheduling.py; uv run mypy tests/test_scheduling.py