### PR TITLE
Enforce Zig formatting and safety linting in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,26 @@ jobs:
           fi
           rm -f zuvloop/_zuvloop.cpucheck-*.so
 
-      - name: Lint
+      - name: Lint and format Python
         run: |
           uv run ruff check
           uv run ruff format --check
+
+      - name: Install ZLint
+        if: runner.os == 'Linux'
+        run: |
+          curl -fsSL \
+            https://github.com/DonIsaac/zlint/releases/download/v0.9.1/zlint-linux-x86_64 \
+            -o /tmp/zlint
+          printf '%s  %s\n' \
+            3290bd511d37e4f6ccca3621b9894cd6c378195cdaac27520d0bd894058b2b9b \
+            /tmp/zlint | sha256sum -c -
+          chmod +x /tmp/zlint
+          echo /tmp >> "$GITHUB_PATH"
+
+      - name: Lint and format Zig
+        if: runner.os == 'Linux'
+        run: ./scripts/check-zig
 
       - name: Type check
         run: uv run mypy

--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ $ uv pip install -e . --group dev
 $ uv run pytest
 $ uv run mypy
 $ uv run ruff check
+$ uv run ruff format --check
+$ ./scripts/check-zig  # requires ZLint 0.9.1 on PATH
 $ uv run --group bench python benchmarks/run.py
 ```
 

--- a/scripts/check-zig
+++ b/scripts/check-zig
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Enforce Zig's canonical formatting and the repository's ZLint rules.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root"
+
+zig fmt --check build.zig zig
+{
+    printf '%s\n' build.zig
+    find zig -type f -name '*.zig' -print | sort
+} | zlint --stdin --deny-warnings

--- a/scripts/check-zig
+++ b/scripts/check-zig
@@ -5,6 +5,24 @@ set -euo pipefail
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$root"
 
+if ! command -v zig >/dev/null; then
+    echo "zig 0.16.0 is required; install it from https://ziglang.org/download/" >&2
+    exit 2
+fi
+if [[ "$(zig version)" != "0.16.0" ]]; then
+    echo "zig 0.16.0 is required to match CI (found $(zig version))" >&2
+    exit 2
+fi
+if ! command -v zlint >/dev/null; then
+    echo "ZLint v0.9.1 is required; download it from https://github.com/DonIsaac/zlint/releases/tag/v0.9.1" >&2
+    echo "CI pins the Linux x86_64 binary to SHA-256 3290bd511d37e4f6ccca3621b9894cd6c378195cdaac27520d0bd894058b2b9b" >&2
+    exit 2
+fi
+if [[ "$(zlint --version)" != "v0.9.1" ]]; then
+    echo "ZLint v0.9.1 is required to match CI (found $(zlint --version))" >&2
+    exit 2
+fi
+
 zig fmt --check build.zig zig
 {
     printf '%s\n' build.zig

--- a/zig/addr.zig
+++ b/zig/addr.zig
@@ -35,6 +35,7 @@ fn tupleItem(t: *py.Object, i: c.Py_ssize_t) py.Error!*py.Object {
 pub fn fromPython(family: c_int, address: *py.Object, out: *Storage) py.Error!c_int {
     out.* = .{};
     if (family == AF_UNIX) {
+        // SAFETY: each accepted address type assigns path, and every other type returns.
         var path: [*c]const u8 = undefined;
         var len: c.Py_ssize_t = 0;
         if (c.PyUnicode_Check(address) != 0) {

--- a/zig/datagram.zig
+++ b/zig/datagram.zig
@@ -392,6 +392,7 @@ fn sendto(self_obj: *py.Object, args: []const ?*py.Object, nargs: usize, kwnames
         return py.errValue("sendto() requires an address on an unconnected transport");
     }
 
+    // SAFETY: PyObject_GetBuffer initializes view or returns an error.
     var view: c.Py_buffer = undefined;
     if (c.PyObject_GetBuffer(args[0].?, &view, c.PyBUF_SIMPLE) < 0) return py.Error.Python;
     defer c.PyBuffer_Release(&view);

--- a/zig/dns.zig
+++ b/zig/dns.zig
@@ -36,7 +36,9 @@ const Request = struct {
     prev: ?*Request = null,
     next: ?*Request = null,
     hints: std.c.addrinfo = std.mem.zeroes(std.c.addrinfo),
+    // SAFETY: request construction fills this array before libuv receives it.
     host: [max_host]u8 = undefined,
+    // SAFETY: request construction fills this array before libuv receives it.
     service: [32]u8 = undefined,
 
     inline fn addrReq(self: *Request) *uv.GetAddrInfo {
@@ -117,6 +119,7 @@ pub fn traverse(st: *loopmod.State, visitproc: c.visitproc, arg: ?*anyopaque) c_
 fn copyZ(dst: []u8, value: *py.Object, what: [:0]const u8) py.Error!?[*:0]const u8 {
     if (py.isNone(value)) return null;
     var len: c.Py_ssize_t = 0;
+    // SAFETY: each accepted Python type assigns src, and every other type returns.
     var src: [*c]const u8 = undefined;
     if (c.PyUnicode_Check(value) != 0) {
         src = c.PyUnicode_AsUTF8AndSize(value, &len) orelse return py.Error.Python;
@@ -368,6 +371,8 @@ fn resolveLiteral(hints: *const std.c.addrinfo, host: ?[*:0]const u8, service: ?
         port = std.fmt.parseInt(u16, text, 10) catch return null;
     }
 
+    // SAFETY: inet_pton initializes the address and the successful branch fills
+    // the remaining sockaddr fields before storage is read.
     var storage: addr.Storage = undefined;
     const family = hints.family;
     if (family == std.c.AF.INET or family == std.c.AF.UNSPEC) {

--- a/zig/process.zig
+++ b/zig/process.zig
@@ -347,11 +347,11 @@ var methods = [_]c.PyMethodDef{
 };
 
 var slots = [_]c.PyType_Slot{
-    .{ .slot = c.Py_tp_dealloc, .pfunc = @constCast(@ptrCast(&dealloc)) },
-    .{ .slot = c.Py_tp_traverse, .pfunc = @constCast(@ptrCast(&traverse)) },
-    .{ .slot = c.Py_tp_clear, .pfunc = @constCast(@ptrCast(&clear_)) },
+    .{ .slot = c.Py_tp_dealloc, .pfunc = @ptrCast(@constCast(&dealloc)) },
+    .{ .slot = c.Py_tp_traverse, .pfunc = @ptrCast(@constCast(&traverse)) },
+    .{ .slot = c.Py_tp_clear, .pfunc = @ptrCast(@constCast(&clear_)) },
     .{ .slot = c.Py_tp_methods, .pfunc = @ptrCast(&methods) },
-    .{ .slot = c.Py_tp_doc, .pfunc = @constCast(@ptrCast("A libuv-backed child process.")) },
+    .{ .slot = c.Py_tp_doc, .pfunc = @ptrCast(@constCast("A libuv-backed child process.")) },
     .{ .slot = 0, .pfunc = null },
 };
 

--- a/zig/transport.zig
+++ b/zig/transport.zig
@@ -186,6 +186,7 @@ fn acquireWriteView(data: *py.Object, view: *c.Py_buffer) py.Error!void {
         return;
     }
 
+    // SAFETY: PyObject_GetBuffer initializes source or returns an error.
     var source: c.Py_buffer = undefined;
     if (c.PyObject_GetBuffer(data, &source, c.PyBUF_SIMPLE) < 0) return py.Error.Python;
     defer c.PyBuffer_Release(&source);
@@ -895,6 +896,7 @@ pub fn startReadingMethod(self_obj: *py.Object) py.Error!*py.Object {
 
 fn write(self_obj: *py.Object, data: *py.Object) py.Error!*py.Object {
     const self = asTransport(self_obj);
+    // SAFETY: acquireWriteView initializes the only element or returns an error.
     var views = [_]c.Py_buffer{undefined};
     try acquireWriteView(data, &views[0]);
     if (self.flags & EOF_WRITTEN != 0) {

--- a/zlint.json
+++ b/zlint.json
@@ -1,0 +1,13 @@
+{
+  "rules": {
+    "avoid-as": "error",
+    "empty-file": "error",
+    "homeless-try": "error",
+    "must-return-ref": "error",
+    "no-catch-return": "error",
+    "no-unresolved": "error",
+    "returned-stack-reference": "error",
+    "unsafe-undefined": "error",
+    "useless-error-return": "error"
+  }
+}


### PR DESCRIPTION
Add the missing Zig quality gate beside the existing Python Ruff checks.

- enforce canonical formatting with `zig fmt --check build.zig zig`
- run ZLint 0.9.1 from a checksum-pinned release binary
- lint only project Zig (`build.zig` and `zig/`), never vendored libuv
- enable a conservative correctness/safety rule set, including unresolved imports, returned stack references, capacity-bearing copies, and unsafe `undefined`
- document every intentional `undefined` initialization with its safety invariant
- expose the same checks locally through `./scripts/check-zig`
- bring the one pre-existing `zig fmt` difference back to canonical form

I evaluated the active Zig linters: ZLint is actively maintained, supports Zig 0.16, ships standalone binaries, and has an independent semantic analyzer. `zlinter` is also credible and more customizable, but requires integrating the linter into `build.zig`; ZLint keeps production builds independent of the lint tool. The older `nektro/ziglint` documentation still targets Zig 0.11/Zigmod.

Validation:
- `./scripts/check-zig`: 0 errors/warnings across 16 files
- Ruff lint + format check
- strict mypy
- native rebuild
- full suite: 415 passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Zig quality gate to CI to enforce canonical formatting and safety linting, with pinned tool versions. Also provides a local `./scripts/check-zig` that verifies tool versions and runs the same checks.

- **New Features**
  - CI (Linux) installs checksum-verified `zlint` v0.9.1 and runs `./scripts/check-zig`.
  - Local `./scripts/check-zig` requires `zig` 0.16.0 and `zlint` v0.9.1, then runs `zig fmt --check` and `zlint --deny-warnings` on project Zig (`build.zig`, `zig/`), excluding vendored libuv.
  - Adds `zlint.json` with conservative correctness/safety rules; README updated with local usage.

- **Refactors**
  - Documents safety invariants for `undefined` and buffer initializations; fixes one `zig fmt` drift.
  - Simplifies pointer casts in `zig/process.zig` to satisfy linting.

<sup>Written for commit 8bf9a8bb3ac25ddc27ccc3a955373de05907c25c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/72?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

