### PR TITLE
Reuse the failing uv_udp_open status

### DIFF
--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -44,6 +44,15 @@ def test_failed_transport_open_does_not_corrupt_the_loop() -> None:
         loop.close()
 
 
+def test_failed_datagram_open_does_not_reopen_the_closing_handle() -> None:
+    loop = zuvloop.new_event_loop()
+    try:
+        with pytest.raises(OSError):
+            loop._make_datagram_transport(-1, socket.AF_INET, False, asyncio.DatagramProtocol(), {})
+    finally:
+        loop.close()
+
+
 def test_failed_transport_open_does_not_retain_the_loop() -> None:
     loop = zuvloop.new_event_loop()
     loop_ref = weakref.ref(loop)

--- a/zig/datagram.zig
+++ b/zig/datagram.zig
@@ -596,12 +596,13 @@ pub fn makeDatagram(self_obj: *py.Object, args: []const ?*py.Object) py.Error!*p
     self.flags |= OPEN;
     uv.setData(self.udp(), self);
 
-    if (uv.uv_udp_open(self.udp(), fd) < 0) {
+    const status = uv.uv_udp_open(self.udp(), fd);
+    if (status < 0) {
         // libuv never took the descriptor, so the caller still owns it.
         self.flags &= ~OPEN;
         py.incref(obj);
         uv.uv_close(uv.asHandle(self.udp()), onOpenFailed);
-        return py.errUv(uv.uv_udp_open(self.udp(), fd));
+        return py.errUv(status);
     }
 
     py.incref(obj);
@@ -704,11 +705,11 @@ var methods = [_]c.PyMethodDef{
 };
 
 var slots = [_]c.PyType_Slot{
-    .{ .slot = c.Py_tp_dealloc, .pfunc = @constCast(@ptrCast(&dealloc)) },
-    .{ .slot = c.Py_tp_traverse, .pfunc = @constCast(@ptrCast(&traverse)) },
-    .{ .slot = c.Py_tp_clear, .pfunc = @constCast(@ptrCast(&clear_)) },
+    .{ .slot = c.Py_tp_dealloc, .pfunc = @ptrCast(@constCast(&dealloc)) },
+    .{ .slot = c.Py_tp_traverse, .pfunc = @ptrCast(@constCast(&traverse)) },
+    .{ .slot = c.Py_tp_clear, .pfunc = @ptrCast(@constCast(&clear_)) },
     .{ .slot = c.Py_tp_methods, .pfunc = @ptrCast(&methods) },
-    .{ .slot = c.Py_tp_doc, .pfunc = @constCast(@ptrCast("A libuv-backed datagram transport.")) },
+    .{ .slot = c.Py_tp_doc, .pfunc = @ptrCast(@constCast("A libuv-backed datagram transport.")) },
     .{ .slot = 0, .pfunc = null },
 };
 


### PR DESCRIPTION
Save the first uv_udp_open return value and use it to construct the Python exception after scheduling handle closure. The failure path no longer invokes uv_udp_open a second time on a handle already marked closing.

Finding: https://chatgpt.com/codex/cloud/security/findings/51be6f475b4481918b86177f8c5c74e6

Tests: uv run python scripts/build.py; uv run pytest tests/test_lifecycle.py::test_failed_datagram_open_does_not_reopen_the_closing_handle; uv run ruff check tests/test_lifecycle.py; uv run mypy tests/test_lifecycle.py

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reuse the first `uv_udp_open` error when a datagram open fails and raise after scheduling the handle close. This prevents a second `uv_udp_open` on a closing UDP handle and avoids reopening attempts.

- **Bug Fixes**
  - Store the initial `uv_udp_open` result and pass it to `py.errUv` instead of calling `uv_udp_open` again.
  - Add `test_failed_datagram_open_does_not_reopen_the_closing_handle` to prevent regressions.

- **Refactors**
  - Normalize `PyType_Slot` casts to fix constness/casting correctness.

<sup>Written for commit fd18f0221c9c262587fc6caa4faffa145a829b5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/68?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

