### PR TITLE
Finalize UNIX server cleanup after errors

### DIFF
--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1056,6 +1056,29 @@ async def test_unix_server_cleanup_tolerates_a_missing_path() -> None:
         await server.wait_closed()
 
 
+async def test_unix_server_cleanup_error_still_wakes_waiters(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    loop = running_loop()
+    with tempfile.TemporaryDirectory() as directory:
+        path = Path(directory) / "denied.sock"
+        server = await loop.create_unix_server(Echo, path)
+        waiting = loop.create_task(server.wait_closed())
+        await asyncio.sleep(0)
+
+        def denied_stat(
+            target: int | str | bytes | os.PathLike[str], *, dir_fd: int | None = None, follow_symlinks: bool = True
+        ) -> os.stat_result:
+            raise PermissionError(target)
+
+        with monkeypatch.context() as patch:
+            patch.setattr(os, "stat", denied_stat)
+            server.close()
+            await asyncio.wait_for(waiting, 2)
+
+        assert "Unable to clean up listening UNIX socket" in caplog.text
+
+
 async def test_unix_server_cleanup_tolerates_a_path_unlinked_while_binding() -> None:
     loop = running_loop()
     with tempfile.TemporaryDirectory() as directory:

--- a/zuvloop/_server.py
+++ b/zuvloop/_server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import socket
 from asyncio import trsock
@@ -10,6 +11,8 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from ._connect import ConnectionOperations
+
+logger = logging.getLogger(__name__)
 
 
 class Server(asyncio.AbstractServer):
@@ -123,15 +126,18 @@ class Server(asyncio.AbstractServer):
         cleanup_identity = self._cleanup_identity
         self._cleanup_path = None
         self._cleanup_identity = None
-        if cleanup_path is not None and cleanup_identity is not None:
-            try:
+        try:
+            if cleanup_path is not None and cleanup_identity is not None:
                 current = os.stat(cleanup_path)
                 if (current.st_dev, current.st_ino) == cleanup_identity:
                     os.unlink(cleanup_path)
-            except FileNotFoundError:
-                pass
-        if self._active == 0:
-            self._wakeup()
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            logger.error("Unable to clean up listening UNIX socket %r: %r", cleanup_path, exc)
+        finally:
+            if self._active == 0:
+                self._wakeup()
 
     def close_clients(self) -> None:
         for transport in tuple(self._transports):


### PR DESCRIPTION
## Summary

- Catch and log filesystem errors while removing a UNIX server socket.
- Wake wait_closed callers from a finally block even when unlinking fails.
- Cover cleanup failure with an existing shutdown waiter.

## Why

An unlink error could interrupt finalization before the close waiter was resolved, leaving callers blocked indefinitely.

## Impact

UNIX server shutdown now completes deterministically while retaining visibility into cleanup errors.

## Validation

- Focused UNIX cleanup regressions: 2 passed.
- Full test suite: 428 passed.
- Ruff and mypy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents hangs during UNIX server shutdown when cleaning up the listening socket fails. Previously, an `OSError` during `stat`/`unlink` could block `wait_closed()` indefinitely; now we log the error and always wake waiters from a finally block.

- Catch and log `OSError` during UNIX socket cleanup (still ignore `FileNotFoundError`) using a module logger; message: "Unable to clean up listening UNIX socket %r: %r".
- Always resolve `wait_closed()` after `close()`, regardless of cleanup outcome.
- Add a regression test that asserts waiters wake and the error is logged; no API changes for successful paths.

<sup>Written for commit 42a0968bf7c963c2a3f8c8c56fa93a40d4029a91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/84?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UNIX socket server shutdown reliability when socket cleanup encounters permission errors.
  * Ensured server shutdown completes promptly and wakes active connections even when cleanup fails.
  * Added logging for socket cleanup failures while continuing to ignore already-missing socket paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->