### PR TITLE
Close sockets after construction failures

### DIFF
--- a/tests/test_datagram.py
+++ b/tests/test_datagram.py
@@ -7,7 +7,7 @@ import socket
 import tempfile
 from collections.abc import Iterator
 from pathlib import Path
-from typing import cast
+from typing import NoReturn, cast
 
 import pytest
 
@@ -388,6 +388,30 @@ async def test_a_socket_that_cannot_be_bound_is_closed() -> None:
     with pytest.raises(OSError):
         # TEST-NET-1: routable as an address, never assigned to an interface.
         await running_loop().create_datagram_endpoint(Collector, local_addr=("192.0.2.1", 0))
+
+
+async def test_a_failed_protocol_factory_closes_its_internal_datagram_socket(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_socket = socket.socket
+    created: list[socket.socket] = []
+
+    def track(
+        family: int = -1, type: int = -1, proto: int = -1, fileno: int | None = None
+    ) -> socket.socket:
+        sock = real_socket(family, type, proto) if fileno is None else real_socket(family, type, proto, fileno)
+        created.append(sock)
+        return sock
+
+    def fail() -> NoReturn:
+        raise RuntimeError("factory failed")
+
+    monkeypatch.setattr(socket, "socket", track)
+    with pytest.raises(RuntimeError, match="factory failed"):
+        await running_loop().create_datagram_endpoint(fail, local_addr=("127.0.0.1", 0))
+
+    assert len(created) == 1
+    assert created[0].fileno() == -1
 
 
 async def test_a_transport_that_fails_to_adopt_releases_the_socket(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_datagram.py
+++ b/tests/test_datagram.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import os
 import shutil
 import socket
 import tempfile
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from pathlib import Path
 from typing import NoReturn, cast
 
@@ -419,6 +420,56 @@ async def test_a_transport_that_fails_to_adopt_releases_the_socket(monkeypatch: 
     monkeypatch.setattr(type(running_loop()), "_make_datagram_transport", refuse)
     with pytest.raises(RuntimeError, match="refused"):
         await running_loop().create_datagram_endpoint(Collector, local_addr=("127.0.0.1", 0))
+
+
+async def test_a_transport_that_fails_to_adopt_its_socket_view_is_aborted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_socket = socket.socket
+    created: list[socket.socket] = []
+
+    class RefusingTransport:
+        def __init__(self, fd: int) -> None:
+            self.fd = fd
+            self.aborted = False
+
+        def _adopt_socket_view(self, _sock: socket.socket) -> NoReturn:
+            raise RuntimeError("adoption failed")
+
+        def abort(self) -> None:
+            os.close(self.fd)
+            self.aborted = True
+
+    refusing: RefusingTransport | None = None
+
+    def track(family: int = -1, type: int = -1, proto: int = -1, fileno: int | None = None) -> socket.socket:
+        sock = real_socket(family, type, proto) if fileno is None else real_socket(family, type, proto, fileno)
+        created.append(sock)
+        return sock
+
+    def make_refusing_transport(
+        _loop: asyncio.AbstractEventLoop,
+        fd: int,
+        _family: int,
+        _connected: bool,
+        _protocol: asyncio.BaseProtocol,
+        _extra: Mapping[str, object],
+    ) -> _zuvloop.DatagramTransport:
+        nonlocal refusing
+        refusing = RefusingTransport(fd)
+        return cast("_zuvloop.DatagramTransport", refusing)
+
+    monkeypatch.setattr(socket, "socket", track)
+    monkeypatch.setattr(type(running_loop()), "_make_datagram_transport", make_refusing_transport)
+    with pytest.raises(RuntimeError, match="adoption failed"):
+        await running_loop().create_datagram_endpoint(Collector, local_addr=("127.0.0.1", 0))
+
+    assert len(created) == 1
+    assert created[0].fileno() == -1
+    assert refusing is not None
+    assert refusing.aborted
+    with pytest.raises(OSError, match="Bad file descriptor"):
+        os.fstat(refusing.fd)
 
 
 async def test_an_empty_resolution_is_reported(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_datagram.py
+++ b/tests/test_datagram.py
@@ -396,9 +396,7 @@ async def test_a_failed_protocol_factory_closes_its_internal_datagram_socket(
     real_socket = socket.socket
     created: list[socket.socket] = []
 
-    def track(
-        family: int = -1, type: int = -1, proto: int = -1, fileno: int | None = None
-    ) -> socket.socket:
+    def track(family: int = -1, type: int = -1, proto: int = -1, fileno: int | None = None) -> socket.socket:
         sock = real_socket(family, type, proto) if fileno is None else real_socket(family, type, proto, fileno)
         created.append(sock)
         return sock

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -9,6 +9,7 @@ import struct
 import tempfile
 from collections.abc import Iterator, Sequence
 from pathlib import Path
+from typing import NoReturn
 
 import pytest
 
@@ -1409,7 +1410,23 @@ async def test_an_ssl_handshake_timeout_without_ssl_is_rejected() -> None:
             await loop.connect_accepted_socket(Echo, left, ssl_handshake_timeout=5.0)
     finally:
         left.close()
-        right.close()
+    right.close()
+
+
+async def test_a_failed_protocol_factory_closes_an_accepted_socket() -> None:
+    loop = running_loop()
+    sock, peer = socket.socketpair()
+
+    def fail() -> NoReturn:
+        raise RuntimeError("factory failed")
+
+    try:
+        with pytest.raises(RuntimeError, match="factory failed"):
+            await loop.connect_accepted_socket(fail, sock)
+        assert sock.fileno() == -1
+    finally:
+        sock.close()
+        peer.close()
 
 
 async def test_an_ssl_shutdown_timeout_without_ssl_is_rejected() -> None:

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1410,7 +1410,7 @@ async def test_an_ssl_handshake_timeout_without_ssl_is_rejected() -> None:
             await loop.connect_accepted_socket(Echo, left, ssl_handshake_timeout=5.0)
     finally:
         left.close()
-    right.close()
+        right.close()
 
 
 async def test_a_failed_protocol_factory_closes_an_accepted_socket() -> None:

--- a/zuvloop/_connect.py
+++ b/zuvloop/_connect.py
@@ -471,24 +471,33 @@ class ConnectionOperations(SendfileOperations):
         ssl_shutdown_timeout: float | None,
         server: Server | None,
     ) -> tuple[asyncio.Transport, Any]:
-        protocol = protocol_factory()
-        waiter = self.create_future()
-        if ssl:
-            context = _resolve_context(ssl, server_side)
-            driver: asyncio.BaseProtocol = sslproto.SSLProtocol(
-                self,
-                protocol,
-                context,
-                waiter,
-                server_side,
-                server_hostname,
-                ssl_handshake_timeout=ssl_handshake_timeout,  # type: ignore[arg-type]  # typeshed says int
-                ssl_shutdown_timeout=ssl_shutdown_timeout,
-            )
-            transport = self._attach_transport(sock, driver, None, server)
-        else:
-            driver = protocol
-            transport = self._attach_transport(sock, driver, waiter, server)
+        try:
+            protocol = protocol_factory()
+            waiter = self.create_future()
+            if ssl:
+                context = _resolve_context(ssl, server_side)
+                driver: asyncio.BaseProtocol = sslproto.SSLProtocol(
+                    self,
+                    protocol,
+                    context,
+                    waiter,
+                    server_side,
+                    server_hostname,
+                    ssl_handshake_timeout=ssl_handshake_timeout,  # type: ignore[arg-type]  # typeshed says int
+                    ssl_shutdown_timeout=ssl_shutdown_timeout,
+                )
+                transport = self._attach_transport(sock, driver, None, server)
+            else:
+                driver = protocol
+                transport = self._attach_transport(sock, driver, waiter, server)
+        except BaseException:
+            # Before native adoption, accepting the socket makes every setup
+            # failure ours to close. After adoption the socket view is detached.
+            # TLS server accepts have an outer owner that must also detach the
+            # server count; leaving its live descriptor intact tells it to do both.
+            if server is None and sock.fileno() != -1:
+                sock.close()
+            raise
         try:
             await waiter
         except BaseException:
@@ -559,9 +568,9 @@ class ConnectionOperations(SendfileOperations):
                 local_addr, remote_addr, family, proto, flags, reuse_port, allow_broadcast
             )
 
-        protocol = protocol_factory()
-        waiter = self.create_future()
         try:
+            protocol = protocol_factory()
+            waiter = self.create_future()
             transport = self._attach_datagram(sock, protocol, connected)
         except BaseException:
             # Until libuv adopts the descriptor, the socket is still ours.
@@ -647,7 +656,12 @@ class ConnectionOperations(SendfileOperations):
         # and `create_datagram_endpoint(sock=...)` callers go on using it.
         extra["socket"] = trsock.TransportSocket(sock)
         transport = self._make_datagram_transport(fd, sock.family, connected, protocol, extra)
-        transport._adopt_socket_view(sock)
+        try:
+            transport._adopt_socket_view(sock)
+        except BaseException:
+            sock.detach()
+            transport.abort()
+            raise
         return transport
 
     async def subprocess_shell(


### PR DESCRIPTION
## Summary

- Keep socket cleanup active through protocol, waiter, and transport construction.
- Apply the same detach-and-abort ownership transfer to datagram transports as stream transports.
- Preserve the TLS server active-connection accounting contract.

## Why

Exceptions during transport construction could leave an adopted socket open after ownership had partially moved into native code.

## Impact

Failed connection and datagram setup paths now close their socket exactly once without regressing successful TLS ownership.

## Validation

- Focused construction-failure regressions: 4 passed.
- Full test suite: 429 passed.
- Ruff, mypy, and native build checks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Close stream and datagram sockets on construction failures to prevent descriptor leaks while preserving TLS server ownership/accounting. Previously, failures during accept/connect or datagram setup could leave sockets open; now failures close the socket exactly once, while TLS server accepts keep the fd for server-side detachment and counts.

- Stream accepts: build protocol/driver in a try; if the factory or setup fails before transport adoption, close the accepted socket. For TLS server accepts, keep the fd so the server detaches and maintains active-connection counts.
- Datagram endpoints: create protocol and waiter in a try; on failure before libuv adoption, close the socket. If adoption into the transport fails, detach the socket view and abort the transport.
- Tests: added cases asserting failed protocol factories close accepted stream sockets and internal datagram sockets; adoption failures abort and release fds. Cleaned up construction tests to close test sockets unconditionally.
- No API changes; callers no longer need to close sockets on construction failures.

<sup>Written for commit ef60906080c95b987b46590adedfecdd57f8648f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/80?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

