### PR TITLE
Compare IPv6 flowinfo for connected datagrams

### DIFF
--- a/tests/test_datagram.py
+++ b/tests/test_datagram.py
@@ -354,6 +354,8 @@ async def test_a_connected_v6_endpoint_tells_the_scope_apart() -> None:
             assert await asyncio.wait_for(protocol.done, 2) == b"re:v6"
             with pytest.raises(ValueError, match="connected"):
                 client.sendto(b"v6", (host, port, 0, 1))
+            with pytest.raises(ValueError, match="connected"):
+                client.sendto(b"v6", (host, port, 1, 0))
         finally:
             client.close()
     finally:

--- a/zig/addr.zig
+++ b/zig/addr.zig
@@ -146,9 +146,9 @@ pub fn same(a: *const posix.sockaddr, a_len: c_int, b: *const posix.sockaddr, b_
         const x: *const posix.sockaddr.in6 = @ptrCast(@alignCast(a));
         const y: *const posix.sockaddr.in6 = @ptrCast(@alignCast(b));
         if (x.port != y.port or !std.mem.eql(u8, &x.addr, &y.addr)) return false;
-        // asyncio compares tuples, so it wants the scope stated rather than
-        // treating a zero as a wildcard.
-        return x.scope_id == y.scope_id;
+        // asyncio compares the complete tuples, so both ancillary fields must
+        // be stated exactly rather than treating zero as a wildcard.
+        return x.flowinfo == y.flowinfo and x.scope_id == y.scope_id;
     }
     return false;
 }


### PR DESCRIPTION
Include flowinfo alongside address, port, and scope ID when deciding whether an explicit IPv6 sendto address equals the connected peer. This matches asyncio’s complete tuple validation; the kernel destination remains the connected peer either way.

Finding: https://chatgpt.com/codex/cloud/security/findings/00c40ca930508191be9d4091eeee4414

Tests: uv run python scripts/build.py; uv run pytest tests/test_datagram.py::test_a_connected_v6_endpoint_tells_the_scope_apart; uv run ruff check tests/test_datagram.py; uv run mypy tests/test_datagram.py

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include IPv6 flowinfo in the equality check for connected datagram destinations. This matches `asyncio`’s full tuple validation and rejects sends with mismatched flowinfo or scope.

- **Bug Fixes**
  - Compare `flowinfo` and `scope_id` in `sockaddr_in6` when checking address equality.
  - Extend test to assert `sendto` raises `ValueError` on mismatched scope or flowinfo.

<sup>Written for commit c998a4f4aa3a340100e2681605262094717f550e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/66?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

