### PR TITLE
Recheck EOF state when submitting writes

### DIFF
--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -440,6 +440,24 @@ async def test_reentrant_writelines_cannot_queue_data_after_eof() -> None:
         await protocol.done
 
 
+async def test_reentrant_buffer_acquisition_cannot_queue_data_after_eof() -> None:
+    server, port, _ = await start_echo()
+    loop = running_loop()
+    async with server:
+        transport, protocol = await loop.create_connection(Collector, "127.0.0.1", port)
+
+        class EofDuringBuffer:
+            def __buffer__(self, flags: int) -> memoryview:
+                transport.write_eof()
+                return memoryview(b"too late")
+
+        with pytest.raises(RuntimeError, match="write_eof"):
+            transport.writelines([EofDuringBuffer()])  # type: ignore[list-item]
+        transport.close()
+        assert protocol.done is not None
+        await protocol.done
+
+
 async def test_writes_after_close_are_dropped() -> None:
     """asyncio drops them; only `write_eof()` makes a later write an error."""
     server, port, echoes = await start_echo()

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -7,7 +7,7 @@ import socket
 import ssl
 import struct
 import tempfile
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from pathlib import Path
 
 import pytest
@@ -417,6 +417,24 @@ async def test_writes_after_write_eof_are_rejected() -> None:
             transport.writelines([b"too late"])
         with pytest.raises(RuntimeError, match=r"Cannot call writelines\(\) after write_eof"):
             transport.writelines([])
+        transport.close()
+        assert protocol.done is not None
+        await protocol.done
+
+
+async def test_reentrant_writelines_cannot_queue_data_after_eof() -> None:
+    server, port, _ = await start_echo()
+    loop = running_loop()
+    async with server:
+        transport, protocol = await loop.create_connection(Collector, "127.0.0.1", port)
+
+        class EofDuringIteration:
+            def __iter__(self) -> Iterator[bytes]:
+                transport.write_eof()
+                yield b"too late"
+
+        with pytest.raises(RuntimeError, match="write_eof"):
+            transport.writelines(EofDuringIteration())
         transport.close()
         assert protocol.done is not None
         await protocol.done

--- a/zig/transport.zig
+++ b/zig/transport.zig
@@ -550,9 +550,13 @@ fn queueWrite(self: *Transport, bufs: []const uv.Buf, views: []c.Py_buffer) py.E
 /// Whether a write may proceed, releasing `views` if it may not.
 ///
 /// A close only drops the data; raising would turn an ordinary shutdown race
-/// into an exception. `write_eof()` is the caller's mistake and each entry point
-/// rejects it earlier, so an empty write is an error too.
+/// into an exception. `write_eof()` is the caller's mistake, and must be checked
+/// here too because acquiring an iterable or buffer can reenter the transport.
 fn acceptsWrite(self: *Transport, views: []c.Py_buffer) py.Error!bool {
+    if (self.flags & EOF_WRITTEN != 0) {
+        releaseViews(views);
+        return py.errRuntime("Cannot write after write_eof()");
+    }
     if (self.flags & (CONN_LOST | CLOSING) != 0) {
         releaseViews(views);
         return false;


### PR DESCRIPTION
Make the shared write-acceptance gate reject EOF_WRITTEN, not just the public entry points. Materializing a writelines iterable or acquiring one of its buffers can execute reentrant code; if that code calls write_eof(), the eventual submit now releases its views and raises instead of queueing bytes after EOF.

Finding: https://chatgpt.com/codex/cloud/security/findings/4e077e6b88b8819182cab05dac2a0172

Tests: uv run python scripts/build.py; uv run pytest tests/test_network.py::test_reentrant_writelines_cannot_queue_data_after_eof tests/test_network.py::test_writes_after_write_eof_are_rejected; uv run ruff check tests/test_network.py; uv run mypy tests/test_network.py

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects writes after `write_eof()` in the shared write path, even if EOF is triggered reentrantly during `writelines` iteration or buffer acquisition. Prevents queuing bytes after EOF by releasing views and raising `RuntimeError`.

- **Bug Fixes**
  - Check EOF in the shared write-acceptance gate to catch reentrant `write_eof()` in iterators and `__buffer__`.
  - On EOF, release `Py_buffer` views and raise `RuntimeError("Cannot write after write_eof()")`.
  - Added tests: `test_reentrant_writelines_cannot_queue_data_after_eof`, `test_reentrant_buffer_acquisition_cannot_queue_data_after_eof`.

<sup>Written for commit dc7be1a252696c7af08d4792f6ac5d8988d753a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/67?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

