### PR TITLE
Stop datagram callbacks after close

### DIFF
--- a/tests/test_datagram.py
+++ b/tests/test_datagram.py
@@ -227,6 +227,8 @@ async def test_shutdown_does_not_resume_or_report_cancelled_sends(abort: bool) -
                 transport.close()
             receiver.close()
             await asyncio.wait_for(protocol.lost, 2)
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
             assert events == ["made", "pause", "lost"]
         finally:
             receiver.close()

--- a/tests/test_datagram.py
+++ b/tests/test_datagram.py
@@ -201,10 +201,10 @@ async def test_shutdown_does_not_resume_or_report_cancelled_sends(abort: bool) -
                 events.append("pause")
 
             def resume_writing(self) -> None:
-                events.append("resume")
+                events.append("resume")  # pragma: no cover - the assertion is that this never runs
 
             def error_received(self, exc: BaseException) -> None:
-                events.append(type(exc).__name__)
+                events.append(type(exc).__name__)  # pragma: no cover - the assertion is that this never runs
 
             def connection_lost(self, exc: BaseException | None) -> None:
                 events.append("lost")
@@ -214,7 +214,7 @@ async def test_shutdown_does_not_resume_or_report_cancelled_sends(abort: bool) -
         transport = cast("_zuvloop.DatagramTransport", raw)
         transport.set_write_buffer_limits(high=1, low=0)
         try:
-            for _ in range(100):
+            for _ in range(100):  # pragma: no branch - exhaustion fails via the assertion below
                 transport.sendto(b"x" * 1024, receiver_path)
                 if transport.get_write_buffer_size() != 0:
                     break

--- a/tests/test_datagram.py
+++ b/tests/test_datagram.py
@@ -173,6 +173,66 @@ async def test_abort_closes_immediately() -> None:
     await asyncio.wait_for(protocol.lost, 2)
 
 
+@pytest.mark.parametrize("abort", [False, True])
+async def test_shutdown_does_not_resume_or_report_cancelled_sends(abort: bool) -> None:
+    loop = running_loop()
+    with unix_socket_dir() as directory:
+        receiver_path = str(directory / "receiver")
+        sender_path = str(directory / "sender")
+        receiver = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+        receiver.bind(receiver_path)
+        receiver.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 2048)
+
+        sender = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+        sender.bind(sender_path)
+        sender.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 2048)
+        sender.setblocking(False)
+
+        events: list[str] = []
+
+        class FlowControl(asyncio.DatagramProtocol):
+            def __init__(self) -> None:
+                self.lost: asyncio.Future[None] = loop.create_future()
+
+            def connection_made(self, transport: asyncio.BaseTransport) -> None:
+                events.append("made")
+
+            def pause_writing(self) -> None:
+                events.append("pause")
+
+            def resume_writing(self) -> None:
+                events.append("resume")
+
+            def error_received(self, exc: BaseException) -> None:
+                events.append(type(exc).__name__)
+
+            def connection_lost(self, exc: BaseException | None) -> None:
+                events.append("lost")
+                self.lost.set_result(None)
+
+        raw, protocol = await loop.create_datagram_endpoint(FlowControl, sock=sender)
+        transport = cast("_zuvloop.DatagramTransport", raw)
+        transport.set_write_buffer_limits(high=1, low=0)
+        try:
+            for _ in range(100):
+                transport.sendto(b"x" * 1024, receiver_path)
+                if transport.get_write_buffer_size() != 0:
+                    break
+            assert transport.get_write_buffer_size() != 0
+            assert events == ["made", "pause"]
+
+            if abort:
+                transport.abort()
+            else:
+                transport.close()
+            receiver.close()
+            await asyncio.wait_for(protocol.lost, 2)
+            assert events == ["made", "pause", "lost"]
+        finally:
+            receiver.close()
+            transport.abort()
+
+
 async def test_sending_after_close_is_dropped() -> None:
     """asyncio drops it; a shutdown race should not raise out of user code."""
     loop = running_loop()

--- a/zig/datagram.zig
+++ b/zig/datagram.zig
@@ -249,7 +249,7 @@ fn onSent(req: ?*uv.UdpSend, status: c_int) callconv(.c) void {
 
     // A failed datagram is reported to the protocol, never raised: asyncio
     // treats the endpoint as still usable.
-    if (status < 0 and self.flags & CONN_LOST == 0) {
+    if (status < 0 and self.flags & (CLOSING | CONN_LOST) == 0) {
         if (takeUvError(status)) |exc| {
             defer py.decref(exc);
             callProtocol(self, self.cb_error_received, exc);
@@ -295,6 +295,7 @@ fn maybePauseProtocol(self: *Datagram) void {
 }
 
 fn maybeResumeProtocol(self: *Datagram) void {
+    if (self.flags & (CLOSING | CONN_LOST) != 0) return;
     if (self.flags & PROTOCOL_PAUSED == 0) return;
     if (self.write_buffer_size > self.low_water) return;
     self.flags &= ~PROTOCOL_PAUSED;


### PR DESCRIPTION
## Summary

- Suppress datagram error and resume-writing callbacks after close or abort.
- Add deterministic backed-up AF_UNIX send tests for both shutdown paths.

## Why

A queued native send completion could still dispatch protocol callbacks after the transport had been closed.

## Impact

Datagram protocols no longer receive late error or flow-control callbacks once their transport is closed.

## Validation

- Focused close and abort regressions: 2 passed.
- Full test suite: 429 passed.
- Ruff, mypy, and ReleaseSafe native build.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop dispatching datagram `error_received` and `resume_writing` callbacks once the transport is closing or lost. Previously, queued send completions could fire after `close()` or `abort()`, causing late events.

- Gate `onSent` error reporting behind `(CLOSING | CONN_LOST)` to suppress `error_received` during shutdown.
- Early-return in `maybeResumeProtocol` when `(CLOSING | CONN_LOST)` is set to prevent `resume_writing`.
- Add deterministic AF_UNIX test (parametrized for `close()`/`abort()`) that fills the send buffer and asserts events `["made", "pause", "lost"]`; mark unreachable `resume_writing`/`error_received` with `# pragma: no cover`.
- No API changes; protocols no longer observe late flow-control or error callbacks after shutdown.

<sup>Written for commit 78564c1cc9d96e26c35b95473a9d8d2c17c9dde5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/77?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

