### PR TITLE
Validate write buffer limits

### DIFF
--- a/tests/test_datagram.py
+++ b/tests/test_datagram.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import shutil
 import socket
+import sys
 import tempfile
 from collections.abc import Iterator
 from pathlib import Path
@@ -233,6 +234,12 @@ async def test_write_buffer_limits_are_reported() -> None:
         assert transport.get_write_buffer_limits() == (256, 1024)
         with pytest.raises(ValueError, match="high water mark"):
             transport.set_write_buffer_limits(high=1, low=2)
+        with pytest.raises(ValueError, match="high water mark must be non-negative"):
+            transport.set_write_buffer_limits(high=-1)
+        with pytest.raises(ValueError, match="low water mark must be non-negative"):
+            transport.set_write_buffer_limits(low=-1)
+        with pytest.raises(OverflowError, match="high water mark is too large"):
+            transport.set_write_buffer_limits(low=sys.maxsize)
         with pytest.raises(TypeError, match="unexpected keyword"):
             transport.set_write_buffer_limits(bogus=1)  # type: ignore[call-arg]
         with pytest.raises(TypeError, match="at most 2"):

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -6,6 +6,7 @@ import os
 import socket
 import ssl
 import struct
+import sys
 import tempfile
 from collections.abc import Iterator, Sequence
 from pathlib import Path
@@ -679,12 +680,16 @@ async def test_write_buffer_limits_validate_their_arguments() -> None:
         assert transport.get_write_buffer_limits() == (16384, 65536)
         transport.set_write_buffer_limits(high=8192)
         assert transport.get_write_buffer_limits() == (2048, 8192)
+        transport.set_write_buffer_limits(low=256)
+        assert transport.get_write_buffer_limits() == (256, 1024)
         with pytest.raises(ValueError, match="high water mark"):
             transport.set_write_buffer_limits(high=10, low=100)
         with pytest.raises(ValueError, match="high water mark must be non-negative"):
             transport.set_write_buffer_limits(high=-1)
         with pytest.raises(ValueError, match="low water mark must be non-negative"):
             transport.set_write_buffer_limits(low=-1)
+        with pytest.raises(OverflowError, match="high water mark is too large"):
+            transport.set_write_buffer_limits(low=sys.maxsize)
         with pytest.raises(TypeError, match="unexpected keyword"):
             transport.set_write_buffer_limits(medium=1)  # type: ignore[call-arg]
         with pytest.raises(TypeError, match="at most 2"):

--- a/zig/datagram.zig
+++ b/zig/datagram.zig
@@ -502,15 +502,28 @@ fn setWriteBufferLimits(
     const self = asDatagram(self_obj);
     var high_value: usize = default_high_water;
     if (high) |h| {
-        if (!py.isNone(h)) high_value = @intCast(try py.asIsize(h));
+        if (!py.isNone(h)) {
+            const parsed = try py.asIsize(h);
+            if (parsed < 0) return py.errValue("high water mark must be non-negative");
+            high_value = @intCast(parsed);
+        }
     }
     var low_value: usize = high_value / 4;
     if (low) |l| {
-        if (!py.isNone(l)) low_value = @intCast(try py.asIsize(l));
+        if (!py.isNone(l)) {
+            const parsed = try py.asIsize(l);
+            if (parsed < 0) return py.errValue("low water mark must be non-negative");
+            low_value = @intCast(parsed);
+        }
     }
     if (high == null or py.isNone(high.?)) {
         if (low) |l| {
-            if (!py.isNone(l)) high_value = low_value * 4;
+            if (!py.isNone(l)) {
+                if (low_value > std.math.maxInt(c.Py_ssize_t) / 4) {
+                    return py.errOverflow("high water mark is too large");
+                }
+                high_value = low_value * 4;
+            }
         }
     }
     if (low_value > high_value) return py.errValue("high water mark must be >= low water mark");

--- a/zig/transport.zig
+++ b/zig/transport.zig
@@ -1014,6 +1014,16 @@ fn setWriteBufferLimits(
             low_water = @intCast(parsed);
         }
     }
+    if (high == null or py.isNone(high.?)) {
+        if (low) |value| {
+            if (!py.isNone(value)) {
+                if (low_water > std.math.maxInt(c.Py_ssize_t) / 4) {
+                    return py.errOverflow("high water mark is too large");
+                }
+                high_water = low_water * 4;
+            }
+        }
+    }
     if (low_water > high_water) return py.errValue("high water mark must be >= low water mark");
     self.high_water = high_water;
     self.low_water = low_water;


### PR DESCRIPTION
## Summary

- Validate stream and datagram write-buffer limits before converting them to native unsigned values.
- Derive a stream high watermark from a low-only configuration without overflowing.
- Add regression coverage for negative and oversized limits.

## Why

Invalid values could reach unsigned native fields, producing wraparound or overflow behavior instead of a clear Python exception.

## Impact

Invalid configurations now fail immediately, while valid low-only stream configurations continue to derive the expected high watermark.

## Validation

- Targeted stream and datagram regression tests.
- Full test suite: 427 passed.
- Ruff, mypy, and Zig formatting checks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate and bound stream and datagram write buffer limits to prevent unsigned wraparound and overflow. Previously, negative or oversized inputs could silently wrap; now invalid inputs raise clear Python errors, and low-only configs derive a safe high watermark.

- Reject negative limits with ValueError: "high water mark must be non-negative" or "low water mark must be non-negative".
- When only low is set, derive high = low * 4; guard overflow and raise OverflowError: "high water mark is too large".
- Enforce high >= low; raise ValueError if violated.
- Update `zig/datagram.zig` and `zig/transport.zig` to perform validation before casting; add regression tests in `tests/test_datagram.py` and `tests/test_network.py`.

<sup>Written for commit 62fa33ab5646b99020b3db6a129be7f2fdff519f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/79?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

