### PR TITLE
Benchmark thread-safe timer fairness

### DIFF
--- a/benchmarks/test_benchmarks.py
+++ b/benchmarks/test_benchmarks.py
@@ -114,7 +114,9 @@ def test_threadsafe_flood_timer_fairness(benchmark: BenchmarkFixture, loop: asyn
             self.accepted = [0] * producers
             self.started = 0.0
             self.fired = 0.0
-            self.threads = [threading.Thread(target=self.produce, args=(index,)) for index in range(producers)]
+            self.threads = [
+                threading.Thread(target=self.produce, args=(index,), daemon=True) for index in range(producers)
+            ]
 
         def produce(self, index: int) -> None:
             self.gate.wait()
@@ -122,7 +124,7 @@ def test_threadsafe_flood_timer_fairness(benchmark: BenchmarkFixture, loop: asyn
             while count < limit_per_producer and not self.stop.is_set():
                 loop.call_soon_threadsafe(_noop)
                 count += 1
-                self.accepted[index] = count
+            self.accepted[index] = count
 
         def timer_fired(self) -> None:
             self.stop.set()

--- a/benchmarks/test_benchmarks.py
+++ b/benchmarks/test_benchmarks.py
@@ -100,6 +100,72 @@ def test_call_soon_threadsafe(benchmark: BenchmarkFixture, loop: asyncio.Abstrac
 
 
 @pytest.mark.benchmark
+def test_threadsafe_flood_timer_fairness(
+    benchmark: BenchmarkFixture, loop: asyncio.AbstractEventLoop
+) -> None:
+    """Bounded producer flood around a 10 ms timer, with cleanup between samples."""
+    delay = 0.01
+    producers = 4
+    limit_per_producer = 250_000
+    accepted_samples: list[int] = []
+
+    class Flood:
+        def __init__(self) -> None:
+            self.stop = threading.Event()
+            self.gate = threading.Event()
+            self.accepted = [0] * producers
+            self.started = 0.0
+            self.fired = 0.0
+            self.threads = [threading.Thread(target=self.produce, args=(index,)) for index in range(producers)]
+
+        def produce(self, index: int) -> None:
+            self.gate.wait()
+            count = 0
+            while count < limit_per_producer and not self.stop.is_set():
+                loop.call_soon_threadsafe(_noop)
+                count += 1
+                self.accepted[index] = count
+
+        def timer_fired(self) -> None:
+            self.stop.set()
+            self.fired = loop.time()
+            loop.stop()
+
+    def setup() -> tuple[tuple[Flood], dict[str, int]]:
+        flood = Flood()
+        for thread in flood.threads:
+            thread.start()
+        return (flood,), {}
+
+    def measure(flood: Flood) -> float:
+        flood.started = loop.time()
+        loop.call_later(delay, flood.timer_fired)
+        flood.gate.set()
+        loop.run_forever()
+        return flood.fired - flood.started
+
+    def teardown(flood: Flood) -> None:
+        try:
+            flood.stop.set()
+            flood.gate.set()
+        finally:
+            for thread in flood.threads:
+                thread.join()
+
+        # Every producer has stopped, so this FIFO marker runs after every
+        # callback it accepted and leaves the next benchmark sample clean.
+        drained: asyncio.Future[None] = loop.create_future()
+        loop.call_soon(drained.set_result, None)
+        loop.run_until_complete(drained)
+        accepted_samples.append(sum(flood.accepted))
+
+    latency = benchmark.pedantic(measure, setup=setup, teardown=teardown, rounds=10)
+    assert latency >= delay
+    assert accepted_samples
+    assert all(0 < accepted <= producers * limit_per_producer for accepted in accepted_samples)
+
+
+@pytest.mark.benchmark
 def test_call_soon_args(benchmark: BenchmarkFixture, loop: asyncio.AbstractEventLoop) -> None:
     """Arguments are where the handle layout shows: asyncio packs a tuple per call."""
     iterations = 10_000

--- a/benchmarks/test_benchmarks.py
+++ b/benchmarks/test_benchmarks.py
@@ -100,9 +100,7 @@ def test_call_soon_threadsafe(benchmark: BenchmarkFixture, loop: asyncio.Abstrac
 
 
 @pytest.mark.benchmark
-def test_threadsafe_flood_timer_fairness(
-    benchmark: BenchmarkFixture, loop: asyncio.AbstractEventLoop
-) -> None:
+def test_threadsafe_flood_timer_fairness(benchmark: BenchmarkFixture, loop: asyncio.AbstractEventLoop) -> None:
     """Bounded producer flood around a 10 ms timer, with cleanup between samples."""
     delay = 0.01
     producers = 4


### PR DESCRIPTION
## Summary

- Add a CodSpeed benchmark that measures timer fairness during sustained call_soon_threadsafe traffic.
- Bound producer work and keep setup, teardown, and queue cleanup outside the measured region.
- Exercise asyncio, zuvloop, and uvloop with the same run_forever stop shape.

## Why

The existing benchmarks measure scheduling throughput but do not record how a flood of cross-thread callbacks delays an already-due timer.

## Impact

The benchmark establishes a reproducible baseline for the follow-up scheduling change before that implementation lands.

## Baseline

- asyncio: 10.0 ms timer delay, 0.8% spread.
- zuvloop: 51.1 ms timer delay, 26.5% spread.
- uvloop: 19.1 ms timer delay, 43.9% spread.

## Validation

- Benchmark module: 36 passed in dry-run mode.
- Ruff, mypy, and Zig formatting checks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Measures timer fairness while the loop is flooded via `call_soon_threadsafe`, closing a gap in throughput-only benchmarks and establishing a baseline before scheduler changes.

- Adds `test_threadsafe_flood_timer_fairness`: four bounded producer threads flood `call_soon_threadsafe` around a 10 ms `call_later` timer and record fired−started latency; asserts latency ≥ delay and bounded accepted-callback counts.
- Hardens workers and teardown for reproducibility: gated start, cooperative stop via `Event`, thread joins, and a FIFO drain marker to leave the next sample clean.
- Uses `benchmark.pedantic` with explicit setup/teardown and 10 rounds; runs via the shared `loop` fixture across `asyncio`, `zuvloop`, and `uvloop`.

<sup>Written for commit 276b113e63bad303f920bd7344c6b7ac671ac9b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/83?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

