### PR TITLE
Validate native socket address fields

### DIFF
--- a/tests/test_datagram.py
+++ b/tests/test_datagram.py
@@ -362,6 +362,30 @@ async def test_a_connected_v6_endpoint_tells_the_scope_apart() -> None:
         server.close()
 
 
+@pytest.mark.parametrize(
+    "address",
+    [
+        ("::1", 9, -1, 0),
+        ("::1", 9, 1_048_576, 0),
+        ("::1", 9, 0, -1),
+        ("::1", 9, 0, 1 << 32),
+    ],
+)
+async def test_ipv6_send_rejects_out_of_range_ancillary_fields(
+    address: tuple[str, int, int, int],
+) -> None:
+    loop = running_loop()
+    try:
+        transport, _protocol = await loop.create_datagram_endpoint(Collector, local_addr=("::1", 0))
+    except OSError:  # pragma: no cover - host without IPv6 loopback
+        pytest.skip("no IPv6 loopback")
+    try:
+        with pytest.raises(OverflowError):
+            transport.sendto(b"x", address)
+    finally:
+        transport.close()
+
+
 async def test_a_cancelled_setup_closes_the_socket(monkeypatch: pytest.MonkeyPatch) -> None:
     # With the waiter never resolved, the setup stays parked exactly where a
     # cancellation has to unwind it.

--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -175,6 +175,8 @@ async def test_getnameinfo_rejects_a_malformed_address() -> None:
         await loop.getnameinfo(("127.0.0.1",))
     with pytest.raises(socket.gaierror):
         await loop.getnameinfo(("not an address", 80))
+    with pytest.raises(ValueError, match="embedded null character"):
+        await loop.getnameinfo(("127.0.0.1\0hidden", 80))
 
 
 @pytest.mark.parametrize("host", ["localhost", "example.com", "not a host"])

--- a/zig/addr.zig
+++ b/zig/addr.zig
@@ -73,7 +73,11 @@ pub fn fromPython(family: c_int, address: *py.Object, out: *Storage) py.Error!c_
         var len: c.Py_ssize_t = 0;
         const s = c.PyUnicode_AsUTF8AndSize(host_obj, &len) orelse return py.Error.Python;
         if (len >= host_buf.len) return py.errValue("host name too long");
-        @memcpy(host_buf[0..@intCast(len)], s[0..@intCast(len)]);
+        const host_len: usize = @intCast(len);
+        if (std.mem.indexOfScalar(u8, s[0..host_len], 0) != null) {
+            return py.errValue("embedded null character");
+        }
+        @memcpy(host_buf[0..host_len], s[0..host_len]);
         host_buf[@intCast(len)] = 0;
         break :blk @ptrCast(&host_buf);
     };
@@ -81,8 +85,18 @@ pub fn fromPython(family: c_int, address: *py.Object, out: *Storage) py.Error!c_
     if (family == AF_INET6 or (family == 0 and std.mem.indexOfScalar(u8, std.mem.span(host), ':') != null)) {
         const sin6: *posix.sockaddr.in6 = @ptrCast(out);
         try py.errUvIfNeg(uv.uv_ip6_addr(host, port, sin6));
-        if (size >= 3) sin6.flowinfo = @intCast(try py.asCInt(try tupleItem(address, 2)));
-        if (size >= 4) sin6.scope_id = @intCast(try py.asCInt(try tupleItem(address, 3)));
+        if (size >= 3) {
+            const flowinfo = try py.asIsizeClamped(try tupleItem(address, 2));
+            if (flowinfo < 0 or flowinfo > 0xfffff) return py.errOverflow("flowinfo must be 0-1048575");
+            sin6.flowinfo = @intCast(flowinfo);
+        }
+        if (size >= 4) {
+            const scope_id = try py.asIsizeClamped(try tupleItem(address, 3));
+            if (scope_id < 0 or scope_id > std.math.maxInt(u32)) {
+                return py.errOverflow("scope_id must be 0-4294967295");
+            }
+            sin6.scope_id = @intCast(scope_id);
+        }
         return @sizeOf(posix.sockaddr.in6);
     }
     const sin: *posix.sockaddr.in = @ptrCast(out);


### PR DESCRIPTION
## Summary

- Reject host strings containing embedded NUL bytes.
- Validate IPv6 flowinfo and scope_id ranges before native casts.
- Add coverage at both valid boundaries and outside them.

## Why

Unchecked address components could be truncated or wrapped while crossing from Python into native socket structures.

## Impact

Malformed socket addresses now fail predictably with Python exceptions instead of reaching the operating system in altered form.

## Validation

- Focused address regressions: 5 passed under ReleaseSafe.
- Full test suite: 431 passed.
- Ruff, mypy, Zig formatting, and native build checks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects hosts with an embedded null character and validates IPv6 `flowinfo` and `scope_id` ranges before writing to native `sockaddr`. Previously, we copied bytes and cast ancillary fields without bounds, which could truncate or wrap at the OS boundary; now we raise `ValueError`/`OverflowError` early.

- `zig/addr.zig`: In `fromPython`, check host bytes for `\0`; range-check `flowinfo` (0–1,048,575) and `scope_id` (0–4,294,967,295) using clamped integer conversion before assignment.
- Tests: `tests/test_datagram.py` asserts `OverflowError` for out-of-range IPv6 ancillary fields; `tests/test_dns.py` asserts `ValueError` for hosts with an embedded null character.

**Migration**
- Code must pass valid IPv6 ancillary fields and hosts without embedded null characters. Ensure `flowinfo` is within 0–1,048,575 and `scope_id` within 0–4,294,967,295.

<sup>Written for commit 436cc7adc93249aa7f7c1d51c1c3072d6d71eb1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/81?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

