### PR TITLE
Clamp oversized timer delays

### DIFF
--- a/tests/test_instrumentation.py
+++ b/tests/test_instrumentation.py
@@ -411,6 +411,17 @@ async def test_the_sampling_interval_must_be_positive() -> None:
         loop._start_metrics(0, print)
 
 
+async def test_an_infinite_sampling_interval_does_not_overflow() -> None:
+    loop = running_loop()
+    snapshots: list[dict[str, int]] = []
+    loop._start_metrics(float("inf"), snapshots.append)
+    try:
+        await asyncio.sleep(0.01)
+    finally:
+        loop._stop_metrics()
+    assert snapshots == []
+
+
 def test_a_failed_metrics_start_restores_running_loop_state() -> None:
     loop = zuvloop.new_event_loop()
     old_hooks = sys.get_asyncgen_hooks()

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -123,6 +123,20 @@ async def test_call_later_ordering() -> None:
     assert seen == ["first", "second", "third"]
 
 
+@pytest.mark.parametrize("delay", [float("inf"), 1e300])
+async def test_oversized_timer_delays_are_effectively_infinite(delay: float) -> None:
+    loop = running_loop()
+    seen: list[str] = []
+    later = loop.call_later(delay, seen.append, "later")
+    absolute = loop.call_at(delay, seen.append, "absolute")
+    try:
+        await asyncio.wait_for(asyncio.sleep(0.01), timeout=float("inf"))
+        assert seen == []
+    finally:
+        later.cancel()
+        absolute.cancel()
+
+
 async def test_loop_time_is_time_monotonic() -> None:
     # Not merely monotonic: callers mix the two clocks, so they have to be one.
     loop = running_loop()

--- a/zig/loop.zig
+++ b/zig/loop.zig
@@ -119,6 +119,16 @@ pub inline fn now() f64 {
     return @as(f64, @floatFromInt(ns)) / 1e9;
 }
 
+/// Converts a positive duration to libuv's millisecond clock without letting
+/// an infinite or oversized Python float reach a trapping float-to-int cast.
+fn timerMilliseconds(seconds: f64, guard_ms: f64) u64 {
+    if (!(seconds > 0)) return 0;
+    const rounded = @ceil(seconds * 1000.0) + guard_ms;
+    const limit: f64 = @floatFromInt(std.math.maxInt(u64));
+    if (!std.math.isFinite(rounded) or rounded >= limit) return std.math.maxInt(u64);
+    return @intFromFloat(rounded);
+}
+
 /// Cancelled means dropped, and being dropped from the heap is what ends being
 /// scheduled - so the flag is cleared on the way out, as it is everywhere else
 /// a timer leaves.
@@ -343,7 +353,7 @@ fn armTimer(self: *LoopObject) void {
     const delta = entry.when - now();
     // libuv's millisecond clock can fire up to 1ms early; +1 keeps callbacks
     // from running before their deadline, which asyncio callers rely on.
-    const ms: u64 = if (delta <= 0) 0 else @intFromFloat(@ceil(delta * 1000.0) + 1);
+    const ms = timerMilliseconds(delta, 1);
     _ = uv.uv_timer_start(st.timer, onTimer, ms, 0);
     st.timer_active = true;
 }
@@ -662,7 +672,7 @@ fn startMetrics(self_obj: *py.Object, args: []const ?*py.Object) py.Error!*py.Ob
     py.incref(args[1].?);
     st.metrics_cb = args[1];
 
-    const ms: u64 = @intFromFloat(@ceil(interval * 1000.0));
+    const ms = timerMilliseconds(interval, 0);
     try py.errUvIfNeg(uv.uv_timer_start(st.sampler, onSampler, ms, ms));
     // The sampler must not be what keeps the loop alive.
     uv.uv_unref(uv.asHandle(st.sampler));


### PR DESCRIPTION
## Summary

- Clamp non-finite and oversized timer delays before converting them to native milliseconds.
- Use the same safe conversion for timer scheduling and timer metrics.
- Cover call_later, call_at, wait_for, and instrumentation paths.

## Why

Infinite or extremely large Python delays could overflow during conversion to the native timer representation.

## Impact

Large delays remain scheduled safely instead of raising conversion errors; non-positive and NaN delays continue to run immediately.

## Validation

- Focused timer regressions: 3 passed.
- Full test suite: 430 passed.
- Ruff, mypy, and native build checks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clamp non-finite and oversized timer delays to a safe millisecond value when scheduling timers and sampling metrics to prevent float-to-int overflows. Previously, infinite or very large delays could raise during conversion to `libuv` milliseconds; now they schedule as effectively infinite, while non-positive and NaN delays still run immediately.

- Adds a bounded `timerMilliseconds(seconds, guard_ms)` conversion and uses it in both timer arming (+1 ms guard) and metrics sampling (no guard).
- Infinite or huge delays: clamped to `u64::MAX` ms; timers and samplers will not fire during normal runs.
- Non-positive or NaN delays: coerced to 0 ms and execute immediately (unchanged).
- Tests cover `asyncio` `call_later`, `call_at`, `wait_for`, and metrics with infinite intervals.

<sup>Written for commit 7b3acc1b594258fea9c38fcf7bc6a9b35c76efde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/76?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

