### PR TITLE
Clean up loop state when metrics start fails

### DIFF
--- a/tests/test_instrumentation.py
+++ b/tests/test_instrumentation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 import time
 from collections.abc import Mapping
 
@@ -407,6 +408,23 @@ async def test_the_sampling_interval_must_be_positive() -> None:
     loop = running_loop()
     with pytest.raises(ValueError, match="must be positive"):
         loop._start_metrics(0, print)
+
+
+def test_a_failed_metrics_start_restores_running_loop_state() -> None:
+    loop = zuvloop.new_event_loop()
+    old_hooks = sys.get_asyncgen_hooks()
+    loop.metrics_interval = 0
+    try:
+        with pytest.raises(ValueError, match="must be positive"):
+            loop.run_forever()
+        assert asyncio.events._get_running_loop() is None
+        assert sys.get_asyncgen_hooks() == old_hooks
+
+        loop.metrics_interval = 0.01
+        loop.call_soon(loop.stop)
+        loop.run_forever()
+    finally:
+        loop.close()
 
 
 async def test_a_failing_sampler_callback_is_reported() -> None:

--- a/zuvloop/_base.py
+++ b/zuvloop/_base.py
@@ -106,9 +106,9 @@ class LoopBase(_zuvloop.Loop, asyncio.AbstractEventLoop):  # type: ignore[misc]
         sys.set_asyncgen_hooks(firstiter=self._asyncgen_firstiter, finalizer=self._asyncgen_finalizer)
         self._monitoring_armed = instrumentation_provider_installed()
         self._metrics_armed = metrics_provider_installed()
-        self._set_slow_callback_monitoring(self._monitoring_armed)
-        self._start_metrics(self.metrics_interval, self._on_sample)
         try:
+            self._set_slow_callback_monitoring(self._monitoring_armed)
+            self._start_metrics(self.metrics_interval, self._on_sample)
             self._run()
         finally:
             self._set_slow_callback_monitoring(False)


### PR DESCRIPTION
Put slow-monitoring and metrics startup inside run_forever()’s existing cleanup boundary. If an invalid interval or another startup error is raised, the loop now stops native instrumentation, restores async-generator hooks, clears the thread’s running-loop pointer, and detaches wakeup state before propagating it.

Finding: https://chatgpt.com/codex/cloud/security/findings/fd51612531848191987fd4582733553a

Tests: uv run pytest tests/test_instrumentation.py::test_a_failed_metrics_start_restores_running_loop_state; uv run ruff check zuvloop/_base.py tests/test_instrumentation.py; uv run mypy zuvloop/_base.py tests/test_instrumentation.py

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the event loop cleans up correctly when metrics startup fails in `run_forever()`, preventing leaked asyncgen hooks and a stale "running loop" pointer after a bad `metrics_interval`.

- **Bug Fixes**
  - Moved slow-callback monitoring and metrics startup under the `run_forever()` try/finally so cleanup always runs.
  - On startup errors (e.g., non-positive `metrics_interval`), we stop native instrumentation, restore async-generator hooks, clear the running-loop pointer, and detach wakeup state before re-raising.
  - Added `test_a_failed_metrics_start_restores_running_loop_state` to verify cleanup behavior.

<sup>Written for commit 4e96a1ffd503be23d3c7341f4b0eaecc5f86e45c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/65?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

