### PR TITLE
Stop draining the self-pipe at EOF

### DIFF
--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -28,6 +28,16 @@ def test_run_returns_the_coroutine_result() -> None:
     assert zuvloop.run(main()) == "done"
 
 
+def test_self_pipe_drain_stops_at_eof() -> None:
+    loop = zuvloop.new_event_loop()
+    try:
+        loop.remove_reader(loop._ssock.fileno())
+        loop._csock.close()
+        loop._drain_self_pipe(loop._ssock)
+    finally:
+        loop.close()
+
+
 def test_run_honours_debug_mode() -> None:
     async def main() -> bool:
         return running_loop().get_debug()

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -28,14 +28,25 @@ def test_run_returns_the_coroutine_result() -> None:
     assert zuvloop.run(main()) == "done"
 
 
-def test_self_pipe_drain_stops_at_eof() -> None:
+def test_self_pipe_drain_stops_watching_at_eof() -> None:
     loop = zuvloop.new_event_loop()
-    try:
-        loop.remove_reader(loop._ssock.fileno())
-        loop._csock.close()
-        loop._drain_self_pipe(loop._ssock)
-    finally:
-        loop.close()
+    errors: list[BaseException] = []
+
+    def run() -> None:
+        try:
+            loop.run_forever()
+        except BaseException as exc:
+            errors.append(exc)
+
+    loop._csock.close()
+    loop.call_later(0.02, loop.stop)
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    thread.join(1)
+    assert not thread.is_alive(), "event loop kept polling the self-pipe at EOF"
+    assert errors == []
+    assert loop.remove_reader(loop._ssock.fileno()) is False
+    loop.close()
 
 
 def test_run_honours_debug_mode() -> None:

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -43,10 +43,15 @@ def test_self_pipe_drain_stops_watching_at_eof() -> None:
     thread = threading.Thread(target=run, daemon=True)
     thread.start()
     thread.join(1)
-    assert not thread.is_alive(), "event loop kept polling the self-pipe at EOF"
-    assert errors == []
-    assert loop.remove_reader(loop._ssock.fileno()) is False
-    loop.close()
+    try:
+        assert not thread.is_alive(), "event loop kept polling the self-pipe at EOF"
+        assert errors == []
+        assert loop.remove_reader(loop._ssock.fileno()) is False
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(1)
+        if not loop.is_running():  # pragma: no branch - watchdog failure may leave a daemon spinning
+            loop.close()
 
 
 def test_run_honours_debug_mode() -> None:

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -35,7 +35,7 @@ def test_self_pipe_drain_stops_watching_at_eof() -> None:
     def run() -> None:
         try:
             loop.run_forever()
-        except BaseException as exc:
+        except BaseException as exc:  # pragma: no cover - assertion diagnostic
             errors.append(exc)
 
     loop._csock.close()

--- a/zuvloop/_base.py
+++ b/zuvloop/_base.py
@@ -345,6 +345,9 @@ class LoopBase(_zuvloop.Loop, asyncio.AbstractEventLoop):  # type: ignore[misc]
             while True:
                 data = sock.recv(4096)
                 if not data:
+                    # EOF remains level-triggered readable forever. Stop
+                    # watching this dead pipe or the loop will spin on it.
+                    self.remove_reader(sock.fileno())
                     break
                 for signum in data:
                     self._dispatch_signal(signum)

--- a/zuvloop/_base.py
+++ b/zuvloop/_base.py
@@ -343,7 +343,10 @@ class LoopBase(_zuvloop.Loop, asyncio.AbstractEventLoop):  # type: ignore[misc]
         """
         try:
             while True:
-                for signum in sock.recv(4096):
+                data = sock.recv(4096)
+                if not data:
+                    break
+                for signum in data:
                     self._dispatch_signal(signum)
         except BlockingIOError, InterruptedError:
             pass


### PR DESCRIPTION
Handle recv() returning empty bytes as EOF in the loop self-pipe callback. Once the writer is closed, the readable socket now leaves the drain loop instead of spinning forever on repeated empty reads.

Finding: https://chatgpt.com/codex/cloud/security/findings/ec210492734481919ec2e0dedf18895b

Tests: uv run pytest tests/test_lifecycle.py::test_self_pipe_drain_stops_at_eof; uv run ruff check zuvloop/_base.py tests/test_lifecycle.py; uv run mypy zuvloop/_base.py tests/test_lifecycle.py

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix a busy-loop in `zuvloop`’s `_drain_self_pipe` by treating empty `recv()` as EOF, removing the self-pipe reader, and exiting. Stops infinite spinning/high CPU, always cleans up the self-pipe watchdog loop, adds a test asserting the reader is removed and the loop stops, and excludes watchdog diagnostics from coverage.

<sup>Written for commit f1e473a228135db2b52df615a81d0c7accd2943a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/70?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

