### PR TITLE
Disarm socket views before native close

### DIFF
--- a/tests/test_datagram.py
+++ b/tests/test_datagram.py
@@ -250,6 +250,8 @@ async def test_an_existing_socket_can_be_adopted() -> None:
         client.sendto(b"adopted", address)
         assert protocol.done is not None
         assert await asyncio.wait_for(protocol.done, 2) == b"re:adopted"
+        client.close()
+        assert sock.fileno() == -1
     finally:
         client.close()
         server.close()

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -761,6 +761,7 @@ async def test_create_connection_from_an_existing_socket() -> None:
         await asyncio.sleep(0.05)
         assert protocol.received == b"via sock"
         transport.close()
+        assert sock.fileno() == -1
         assert protocol.done is not None
         await protocol.done
 

--- a/tests/test_pipes.py
+++ b/tests/test_pipes.py
@@ -82,11 +82,9 @@ async def test_closing_a_transport_closes_its_pipe() -> None:
     read_transport.close()
     write_transport.close()
 
-    async def until_both_close() -> None:
-        while not (reader_file.closed and writer_file.closed):
+    async with asyncio.timeout(2):
+        while not (reader_file.closed and writer_file.closed):  # pragma: no cover - close may be synchronous
             await asyncio.sleep(0.01)
-
-    await asyncio.wait_for(until_both_close(), 2)
 
 
 async def test_a_regular_file_is_rejected() -> None:

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import socket
 import ssl
 
 import pytest
 
 from conftest import collect_contexts, running_loop
+from zuvloop._server import Server
 
 pytestmark = pytest.mark.anyio
 
@@ -57,6 +59,39 @@ async def test_tls_rejects_an_untrusted_certificate(server_context: ssl.SSLConte
     finally:
         server.close()
         loop.set_exception_handler(None)
+
+
+async def test_cancelling_a_server_handshake_disarms_the_accepted_socket_before_close(
+    server_context: ssl.SSLContext,
+) -> None:
+    loop = running_loop()
+
+    class CloseTrackingSocket(socket.socket):
+        close_calls = 0
+
+        def close(self) -> None:
+            self.close_calls += 1
+            super().close()
+
+    raw, peer = socket.socketpair()
+    accepted = CloseTrackingSocket(fileno=raw.detach())
+    accepted.setblocking(False)
+    server = Server(loop, (), asyncio.Protocol, server_context, 1, None, None)
+    server._active = 1
+
+    try:
+        handshake = loop.create_task(loop._accept_tls(accepted, asyncio.Protocol, server))
+        await asyncio.sleep(0)
+        handshake.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await handshake
+        await asyncio.sleep(0)
+
+        assert accepted.close_calls == 0
+        assert accepted.fileno() == -1
+        assert server._active == 0
+    finally:
+        peer.close()
 
 
 async def test_a_failed_handshake_is_reported(server_context: ssl.SSLContext) -> None:

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -69,7 +69,7 @@ async def test_cancelling_a_server_handshake_disarms_the_accepted_socket_before_
     class CloseTrackingSocket(socket.socket):
         close_calls = 0
 
-        def close(self) -> None:
+        def close(self) -> None:  # pragma: no cover - the assertion is that this never runs
             self.close_calls += 1
             super().close()
 

--- a/zig/datagram.zig
+++ b/zig/datagram.zig
@@ -318,7 +318,6 @@ fn onClosed(handle: ?*uv.Handle) callconv(.c) void {
     st.gilEnter();
     defer st.gilExit();
 
-    releaseSocketView(self);
     self.flags |= CONN_LOST;
     scheduleCall(self, self.cb_connection_lost, self.conn_lost_exc orelse py.none());
     py.decref(self);
@@ -331,7 +330,11 @@ fn shutdownAndClose(self: *Datagram) void {
         _ = uv.uv_udp_recv_stop(self.udp());
         self.flags &= ~READING;
     }
-    uv.uv_close(uv.asHandle(self.udp()), onClosed);
+    // As with streams, uv_close closes the descriptor before its callback.
+    // Detach the Python socket while the number still names our endpoint.
+    releaseSocketView(self);
+    const handle = uv.asHandle(self.udp());
+    if (uv.uv_is_closing(handle) == 0) uv.uv_close(handle, onClosed);
 }
 
 /// Closes a datagram endpoint discovered while the owning loop shuts down.
@@ -343,7 +346,8 @@ pub fn closeFromLoop(handle: *uv.Handle) void {
         _ = uv.uv_udp_recv_stop(self.udp());
         self.flags &= ~READING;
     }
-    uv.uv_close(handle, onClosed);
+    releaseSocketView(self);
+    if (uv.uv_is_closing(handle) == 0) uv.uv_close(handle, onClosed);
 }
 
 // ---------------------------------------------------------------------------

--- a/zig/transport.zig
+++ b/zig/transport.zig
@@ -706,8 +706,9 @@ fn shutdownWrite(self: *Transport) void {
 // teardown
 
 /// libuv owns the descriptor, so the socket object handed out through
-/// `get_extra_info("socket")` must be detached rather than closed - otherwise
-/// Python would close a descriptor libuv has already closed and reused.
+/// `get_extra_info("socket")` must be detached rather than closed. The object
+/// is disarmed before libuv closes the number, preventing a second close after
+/// another thread reuses it.
 fn releaseSocketView(self: *Transport) void {
     const view = self.socket_view orelse return;
     self.socket_view = null;
@@ -723,7 +724,6 @@ fn onClosed(handle: ?*uv.Handle) callconv(.c) void {
     st.gilEnter();
     defer st.gilExit();
 
-    releaseSocketView(self);
     self.flags |= CONN_LOST;
     scheduleCall(self, self.cb_connection_lost, self.conn_lost_exc orelse py.none());
     if (self.server) |server| {
@@ -759,7 +759,12 @@ fn shutdownAndClose(self: *Transport) void {
         _ = uv.uv_read_stop(self.stream());
         self.flags &= ~READING;
     }
-    uv.uv_close(uv.asHandle(self.stream()), onClosed);
+    // uv_close closes a stream descriptor synchronously. Disarm the Python
+    // object first, or code that still holds the accepted socket can close the
+    // same number after another thread has already reused it.
+    releaseSocketView(self);
+    const handle = uv.asHandle(self.stream());
+    if (uv.uv_is_closing(handle) == 0) uv.uv_close(handle, onClosed);
 }
 
 /// Closes a transport discovered while the owning loop is shutting down.
@@ -773,7 +778,8 @@ pub fn closeFromLoop(handle: *uv.Handle) void {
         _ = uv.uv_read_stop(self.stream());
         self.flags &= ~READING;
     }
-    uv.uv_close(handle, onClosed);
+    releaseSocketView(self);
+    if (uv.uv_is_closing(handle) == 0) uv.uv_close(handle, onClosed);
 }
 
 fn closeTransport(self: *Transport) void {


### PR DESCRIPTION
## Summary

- detach stream and datagram socket views before `uv_close()` closes their descriptors
- prevent stale Python socket objects from closing a descriptor number after another thread reuses it
- cover immediate socket disarming and cancellation during a server-side TLS handshake

`uv_close()` closes stream descriptors synchronously, before its asynchronous close callback runs. The callback previously detached the Python socket view too late. Cleanup paths such as a cancelled TLS handshake could then close that still-armed object a second time; under concurrent fd churn, that close could target a newly reused descriptor such as an idle psycopg connection.

Closes #74.

## Validation

- `uv run pytest -q` (428 passed)
- `uv run ruff check .`
- `uv run mypy`
- `zig fmt --check zig build.zig`
- `uv run python scripts/build.py`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disarms Python socket views before native `uv_close()` on streams and datagrams to prevent double-close and descriptor reuse. Previously the view detached in the close callback; now it detaches immediately. Sockets from `get_extra_info("socket")` invalidate sooner.

- Moves `releaseSocketView()` before `uv_close()` in `zig/transport.zig` and `zig/datagram.zig`, including `closeFromLoop`; guards with `uv_is_closing()`; read/recv stops still precede close.
- Ensures server-side TLS handshake cancellation disarms the accepted socket before close; adds test asserting no extra `close()`, `accepted.fileno() == -1`, and `Server._active` decrements.
- Makes socket-close coverage deterministic in tests: asserts `fileno() == -1` after closing adopted sockets and transports; stabilizes pipe-close wait with `asyncio.timeout`.

<sup>Written for commit 337950ccc8132508b5c61540b6c75260e93169c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/75?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved socket cleanup when datagram clients and network transports are closed.
  - Ensured caller-provided sockets are properly closed with their associated transports.
  - Fixed cleanup after cancelled TLS server handshakes, including closing accepted connections and updating active connection counts.
  - Prevented duplicate socket closures and potential file descriptor reuse issues during shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->