### PR TITLE
Back off exhausted accept loops

### DIFF
--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 import asyncio
+import errno
 import gc
 import os
 import socket
 import ssl
 import struct
 import tempfile
+from asyncio import constants
 from collections.abc import Iterator, Sequence
 from pathlib import Path
+from typing import NoReturn, cast
 
 import pytest
 
@@ -75,6 +78,26 @@ class Collector(asyncio.Protocol):
     def connection_lost(self, exc: BaseException | None) -> None:
         assert self.done is not None
         self.done.set_result(bytes(self.received))
+
+
+class ExhaustedListener:
+    def __init__(self, sock: socket.socket, error: int) -> None:
+        self.sock = sock
+        self.error = error
+        self.accepts = 0
+
+    def listen(self, _backlog: int) -> None:
+        pass
+
+    def fileno(self) -> int:
+        return self.sock.fileno()
+
+    def accept(self) -> NoReturn:
+        self.accepts += 1
+        raise OSError(self.error, os.strerror(self.error))
+
+    def close(self) -> None:
+        self.sock.close()
 
 
 async def start_echo(backlog: int = 100) -> tuple[zuvloop.Server, int, list[Echo]]:
@@ -1245,6 +1268,40 @@ async def test_a_backlog_of_one_accepts_one_connection_per_wakeup() -> None:
         for writer in writers:
             writer.close()
             await writer.wait_closed()
+
+
+@pytest.mark.parametrize("error", [errno.EMFILE, errno.ENFILE, errno.ENOBUFS, errno.ENOMEM])
+async def test_accept_resource_exhaustion_backs_off(
+    error: int, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    loop = running_loop()
+    listener_sock, notifier = socket.socketpair()
+    listener = ExhaustedListener(listener_sock, error)
+    server = Server(loop, [cast("socket.socket", listener)], Echo, None, 100, None, None)
+    reports: list[tuple[str | None, BaseException | None]] = []
+    previous_handler = loop.get_exception_handler()
+    loop.set_exception_handler(
+        lambda _loop, context: reports.append((context.get("message"), context.get("exception")))
+    )
+    monkeypatch.setattr(constants, "ACCEPT_RETRY_DELAY", 0.02)
+
+    try:
+        await server.start_serving()
+        notifier.send(b"ready")
+        await asyncio.sleep(0.005)
+
+        assert listener.accepts == 1
+        assert reports == [("socket.accept() out of system resource", reports[0][1])]
+        assert isinstance(reports[0][1], OSError)
+        assert reports[0][1].errno == error
+
+        server.close()
+        await asyncio.sleep(0.03)
+        assert listener.accepts == 1
+    finally:
+        server.close()
+        notifier.close()
+        loop.set_exception_handler(previous_handler)
 
 
 async def test_wait_closed_tolerates_a_cancelled_waiter() -> None:

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -8,8 +8,8 @@ import socket
 import ssl
 import struct
 import tempfile
-from asyncio import constants
-from collections.abc import Iterator, Mapping, Sequence
+from asyncio import constants, trsock
+from collections.abc import Iterator, Sequence
 from pathlib import Path
 from typing import NoReturn, cast
 
@@ -1385,12 +1385,20 @@ async def test_accept_resource_handler_can_close_server(monkeypatch: pytest.Monk
     listener_sock, notifier = socket.socketpair()
     listener = ExhaustedListener(listener_sock, errno.EMFILE)
     server = Server(loop, [cast("socket.socket", listener)], Echo, None, 100, None, None)
-    reports: list[str | None] = []
+    reports: list[tuple[str | None, trsock.TransportSocket | None]] = []
     previous_handler = loop.get_exception_handler()
 
-    def close_server(_loop: asyncio.AbstractEventLoop, context: Mapping[str, object]) -> None:
+    def close_server(
+        _loop: asyncio.AbstractEventLoop, context: dict[str, str | BaseException | trsock.TransportSocket]
+    ) -> None:
         message = context.get("message")
-        reports.append(message if isinstance(message, str) else None)
+        socket_view = context.get("socket")
+        reports.append(
+            (
+                message if isinstance(message, str) else None,
+                socket_view if isinstance(socket_view, trsock.TransportSocket) else None,
+            )
+        )
         server.close()
 
     loop.set_exception_handler(close_server)
@@ -1403,7 +1411,9 @@ async def test_accept_resource_handler_can_close_server(monkeypatch: pytest.Monk
             while not reports:
                 await asyncio.sleep(0)
 
-        assert reports == ["socket.accept() out of system resource"]
+        assert len(reports) == 1
+        assert reports[0][0] == "socket.accept() out of system resource"
+        assert isinstance(reports[0][1], trsock.TransportSocket)
         assert not server.is_serving()
     finally:
         server.close()

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1271,9 +1271,7 @@ async def test_a_backlog_of_one_accepts_one_connection_per_wakeup() -> None:
 
 
 @pytest.mark.parametrize("error", [errno.EMFILE, errno.ENFILE, errno.ENOBUFS, errno.ENOMEM])
-async def test_accept_resource_exhaustion_backs_off(
-    error: int, monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_accept_resource_exhaustion_backs_off(error: int, monkeypatch: pytest.MonkeyPatch) -> None:
     loop = running_loop()
     listener_sock, notifier = socket.socketpair()
     listener = ExhaustedListener(listener_sock, error)

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -9,7 +9,7 @@ import ssl
 import struct
 import tempfile
 from asyncio import constants
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from pathlib import Path
 from typing import NoReturn, cast
 
@@ -1289,13 +1289,92 @@ async def test_accept_resource_exhaustion_backs_off(error: int, monkeypatch: pyt
         await asyncio.sleep(0.005)
 
         assert listener.accepts == 1
-        assert reports == [("socket.accept() out of system resource", reports[0][1])]
-        assert isinstance(reports[0][1], OSError)
-        assert reports[0][1].errno == error
+        assert len(reports) == 1
+        message, reported_error = reports[0]
+        assert message == "socket.accept() out of system resource"
+        assert isinstance(reported_error, OSError)
+        assert reported_error.errno == error
+
+        await asyncio.sleep(0.03)
+        assert listener.accepts >= 2
 
         server.close()
+        accepts_after_close = listener.accepts
         await asyncio.sleep(0.03)
+        assert listener.accepts == accepts_after_close
+    finally:
+        server.close()
+        notifier.close()
+        loop.set_exception_handler(previous_handler)
+
+
+async def test_accept_other_oserror_is_reported() -> None:
+    loop = running_loop()
+    listener_sock, notifier = socket.socketpair()
+    listener = ExhaustedListener(listener_sock, errno.EINVAL)
+    server = Server(loop, [cast("socket.socket", listener)], Echo, None, 100, None, None)
+    reports: list[tuple[str | None, BaseException | None]] = []
+    previous_handler = loop.get_exception_handler()
+    loop.set_exception_handler(
+        lambda _loop, context: reports.append((context.get("message"), context.get("exception")))
+    )
+
+    try:
+        loop.call_soon(server._accept, cast("socket.socket", listener))
+        await asyncio.sleep(0)
+
         assert listener.accepts == 1
+        assert len(reports) == 1
+        message, reported_error = reports[0]
+        assert message == "Error accepting a connection"
+        assert isinstance(reported_error, OSError)
+        assert reported_error.errno == errno.EINVAL
+    finally:
+        server.close()
+        notifier.close()
+        loop.set_exception_handler(previous_handler)
+
+
+async def test_retry_accept_ignores_a_closed_listener() -> None:
+    loop = running_loop()
+    listener_sock, notifier = socket.socketpair()
+    listener = ExhaustedListener(listener_sock, errno.EMFILE)
+    server = Server(loop, [cast("socket.socket", listener)], Echo, None, 100, None, None)
+
+    try:
+        server._start_serving()
+        loop.remove_reader(listener.fileno())
+        listener.close()
+        server._retry_accept(cast("socket.socket", listener))
+        await asyncio.sleep(0)
+    finally:
+        server.close()
+        notifier.close()
+
+
+async def test_accept_resource_handler_can_close_server(monkeypatch: pytest.MonkeyPatch) -> None:
+    loop = running_loop()
+    listener_sock, notifier = socket.socketpair()
+    listener = ExhaustedListener(listener_sock, errno.EMFILE)
+    server = Server(loop, [cast("socket.socket", listener)], Echo, None, 100, None, None)
+    reports: list[str | None] = []
+    previous_handler = loop.get_exception_handler()
+
+    def close_server(_loop: asyncio.AbstractEventLoop, context: Mapping[str, object]) -> None:
+        message = context.get("message")
+        reports.append(message if isinstance(message, str) else None)
+        server.close()
+
+    loop.set_exception_handler(close_server)
+    monkeypatch.setattr(constants, "ACCEPT_RETRY_DELAY", 0.01)
+
+    try:
+        await server.start_serving()
+        notifier.send(b"ready")
+        await asyncio.sleep(0.02)
+
+        assert reports == ["socket.accept() out of system resource"]
+        assert not server.is_serving()
     finally:
         server.close()
         notifier.close()

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1374,6 +1374,7 @@ async def test_retry_accept_ignores_a_closed_listener() -> None:
         listener.close()
         server._retry_accept(cast("socket.socket", listener))
         await asyncio.sleep(0)
+        assert listener.accepts == 0
     finally:
         server.close()
         notifier.close()

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1286,7 +1286,9 @@ async def test_accept_resource_exhaustion_backs_off(error: int, monkeypatch: pyt
     try:
         await server.start_serving()
         notifier.send(b"ready")
-        await asyncio.sleep(0.005)
+        async with asyncio.timeout(1):
+            while not reports:
+                await asyncio.sleep(0)
 
         assert listener.accepts == 1
         assert len(reports) == 1
@@ -1295,12 +1297,14 @@ async def test_accept_resource_exhaustion_backs_off(error: int, monkeypatch: pyt
         assert isinstance(reported_error, OSError)
         assert reported_error.errno == error
 
-        await asyncio.sleep(0.03)
+        async with asyncio.timeout(1):
+            while listener.accepts < 2:
+                await asyncio.sleep(0)
         assert listener.accepts >= 2
 
         server.close()
         accepts_after_close = listener.accepts
-        await asyncio.sleep(0.03)
+        server._retry_accept(cast("socket.socket", listener))
         assert listener.accepts == accepts_after_close
     finally:
         server.close()
@@ -1371,7 +1375,9 @@ async def test_accept_resource_handler_can_close_server(monkeypatch: pytest.Monk
     try:
         await server.start_serving()
         notifier.send(b"ready")
-        await asyncio.sleep(0.02)
+        async with asyncio.timeout(1):
+            while not reports:
+                await asyncio.sleep(0)
 
         assert reports == ["socket.accept() out of system resource"]
         assert not server.is_serving()

--- a/zuvloop/_server.py
+++ b/zuvloop/_server.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import errno
 import os
 import socket
-from asyncio import trsock
+from asyncio import constants, trsock
 from collections.abc import Callable, Sequence
 from types import TracebackType
 from typing import TYPE_CHECKING, Any
@@ -67,13 +68,28 @@ class Server(asyncio.AbstractServer):
         # Let the accept callbacks register before returning, matching asyncio.
         await asyncio.sleep(0)
 
+    def _retry_accept(self, sock: socket.socket) -> None:
+        sockets = self._sockets
+        if not self._serving or sockets is None or sock not in sockets:
+            return
+        fd = sock.fileno()
+        if fd != -1:
+            self._loop.add_reader(fd, self._accept, sock)
+
     def _accept(self, sock: socket.socket) -> None:
         for _ in range(self._backlog):
             try:
                 conn, _addr = sock.accept()
             except BlockingIOError, InterruptedError:
                 return
-            except OSError as exc:  # pragma: no cover - needs descriptor exhaustion
+            except OSError as exc:
+                if exc.errno in (errno.EMFILE, errno.ENFILE, errno.ENOBUFS, errno.ENOMEM):
+                    self._loop.call_exception_handler(
+                        {"message": "socket.accept() out of system resource", "exception": exc, "socket": sock}
+                    )
+                    self._loop.remove_reader(sock.fileno())
+                    self._loop.call_later(constants.ACCEPT_RETRY_DELAY, self._retry_accept, sock)
+                    return
                 self._loop.call_exception_handler(
                     {"message": "Error accepting a connection", "exception": exc, "socket": sock}
                 )

--- a/zuvloop/_server.py
+++ b/zuvloop/_server.py
@@ -89,7 +89,11 @@ class Server(asyncio.AbstractServer):
                 if exc.errno in (errno.EMFILE, errno.ENFILE, errno.ENOBUFS, errno.ENOMEM):
                     self._loop.remove_reader(sock.fileno())
                     self._loop.call_exception_handler(
-                        {"message": "socket.accept() out of system resource", "exception": exc, "socket": sock}
+                        {
+                            "message": "socket.accept() out of system resource",
+                            "exception": exc,
+                            "socket": trsock.TransportSocket(sock),
+                        }
                     )
                     self._loop.call_later(constants.ACCEPT_RETRY_DELAY, self._retry_accept, sock)
                     return

--- a/zuvloop/_server.py
+++ b/zuvloop/_server.py
@@ -84,10 +84,10 @@ class Server(asyncio.AbstractServer):
                 return
             except OSError as exc:
                 if exc.errno in (errno.EMFILE, errno.ENFILE, errno.ENOBUFS, errno.ENOMEM):
+                    self._loop.remove_reader(sock.fileno())
                     self._loop.call_exception_handler(
                         {"message": "socket.accept() out of system resource", "exception": exc, "socket": sock}
                     )
-                    self._loop.remove_reader(sock.fileno())
                     self._loop.call_later(constants.ACCEPT_RETRY_DELAY, self._retry_accept, sock)
                     return
                 self._loop.call_exception_handler(


### PR DESCRIPTION
## Summary

- Pause accept handling after EMFILE, ENFILE, ENOBUFS, or ENOMEM.
- Retry after the standard asyncio accept backoff delay.
- Make the delayed retry harmless when the server has already closed.

## Why

Resource-exhaustion errors could leave the listener hot-looping and repeatedly consuming CPU while the underlying condition persisted.

## Impact

Servers now yield during transient resource exhaustion and resume accepting automatically.

## Validation

- Focused accept-loop regressions: 4 passed.
- Full test suite: 431 passed.
- Ruff and mypy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backs off the server accept loop on resource exhaustion and protects sockets in accept error contexts to prevent hot CPU loops and accidental socket closes. Previously, `accept()` spun on EMFILE/ENFILE/ENOBUFS/ENOMEM and error handlers received raw sockets; now it yields and reports with a safe view.

- On EMFILE, ENFILE, ENOBUFS, ENOMEM: remove the reader, call the loop exception handler with "socket.accept() out of system resource" and a `trsock.TransportSocket`, then retry after `asyncio.constants.ACCEPT_RETRY_DELAY`.
- `_retry_accept` re-arms the reader only if still serving, the listener is still tracked, and `fileno()` is valid; the delayed task is a no-op if the server or listener closed.
- Other `OSError`s still report "Error accepting a connection" but now pass a `trsock.TransportSocket` in the context.
- Tests cover backoff timing, handler-initiated server close, ignoring closed listeners, and protected sockets.

<sup>Written for commit 11a2338a683a1bb90abc3b77f6cdbfb7793a9368. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

