### PR TITLE
Transfer buffered stream data into TLS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,4 @@
 1. `Any` should be avoided in the Python type hints, and `object` is only marginally better — both are poor choices. Use the proper, most precise type possible.
 2. A performance change lands as two PRs: first the benchmark on its own, then the change itself, so the effect is visible against the recorded baseline.
 3. Private functions that are used only once should not be written; inline their implementation at the sole call site.
+4. Avoid `typing.cast` in Python. Narrow types with runtime checks or improve the underlying annotation or interface instead.

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -137,9 +137,11 @@ async def test_start_tls_consumes_a_buffered_client_hello(
         try:
             assert await reader.readline() == proxy_line
             stream_reader = cast("BufferedStreamReader", reader)
+            async with asyncio.timeout(1):
+                while not stream_reader._paused:  # pragma: no cover - TCP chunking varies by platform
+                    await asyncio.sleep(0)
             buffered = len(stream_reader._buffer)
             assert buffered > 0
-            assert stream_reader._paused is True
             await writer.start_tls(server_context)
             assert stream_reader._paused is False
             payload = await reader.readexactly(6)

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -4,7 +4,7 @@ import asyncio
 import contextlib
 import socket
 import ssl
-from typing import Protocol, cast
+from typing import Protocol, runtime_checkable
 
 import pytest
 
@@ -14,6 +14,7 @@ from zuvloop._server import Server
 pytestmark = pytest.mark.anyio
 
 
+@runtime_checkable
 class BufferedStreamReader(Protocol):
     _buffer: bytearray
     _paused: bool
@@ -170,14 +171,14 @@ async def test_start_tls_consumes_a_buffered_client_hello(
     async def handle_target(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
         try:
             assert await reader.readline() == proxy_line
-            stream_reader = cast("BufferedStreamReader", reader)
+            assert isinstance(reader, BufferedStreamReader)
             async with asyncio.timeout(1):
-                while not stream_reader._paused:  # pragma: no cover - TCP chunking varies by platform
+                while not reader._paused:  # pragma: no cover - TCP chunking varies by platform
                     await asyncio.sleep(0)
-            buffered = len(stream_reader._buffer)
+            buffered = len(reader._buffer)
             assert buffered > 0
             await writer.start_tls(server_context)
-            assert stream_reader._paused is False
+            assert reader._paused is False
             payload = await reader.readexactly(6)
             writer.write(payload)
             await writer.drain()

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -138,7 +138,7 @@ async def test_start_tls_consumes_a_buffered_client_hello(
             writer.write(payload)
             await writer.drain()
             target_done.set_result(buffered)
-        except BaseException as exc:
+        except BaseException as exc:  # pragma: no cover - assertion diagnostic
             if not target_done.done():
                 target_done.set_exception(exc)
         finally:
@@ -166,7 +166,7 @@ async def test_start_tls_consumes_a_buffered_client_hello(
             await loop.sock_connect(remote, target_address)
             client_hello = bytearray()
             while len(client_hello) < 5:
-                client_hello += await loop.sock_recv(client, 65_536)
+                client_hello += await loop.sock_recv(client, 5 - len(client_hello))
             record_size = 5 + int.from_bytes(client_hello[3:5])
             while len(client_hello) < record_size:
                 client_hello += await loop.sock_recv(client, 65_536)
@@ -194,14 +194,14 @@ async def test_start_tls_consumes_a_buffered_client_hello(
         assert await asyncio.wait_for(reader.readexactly(6), 5) == b"secure"
         assert await asyncio.wait_for(target_done, 5) > 0
     finally:
-        if writer is not None:
+        if writer is not None:  # pragma: no branch - open failure is cleanup-only
             writer.close()
             with contextlib.suppress(OSError):
                 await writer.wait_closed()
         listener.close()
         target.close()
         await target.wait_closed()
-        if not proxy_task.done():
+        if not proxy_task.done():  # pragma: no branch - completion timing is platform-dependent
             proxy_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await proxy_task

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -4,13 +4,18 @@ import asyncio
 import contextlib
 import socket
 import ssl
-from typing import cast
+from typing import Protocol, cast
 
 import pytest
 
 from conftest import collect_contexts, running_loop
 
 pytestmark = pytest.mark.anyio
+
+
+class BufferedStreamReader(Protocol):
+    _buffer: bytearray
+    _paused: bool
 
 
 async def echo(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
@@ -131,9 +136,12 @@ async def test_start_tls_consumes_a_buffered_client_hello(
     async def handle_target(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
         try:
             assert await reader.readline() == proxy_line
-            buffered = len(cast("bytearray", getattr(reader, "_buffer")))
+            stream_reader = cast("BufferedStreamReader", reader)
+            buffered = len(stream_reader._buffer)
             assert buffered > 0
+            assert stream_reader._paused is True
             await writer.start_tls(server_context)
+            assert stream_reader._paused is False
             payload = await reader.readexactly(6)
             writer.write(payload)
             await writer.drain()
@@ -146,7 +154,7 @@ async def test_start_tls_consumes_a_buffered_client_hello(
             with contextlib.suppress(OSError):
                 await writer.wait_closed()
 
-    target = await asyncio.start_server(handle_target, "127.0.0.1", 0)
+    target = await asyncio.start_server(handle_target, "127.0.0.1", 0, limit=64)
     target_address = target.sockets[0].getsockname()
     listener = socket.socket()
     listener.bind(("127.0.0.1", 0))

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import socket
 import ssl
+from typing import cast
 
 import pytest
 
@@ -116,6 +119,92 @@ async def test_start_tls_upgrades_a_plain_connection(
         assert await reader.readexactly(10) == b"secure now"
         writer.close()
         await asyncio.sleep(0.05)
+
+
+async def test_start_tls_consumes_a_buffered_client_hello(
+    server_context: ssl.SSLContext, client_context: ssl.SSLContext
+) -> None:
+    loop = running_loop()
+    proxy_line = b"PROXY TCP4 127.0.0.1 127.0.0.1 54321 443\r\n"
+    target_done: asyncio.Future[int] = loop.create_future()
+
+    async def handle_target(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            assert await reader.readline() == proxy_line
+            buffered = len(cast("bytearray", getattr(reader, "_buffer")))
+            assert buffered > 0
+            await writer.start_tls(server_context)
+            payload = await reader.readexactly(6)
+            writer.write(payload)
+            await writer.drain()
+            target_done.set_result(buffered)
+        except BaseException as exc:
+            if not target_done.done():
+                target_done.set_exception(exc)
+        finally:
+            writer.close()
+            with contextlib.suppress(OSError):
+                await writer.wait_closed()
+
+    target = await asyncio.start_server(handle_target, "127.0.0.1", 0)
+    target_address = target.sockets[0].getsockname()
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+    listener.setblocking(False)
+
+    async def relay(source: socket.socket, destination: socket.socket) -> None:
+        while data := await loop.sock_recv(source, 65_536):
+            await loop.sock_sendall(destination, data)
+
+    async def proxy_once() -> None:
+        client, _address = await loop.sock_accept(listener)
+        remote = socket.socket()
+        client.setblocking(False)
+        remote.setblocking(False)
+        try:
+            await loop.sock_connect(remote, target_address)
+            client_hello = bytearray()
+            while len(client_hello) < 5:
+                client_hello += await loop.sock_recv(client, 65_536)
+            record_size = 5 + int.from_bytes(client_hello[3:5])
+            while len(client_hello) < record_size:
+                client_hello += await loop.sock_recv(client, 65_536)
+            await loop.sock_sendall(remote, proxy_line + client_hello)
+
+            relays = [
+                loop.create_task(relay(client, remote)),
+                loop.create_task(relay(remote, client)),
+            ]
+            _done, pending = await asyncio.wait(relays, return_when=asyncio.FIRST_COMPLETED)
+            for task in pending:
+                task.cancel()
+            await asyncio.gather(*relays, return_exceptions=True)
+        finally:
+            client.close()
+            remote.close()
+
+    proxy_task = loop.create_task(proxy_once())
+    writer: asyncio.StreamWriter | None = None
+    try:
+        reader, writer = await asyncio.open_connection(*listener.getsockname())
+        await writer.start_tls(client_context, server_hostname="localhost")
+        writer.write(b"secure")
+        await writer.drain()
+        assert await asyncio.wait_for(reader.readexactly(6), 5) == b"secure"
+        assert await asyncio.wait_for(target_done, 5) > 0
+    finally:
+        if writer is not None:
+            writer.close()
+            with contextlib.suppress(OSError):
+                await writer.wait_closed()
+        listener.close()
+        target.close()
+        await target.wait_closed()
+        if not proxy_task.done():
+            proxy_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await proxy_task
 
 
 async def test_server_side_tls_needs_a_context() -> None:

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -4,7 +4,6 @@ import asyncio
 import contextlib
 import socket
 import ssl
-from typing import Protocol, runtime_checkable
 
 import pytest
 
@@ -12,12 +11,6 @@ from conftest import collect_contexts, running_loop
 from zuvloop._server import Server
 
 pytestmark = pytest.mark.anyio
-
-
-@runtime_checkable
-class BufferedStreamReader(Protocol):
-    _buffer: bytearray
-    _paused: bool
 
 
 async def echo(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
@@ -171,14 +164,14 @@ async def test_start_tls_consumes_a_buffered_client_hello(
     async def handle_target(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
         try:
             assert await reader.readline() == proxy_line
-            assert isinstance(reader, BufferedStreamReader)
+            buffer: bytearray = getattr(reader, "_buffer")
             async with asyncio.timeout(1):
-                while not reader._paused:  # pragma: no cover - TCP chunking varies by platform
+                while not getattr(reader, "_paused"):  # pragma: no cover - TCP chunking varies by platform
                     await asyncio.sleep(0)
-            buffered = len(reader._buffer)
+            buffered = len(buffer)
             assert buffered > 0
             await writer.start_tls(server_context)
-            assert reader._paused is False
+            assert getattr(reader, "_paused") is False
             payload = await reader.readexactly(6)
             writer.write(payload)
             await writer.drain()

--- a/zuvloop/_connect.py
+++ b/zuvloop/_connect.py
@@ -30,7 +30,7 @@ class _BufferedStreamReader(Protocol):
 
 class _BufferedStreamProtocol(Protocol):
     @property
-    def _stream_reader(self) -> _BufferedStreamReader | None: ...
+    def _stream_reader(self) -> _BufferedStreamReader | None: ...  # pragma: no cover - typing-only protocol
 
 
 class ConnectionOperations(SendfileOperations):
@@ -535,7 +535,7 @@ class ConnectionOperations(SendfileOperations):
         stream.pause_reading()
         if server_side and isinstance(protocol, StreamReaderProtocol):
             stream_reader = cast("_BufferedStreamProtocol", protocol)._stream_reader
-            if stream_reader is not None and stream_reader._buffer:
+            if stream_reader is not None and stream_reader._buffer:  # pragma: no branch - only data needs transfer
                 ssl_protocol._incoming.write(stream_reader._buffer)  # type: ignore[attr-defined]
                 stream_reader._buffer.clear()
         stream.set_protocol(ssl_protocol)

--- a/zuvloop/_connect.py
+++ b/zuvloop/_connect.py
@@ -26,6 +26,7 @@ _SSLArg = ssl_module.SSLContext | bool | None
 
 class _BufferedStreamReader(Protocol):
     _buffer: bytearray
+    _paused: bool
 
 
 class _BufferedStreamProtocol(Protocol):
@@ -538,6 +539,7 @@ class ConnectionOperations(SendfileOperations):
             if stream_reader is not None and stream_reader._buffer:  # pragma: no branch - only data needs transfer
                 ssl_protocol._incoming.write(stream_reader._buffer)  # type: ignore[attr-defined]
                 stream_reader._buffer.clear()
+                stream_reader._paused = False
         stream.set_protocol(ssl_protocol)
         self.call_soon(ssl_protocol.connection_made, stream)
         self.call_soon(stream.resume_reading)

--- a/zuvloop/_connect.py
+++ b/zuvloop/_connect.py
@@ -10,8 +10,9 @@ import stat
 import subprocess
 from asyncio import base_subprocess, sslproto, staggered, trsock
 from asyncio.base_events import _interleave_addrinfos  # type: ignore[attr-defined]  # private, not in typeshed
+from asyncio.streams import StreamReaderProtocol
 from collections.abc import Awaitable, Callable, Sequence
-from typing import Any, Protocol, cast, runtime_checkable
+from typing import Any, Protocol, cast
 
 from . import _zuvloop
 from ._process import Popen
@@ -26,12 +27,6 @@ _SSLArg = ssl_module.SSLContext | bool | None
 class _BufferedStreamReader(Protocol):
     _buffer: bytearray
     _paused: bool
-
-
-@runtime_checkable
-class _BufferedStreamProtocol(Protocol):
-    @property
-    def _stream_reader(self) -> _BufferedStreamReader | None: ...  # pragma: no cover - typing-only protocol
 
 
 class ConnectionOperations(SendfileOperations):
@@ -543,8 +538,8 @@ class ConnectionOperations(SendfileOperations):
         )
         stream = cast("asyncio.Transport", transport)
         stream.pause_reading()
-        if server_side and isinstance(protocol, _BufferedStreamProtocol):
-            stream_reader = protocol._stream_reader
+        if server_side and isinstance(protocol, StreamReaderProtocol):
+            stream_reader: _BufferedStreamReader | None = getattr(protocol, "_stream_reader", None)
             if stream_reader is not None and stream_reader._buffer:  # pragma: no branch - only data needs transfer
                 ssl_protocol._incoming.write(stream_reader._buffer)  # type: ignore[attr-defined]
                 stream_reader._buffer.clear()

--- a/zuvloop/_connect.py
+++ b/zuvloop/_connect.py
@@ -10,8 +10,9 @@ import stat
 import subprocess
 from asyncio import base_subprocess, sslproto, staggered, trsock
 from asyncio.base_events import _interleave_addrinfos  # type: ignore[attr-defined]  # private, not in typeshed
+from asyncio.streams import StreamReaderProtocol
 from collections.abc import Awaitable, Callable, Sequence
-from typing import Any, cast
+from typing import Any, Protocol, cast
 
 from . import _zuvloop
 from ._process import Popen
@@ -21,6 +22,15 @@ from ._server import Server
 # What `getaddrinfo` hands back: family, kind, protocol, canonical name, address.
 type _AddrInfo = tuple[int, int, int, str, tuple[str, int] | tuple[str, int, int, int]]
 _SSLArg = ssl_module.SSLContext | bool | None
+
+
+class _BufferedStreamReader(Protocol):
+    _buffer: bytearray
+
+
+class _BufferedStreamProtocol(Protocol):
+    @property
+    def _stream_reader(self) -> _BufferedStreamReader | None: ...
 
 
 class ConnectionOperations(SendfileOperations):
@@ -523,6 +533,11 @@ class ConnectionOperations(SendfileOperations):
         )
         stream = cast("asyncio.Transport", transport)
         stream.pause_reading()
+        if server_side and isinstance(protocol, StreamReaderProtocol):
+            stream_reader = cast("_BufferedStreamProtocol", protocol)._stream_reader
+            if stream_reader is not None and stream_reader._buffer:
+                ssl_protocol._incoming.write(stream_reader._buffer)  # type: ignore[attr-defined]
+                stream_reader._buffer.clear()
         stream.set_protocol(ssl_protocol)
         self.call_soon(ssl_protocol.connection_made, stream)
         self.call_soon(stream.resume_reading)

--- a/zuvloop/_connect.py
+++ b/zuvloop/_connect.py
@@ -10,9 +10,8 @@ import stat
 import subprocess
 from asyncio import base_subprocess, sslproto, staggered, trsock
 from asyncio.base_events import _interleave_addrinfos  # type: ignore[attr-defined]  # private, not in typeshed
-from asyncio.streams import StreamReaderProtocol
 from collections.abc import Awaitable, Callable, Sequence
-from typing import Any, Protocol, cast
+from typing import Any, Protocol, cast, runtime_checkable
 
 from . import _zuvloop
 from ._process import Popen
@@ -29,6 +28,7 @@ class _BufferedStreamReader(Protocol):
     _paused: bool
 
 
+@runtime_checkable
 class _BufferedStreamProtocol(Protocol):
     @property
     def _stream_reader(self) -> _BufferedStreamReader | None: ...  # pragma: no cover - typing-only protocol
@@ -543,8 +543,8 @@ class ConnectionOperations(SendfileOperations):
         )
         stream = cast("asyncio.Transport", transport)
         stream.pause_reading()
-        if server_side and isinstance(protocol, StreamReaderProtocol):
-            stream_reader = cast("_BufferedStreamProtocol", protocol)._stream_reader
+        if server_side and isinstance(protocol, _BufferedStreamProtocol):
+            stream_reader = protocol._stream_reader
             if stream_reader is not None and stream_reader._buffer:  # pragma: no branch - only data needs transfer
                 ssl_protocol._incoming.write(stream_reader._buffer)  # type: ignore[attr-defined]
                 stream_reader._buffer.clear()


### PR DESCRIPTION
## Summary

- Move already-buffered server-side StreamReaderProtocol data into the TLS protocol before switching transports.
- Clear the original buffer after transferring ownership.
- Add a proxy-style integration test with a PROXY header and ClientHello arriving together.

## Why

Data read ahead by the plaintext stream protocol could remain stranded when start_tls replaced the protocol, causing the TLS handshake to stall.

## Impact

Server-side TLS upgrades preserve bytes that arrived before the protocol switch, including combined proxy-header and handshake packets.

## Validation

- Focused proxy and TLS integration regression: 1 passed.
- Full test suite: 428 passed.
- Ruff, mypy, and native build checks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Transfers bytes buffered by the plaintext `StreamReaderProtocol` into TLS during server-side `start_tls` to prevent handshake stalls. Previously, read-ahead bytes were stranded when swapping protocols; now they are written into TLS `_incoming`, the buffer is cleared, and reader backpressure is reset.

- Server-side only; guards via concrete `StreamReaderProtocol` and a minimal `_BufferedStreamReader` Protocol; client-side unchanged.
- Sequence: pause reading; move buffered bytes into TLS `_incoming`; clear buffer; set `_paused = False`; swap protocol; resume reading.
- Reduces `typing.cast` usage with concrete narrowing and a Protocol; documents the guidance in `AGENTS.md`.
- Adds a deterministic proxy-style integration test that coalesces a PROXY line and ClientHello, waits for backpressure, then asserts buffer consumption and unpause; handshake and echo succeed.
- No public API changes; relies on `asyncio` internals and is covered by tests.

<sup>Written for commit d51da7cc93cc9ff1ad93421f1fea395e9acfa5e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/85?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS upgrades for connections with buffered incoming data.
  * Buffered client handshake data is now processed correctly, allowing encrypted communication to begin reliably.
  * Reading resumes properly after the TLS transition, with improved cleanup and error handling.
* **Tests**
  * Added integration coverage for TLS negotiation through socket proxies and buffered streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->