### PR TITLE
Skip call graph formatting for completed tasks

### DIFF
--- a/tests/test_instrumentation.py
+++ b/tests/test_instrumentation.py
@@ -432,6 +432,13 @@ async def test_metrics_on_a_closed_loop_are_zero() -> None:
     assert loop._metrics()["loop_count"] == 0
 
 
+async def test_completed_tasks_have_no_call_graph(monkeypatch: pytest.MonkeyPatch) -> None:
+    task = asyncio.create_task(asyncio.sleep(0))
+    await task
+    monkeypatch.setattr(asyncio, "current_task", lambda: task)
+    assert capture_call_graph() is None
+
+
 async def test_the_stdlib_call_graph_apis_work_on_this_loop() -> None:
     """3.14's introspection reads real asyncio.Task objects, which is what zuvloop schedules."""
     import io

--- a/tests/test_instrumentation.py
+++ b/tests/test_instrumentation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import Mapping
+from types import MethodType
 
 import pytest
 from opentelemetry.trace import StatusCode
@@ -432,11 +433,15 @@ async def test_metrics_on_a_closed_loop_are_zero() -> None:
     assert loop._metrics()["loop_count"] == 0
 
 
-async def test_completed_tasks_have_no_call_graph(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_completed_task_recovered_from_a_handle_has_no_call_graph() -> None:
     task = asyncio.create_task(asyncio.sleep(0))
     await task
-    monkeypatch.setattr(asyncio, "current_task", lambda: task)
-    assert capture_call_graph() is None
+    callback = MethodType(lambda _task: None, task)
+    handle = running_loop().call_soon(callback)
+    try:
+        assert capture_call_graph(handle) is None
+    finally:
+        handle.cancel()
 
 
 async def test_the_stdlib_call_graph_apis_work_on_this_loop() -> None:

--- a/zuvloop/_instrumentation.py
+++ b/zuvloop/_instrumentation.py
@@ -99,7 +99,7 @@ def capture_call_graph(handle: object = None) -> str | None:
     task = getattr(getattr(handle, "_callback", None), "__self__", None)
     if not isinstance(task, asyncio.Task):
         task = asyncio.current_task()
-    if task is None:
+    if task is None or task.done():
         return None
     return asyncio.format_call_graph(task)
 


### PR DESCRIPTION
Treat a completed task like an absent task when constructing slow-callback call graphs. A final Task step can cross the threshold and finish before reporting runs; its coroutine frame is already gone, so asyncio.format_call_graph has nothing valid to format.

Finding: https://chatgpt.com/codex/cloud/security/findings/4f052ed5ab588191b2e1c1f648823a43

Tests: uv run pytest tests/test_instrumentation.py::test_completed_tasks_have_no_call_graph; uv run ruff check zuvloop/_instrumentation.py tests/test_instrumentation.py; uv run mypy zuvloop/_instrumentation.py tests/test_instrumentation.py

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip call graph formatting for completed `asyncio.Task`s in slow-callback instrumentation. Prevents invalid call graphs when a task finishes before reporting and avoids formatting cleared frames.

- **Bug Fixes**
  - `capture_call_graph()` now returns `None` when the task is missing or `done()`.
  - Added tests `test_completed_tasks_have_no_call_graph` and `test_completed_task_recovered_from_a_handle_has_no_call_graph` to cover both direct tasks and tasks recovered from a handle.

<sup>Written for commit 8e22a435b6943068080d4bdd858982380ca99add. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/69?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

