### PR TITLE
Preserve reused process registrations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,4 @@
 
 1. `Any` should be avoided in the Python type hints, and `object` is only marginally better — both are poor choices. Use the proper, most precise type possible.
 2. A performance change lands as two PRs: first the benchmark on its own, then the change itself, so the effect is visible against the recorded baseline.
+3. Private functions that are used only once should not be written; inline their implementation at the sole call site.

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -9,8 +9,9 @@ import socket
 import subprocess
 import sys
 from asyncio.subprocess import Process
+from collections.abc import Callable
 from pathlib import Path
-from typing import cast
+from typing import NoReturn, cast
 
 import pytest
 
@@ -24,18 +25,52 @@ PIPE = asyncio.subprocess.PIPE
 
 
 def test_process_reaper_does_not_discard_a_reused_pid() -> None:
-    reaper = ProcessReaper()
-    old_process = cast("subprocess.Popen[bytes]", object())
-    new_process = cast("subprocess.Popen[bytes]", object())
-    loop = cast("ConnectionOperations", object())
-    wrapper = cast("Popen", object())
-    replacement = (new_process, loop, wrapper)
-    reaper.processes[42] = replacement
+    class StopReaper(Exception):
+        pass
 
-    assert reaper._discard_process(42, old_process) is False
+    class ReplacementProcess:
+        def poll(self) -> NoReturn:
+            raise StopReaper
+
+    class RecordingLoop:
+        def call_soon_threadsafe(self, callback: Callable[[int], None], returncode: int) -> None:
+            callback(returncode)
+
+    class RecordingWrapper:
+        def __init__(self) -> None:
+            self.returncodes: list[int] = []
+
+        def exited(self, returncode: int) -> None:
+            self.returncodes.append(returncode)
+
+    class ReplacedProcess:
+        def __init__(
+            self,
+            reaper: ProcessReaper,
+            replacement: tuple[subprocess.Popen[bytes], ConnectionOperations, Popen],
+        ) -> None:
+            self.reaper = reaper
+            self.replacement = replacement
+
+        def poll(self) -> int:
+            with self.reaper.condition:
+                self.reaper.processes[42] = self.replacement
+            return 0
+
+    reaper = ProcessReaper()
+    new_process = cast("subprocess.Popen[bytes]", ReplacementProcess())
+    loop = cast("ConnectionOperations", RecordingLoop())
+    recording_wrapper = RecordingWrapper()
+    wrapper = cast("Popen", recording_wrapper)
+    replacement = (new_process, loop, wrapper)
+    old_process = cast("subprocess.Popen[bytes]", ReplacedProcess(reaper, replacement))
+    reaper.processes[42] = (old_process, loop, wrapper)
+
+    with pytest.raises(StopReaper):
+        reaper.run()
+
     assert reaper.processes[42] is replacement
-    assert reaper._discard_process(42, new_process) is True
-    assert reaper.processes == {}
+    assert recording_wrapper.returncodes == [0]
 
 
 async def test_a_command_runs_and_reports_its_output() -> None:

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -6,17 +6,36 @@ import errno
 import os
 import signal
 import socket
+import subprocess
 import sys
 from asyncio.subprocess import Process
 from pathlib import Path
+from typing import cast
 
 import pytest
 
 from conftest import running_loop
+from zuvloop._connect import ConnectionOperations
+from zuvloop._process import Popen, ProcessReaper
 
 pytestmark = pytest.mark.anyio
 
 PIPE = asyncio.subprocess.PIPE
+
+
+def test_process_reaper_does_not_discard_a_reused_pid() -> None:
+    reaper = ProcessReaper()
+    old_process = cast("subprocess.Popen[bytes]", object())
+    new_process = cast("subprocess.Popen[bytes]", object())
+    loop = cast("ConnectionOperations", object())
+    wrapper = cast("Popen", object())
+    replacement = (new_process, loop, wrapper)
+    reaper.processes[42] = replacement
+
+    assert reaper._discard_process(42, old_process) is False
+    assert reaper.processes[42] is replacement
+    assert reaper._discard_process(42, new_process) is True
+    assert reaper.processes == {}
 
 
 async def test_a_command_runs_and_reports_its_output() -> None:

--- a/zuvloop/_process.py
+++ b/zuvloop/_process.py
@@ -181,6 +181,14 @@ class ProcessReaper:
                 self.started = True
             self.condition.notify()
 
+    def _discard_process(self, pid: int, process: subprocess.Popen[bytes]) -> bool:
+        with self.condition:
+            current = self.processes.get(pid)
+            if current is None or current[0] is not process:
+                return False
+            del self.processes[pid]
+            return True
+
     def run(self) -> None:
         while True:
             with self.condition:
@@ -194,8 +202,7 @@ class ProcessReaper:
                 if returncode is None:
                     continue
                 completed = True
-                with self.condition:
-                    self.processes.pop(pid, None)
+                self._discard_process(pid, process)
                 try:
                     loop.call_soon_threadsafe(wrapper.exited, returncode)
                 except RuntimeError:  # pragma: no cover - loop closed while child exited

--- a/zuvloop/_process.py
+++ b/zuvloop/_process.py
@@ -181,14 +181,6 @@ class ProcessReaper:
                 self.started = True
             self.condition.notify()
 
-    def _discard_process(self, pid: int, process: subprocess.Popen[bytes]) -> bool:
-        with self.condition:
-            current = self.processes.get(pid)
-            if current is None or current[0] is not process:
-                return False
-            del self.processes[pid]
-            return True
-
     def run(self) -> None:
         while True:
             with self.condition:
@@ -202,7 +194,10 @@ class ProcessReaper:
                 if returncode is None:
                     continue
                 completed = True
-                self._discard_process(pid, process)
+                with self.condition:
+                    current = self.processes.get(pid)
+                    if current is not None and current[0] is process:
+                        del self.processes[pid]
                 try:
                     loop.call_soon_threadsafe(wrapper.exited, returncode)
                 except RuntimeError:  # pragma: no cover - loop closed while child exited


### PR DESCRIPTION
## Summary

- Remove a reaped process only when the registered object still matches the process being reaped.
- Add a regression test for PID reuse in the process reaper.

## Why

A stale reaper callback could delete a newer process registration that reused the same PID.

## Impact

Replacement process registrations survive late cleanup from an earlier process with the same PID.

## Validation

- Focused PID-reuse regression: 1 passed.
- Full test suite: 428 passed.
- Ruff and mypy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves replacement process registrations when a PID is reused by only deleting the mapping if the reaped child matches the stored process. Previously the reaper removed by PID alone, which could drop a newer registration after PID reuse.

- Inline the atomic check-and-remove in ProcessReaper.run under the reaper lock (no one-off helper); document this practice in AGENTS.md.
- Add regression test: test_process_reaper_does_not_discard_a_reused_pid.
- No public API changes; exited callbacks still fire for the reaped process, and replacement registrations remain intact.

<sup>Written for commit 4fbb7b7d885b62c1fe179cb984bfafdc50c27735. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/82?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

