### PR TITLE
Preserve abstract UNIX datagram addresses

### DIFF
--- a/tests/test_datagram.py
+++ b/tests/test_datagram.py
@@ -438,9 +438,7 @@ async def test_abstract_unix_datagram_sender_address_is_preserved() -> None:
     suffix = f"{os.getpid()}-{os.urandom(6).hex()}".encode()
     receiver_name = b"\0zuvloop-receiver-" + suffix
     sender_name = b"\0zuvloop-sender-" + suffix
-    receiver, protocol = await loop.create_datagram_endpoint(
-        Collector, local_addr=receiver_name, family=socket.AF_UNIX
-    )
+    receiver, protocol = await loop.create_datagram_endpoint(Collector, local_addr=receiver_name, family=socket.AF_UNIX)
     sender, _sender_protocol = await loop.create_datagram_endpoint(
         Collector, local_addr=sender_name, family=socket.AF_UNIX
     )

--- a/tests/test_datagram.py
+++ b/tests/test_datagram.py
@@ -436,7 +436,7 @@ async def test_unix_datagram_endpoints_round_trip() -> None:
 async def test_abstract_unix_datagram_sender_address_is_preserved() -> None:  # pragma: no cover - Linux CI
     loop = running_loop()
     suffix = f"{os.getpid()}-{os.urandom(6).hex()}".encode()
-    receiver_name = b"\0zuvloop-receiver-" + suffix
+    receiver_name = b"\0zuvloop-receiver-" + suffix + b"\0"
     sender_name = b"\0zuvloop-sender-" + suffix + b"\0"
     receiver, protocol = await loop.create_datagram_endpoint(Collector, local_addr=receiver_name, family=socket.AF_UNIX)
     sender, _sender_protocol = await loop.create_datagram_endpoint(

--- a/tests/test_datagram.py
+++ b/tests/test_datagram.py
@@ -433,7 +433,7 @@ async def test_unix_datagram_endpoints_round_trip() -> None:
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="abstract AF_UNIX names are a Linux feature")
-async def test_abstract_unix_datagram_sender_address_is_preserved() -> None:
+async def test_abstract_unix_datagram_sender_address_is_preserved() -> None:  # pragma: no cover - Linux CI
     loop = running_loop()
     suffix = f"{os.getpid()}-{os.urandom(6).hex()}".encode()
     receiver_name = b"\0zuvloop-receiver-" + suffix

--- a/tests/test_datagram.py
+++ b/tests/test_datagram.py
@@ -437,7 +437,7 @@ async def test_abstract_unix_datagram_sender_address_is_preserved() -> None:  # 
     loop = running_loop()
     suffix = f"{os.getpid()}-{os.urandom(6).hex()}".encode()
     receiver_name = b"\0zuvloop-receiver-" + suffix
-    sender_name = b"\0zuvloop-sender-" + suffix
+    sender_name = b"\0zuvloop-sender-" + suffix + b"\0"
     receiver, protocol = await loop.create_datagram_endpoint(Collector, local_addr=receiver_name, family=socket.AF_UNIX)
     sender, _sender_protocol = await loop.create_datagram_endpoint(
         Collector, local_addr=sender_name, family=socket.AF_UNIX

--- a/tests/test_datagram.py
+++ b/tests/test_datagram.py
@@ -18,7 +18,7 @@ from zuvloop import _connect, _zuvloop
 
 pytestmark = pytest.mark.anyio
 
-Address = tuple[str, int] | str | bytes
+Address = tuple[str, int] | str | bytes | None
 
 
 @contextlib.contextmanager
@@ -447,6 +447,22 @@ async def test_abstract_unix_datagram_sender_address_is_preserved() -> None:  # 
         assert protocol.done is not None
         assert await asyncio.wait_for(protocol.done, 2) == b"abstract"
         assert protocol.received == [(b"abstract", sender_name)]
+    finally:
+        sender.close()
+        receiver.close()
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="abstract AF_UNIX names are a Linux feature")
+async def test_unnamed_unix_datagram_sender_has_no_address() -> None:  # pragma: no cover - Linux CI
+    loop = running_loop()
+    receiver_name = b"\0zuvloop-receiver-" + f"{os.getpid()}-{os.urandom(6).hex()}".encode()
+    receiver, protocol = await loop.create_datagram_endpoint(Collector, local_addr=receiver_name, family=socket.AF_UNIX)
+    sender, _sender_protocol = await loop.create_datagram_endpoint(Collector, family=socket.AF_UNIX)
+    try:
+        sender.sendto(b"unnamed", receiver_name)
+        assert protocol.done is not None
+        assert await asyncio.wait_for(protocol.done, 2) == b"unnamed"
+        assert protocol.received == [(b"unnamed", None)]
     finally:
         sender.close()
         receiver.close()

--- a/tests/test_datagram.py
+++ b/tests/test_datagram.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import os
 import shutil
 import socket
+import sys
 import tempfile
 from collections.abc import Iterator
 from pathlib import Path
@@ -16,7 +18,7 @@ from zuvloop import _connect, _zuvloop
 
 pytestmark = pytest.mark.anyio
 
-Address = tuple[str, int] | str
+Address = tuple[str, int] | str | bytes
 
 
 @contextlib.contextmanager
@@ -77,9 +79,9 @@ class Collector(asyncio.DatagramProtocol):
             self.lost.set_result(exc)
 
 
-async def start_echo() -> tuple[asyncio.DatagramTransport, Echo, Address]:
+async def start_echo() -> tuple[asyncio.DatagramTransport, Echo, tuple[str, int]]:
     transport, protocol = await running_loop().create_datagram_endpoint(Echo, local_addr=("127.0.0.1", 0))
-    return transport, protocol, transport.get_extra_info("sockname")
+    return transport, protocol, cast("tuple[str, int]", transport.get_extra_info("sockname"))
 
 
 async def test_datagram_round_trip() -> None:
@@ -428,6 +430,28 @@ async def test_unix_datagram_endpoints_round_trip() -> None:
         finally:
             client.close()
             server.close()
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="abstract AF_UNIX names are a Linux feature")
+async def test_abstract_unix_datagram_sender_address_is_preserved() -> None:
+    loop = running_loop()
+    suffix = f"{os.getpid()}-{os.urandom(6).hex()}".encode()
+    receiver_name = b"\0zuvloop-receiver-" + suffix
+    sender_name = b"\0zuvloop-sender-" + suffix
+    receiver, protocol = await loop.create_datagram_endpoint(
+        Collector, local_addr=receiver_name, family=socket.AF_UNIX
+    )
+    sender, _sender_protocol = await loop.create_datagram_endpoint(
+        Collector, local_addr=sender_name, family=socket.AF_UNIX
+    )
+    try:
+        sender.sendto(b"abstract", receiver_name)
+        assert protocol.done is not None
+        assert await asyncio.wait_for(protocol.done, 2) == b"abstract"
+        assert protocol.received == [(b"abstract", sender_name)]
+    finally:
+        sender.close()
+        receiver.close()
 
 
 async def test_a_connected_unix_endpoint_accepts_the_path_it_is_connected_to() -> None:

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -10,10 +10,10 @@ The tree under `libuv/` is the upstream release with the patches under `patches/
 **Never edit it directly.** Update the corresponding patch instead. `build.zig` compiles the vendored
 sources with the same defines and file lists as upstream's `CMakeLists.txt`.
 
-`0001-expose-udp-recv-address-length.patch` preserves the kernel-reported `sockaddr` length through
-libuv's UDP receive callback. Linux needs that length to distinguish abstract UNIX names whose bytes
-differ only by trailing NULs. The updater applies the patch before replacing the existing tree and
-fails if a future libuv release no longer accepts it cleanly.
+`0001-expose-udp-recv-address-length.patch` preserves both the kernel-reported source length and the
+caller-supplied destination length through libuv's UDP paths. Linux needs those lengths to distinguish
+abstract UNIX names whose bytes differ only by trailing NULs. The updater applies the patch before
+replacing the existing tree and fails if a future libuv release no longer accepts it cleanly.
 
 A weekly workflow checks for a new signed release, verifies its signer against
 `libuv-maintainer-keys.txt`, tests every supported target, and opens an update pull request. For a

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -6,9 +6,14 @@
 - Source: <https://dist.libuv.org/dist/v1.51.0/libuv-v1.51.0.tar.gz>
 - SHA-256: `5f0557b90b1106de71951a3c3931de5e0430d78da1d9a10287ebc7a3f78ef8eb`
 
-The tree under `libuv/` is the upstream release tarball, extracted verbatim. **Never edit it.**
-Everything zuvloop adds lives in `zig/`, and `build.zig` compiles the vendored sources with the same
-defines and file lists as upstream's `CMakeLists.txt`.
+The tree under `libuv/` is the upstream release with the patches under `patches/libuv/` applied.
+**Never edit it directly.** Update the corresponding patch instead. `build.zig` compiles the vendored
+sources with the same defines and file lists as upstream's `CMakeLists.txt`.
+
+`0001-expose-udp-recv-address-length.patch` preserves the kernel-reported `sockaddr` length through
+libuv's UDP receive callback. Linux needs that length to distinguish abstract UNIX names whose bytes
+differ only by trailing NULs. The updater applies the patch before replacing the existing tree and
+fails if a future libuv release no longer accepts it cleanly.
 
 A weekly workflow checks for a new signed release, verifies its signer against
 `libuv-maintainer-keys.txt`, tests every supported target, and opens an update pull request. For a

--- a/vendor/libuv/include/uv.h
+++ b/vendor/libuv/include/uv.h
@@ -775,10 +775,22 @@ UV_EXTERN int uv_udp_send(uv_udp_send_t* req,
                           unsigned int nbufs,
                           const struct sockaddr* addr,
                           uv_udp_send_cb send_cb);
+UV_EXTERN int uv_udp_send_with_addrlen(uv_udp_send_t* req,
+                                       uv_udp_t* handle,
+                                       const uv_buf_t bufs[],
+                                       unsigned int nbufs,
+                                       const struct sockaddr* addr,
+                                       unsigned int addrlen,
+                                       uv_udp_send_cb send_cb);
 UV_EXTERN int uv_udp_try_send(uv_udp_t* handle,
                               const uv_buf_t bufs[],
                               unsigned int nbufs,
                               const struct sockaddr* addr);
+UV_EXTERN int uv_udp_try_send_with_addrlen(uv_udp_t* handle,
+                                           const uv_buf_t bufs[],
+                                           unsigned int nbufs,
+                                           const struct sockaddr* addr,
+                                           unsigned int addrlen);
 UV_EXTERN int uv_udp_try_send2(uv_udp_t* handle,
                                unsigned int count,
                                uv_buf_t* bufs[/*count*/],

--- a/vendor/libuv/include/uv.h
+++ b/vendor/libuv/include/uv.h
@@ -727,6 +727,8 @@ struct uv_udp_s {
    * Number of send requests currently in the queue awaiting to be processed.
    */
   size_t send_queue_count;
+  /* Length of the source address passed to the current receive callback. */
+  size_t recv_addrlen;
   UV_UDP_PRIVATE_FIELDS
 };
 
@@ -790,6 +792,7 @@ UV_EXTERN int uv_udp_using_recvmmsg(const uv_udp_t* handle);
 UV_EXTERN int uv_udp_recv_stop(uv_udp_t* handle);
 UV_EXTERN size_t uv_udp_get_send_queue_size(const uv_udp_t* handle);
 UV_EXTERN size_t uv_udp_get_send_queue_count(const uv_udp_t* handle);
+UV_EXTERN size_t uv_udp_get_recv_addrlen(const uv_udp_t* handle);
 
 
 /*

--- a/vendor/libuv/include/uv/unix.h
+++ b/vendor/libuv/include/uv/unix.h
@@ -275,6 +275,7 @@ typedef struct {
     struct sockaddr addr;                                                     \
     struct sockaddr_storage storage;                                          \
   } u;                                                                        \
+  unsigned int addrlen;                                                       \
   unsigned int nbufs;                                                         \
   uv_buf_t* bufs;                                                             \
   ssize_t status;                                                             \

--- a/vendor/libuv/src/unix/udp.c
+++ b/vendor/libuv/src/unix/udp.c
@@ -50,7 +50,8 @@ static int uv__udp_maybe_deferred_bind(uv_udp_t* handle,
 static int uv__udp_sendmsg1(int fd,
                             const uv_buf_t* bufs,
                             unsigned int nbufs,
-                            const struct sockaddr* addr);
+                            const struct sockaddr* addr,
+                            unsigned int addrlen);
 
 
 void uv__udp_close(uv_udp_t* handle) {
@@ -604,6 +605,7 @@ int uv__udp_send(uv_udp_send_t* req,
     req->u.storage.ss_family = AF_UNSPEC;
   else
     memcpy(&req->u.storage, addr, addrlen);
+  req->addrlen = addrlen;
   req->send_cb = send_cb;
   req->handle = handle;
   req->nbufs = nbufs;
@@ -662,7 +664,11 @@ int uv__udp_try_send(uv_udp_t* handle,
     assert(handle->flags & UV_HANDLE_UDP_CONNECTED);
   }
 
-  err = uv__udp_sendmsg1(handle->io_watcher.fd, bufs, nbufs, addr);
+  err = uv__udp_sendmsg1(handle->io_watcher.fd,
+                         bufs,
+                         nbufs,
+                         addr,
+                         addrlen);
   if (err > 0)
     return uv__count_bufs(bufs, nbufs);
 
@@ -1248,13 +1254,18 @@ int uv__udp_recv_stop(uv_udp_t* handle) {
 static int uv__udp_prep_pkt(struct msghdr* h,
                             const uv_buf_t* bufs,
                             const unsigned int nbufs,
-                            const struct sockaddr* addr) {
+                            const struct sockaddr* addr,
+                            unsigned int addrlen) {
   memset(h, 0, sizeof(*h));
   h->msg_name = (void*) addr;
   h->msg_iov = (void*) bufs;
   h->msg_iovlen = nbufs;
   if (addr == NULL)
     return 0;
+  if (addrlen != 0) {
+    h->msg_namelen = addrlen;
+    return 0;
+  }
   switch (addr->sa_family) {
   case AF_INET:
     h->msg_namelen = sizeof(struct sockaddr_in);
@@ -1262,23 +1273,9 @@ static int uv__udp_prep_pkt(struct msghdr* h,
   case AF_INET6:
     h->msg_namelen = sizeof(struct sockaddr_in6);
     return 0;
-  case AF_UNIX: {
-#if defined(__linux__)
-    const struct sockaddr_un* un;
-    size_t path_len;
-
-    un = (const struct sockaddr_un*) addr;
-    if (un->sun_path[0] == '\0') {
-      path_len = sizeof(un->sun_path);
-      while (path_len > 1 && un->sun_path[path_len - 1] == '\0')
-        path_len--;
-      h->msg_namelen = offsetof(struct sockaddr_un, sun_path) + path_len;
-      return 0;
-    }
-#endif
+  case AF_UNIX:
     h->msg_namelen = sizeof(struct sockaddr_un);
     return 0;
-  }
   case AF_UNSPEC:
     h->msg_name = NULL;
     return 0;
@@ -1290,11 +1287,12 @@ static int uv__udp_prep_pkt(struct msghdr* h,
 static int uv__udp_sendmsg1(int fd,
                             const uv_buf_t* bufs,
                             unsigned int nbufs,
-                            const struct sockaddr* addr) {
+                            const struct sockaddr* addr,
+                            unsigned int addrlen) {
   struct msghdr h;
   int r;
 
-  if ((r = uv__udp_prep_pkt(&h, bufs, nbufs, addr)))
+  if ((r = uv__udp_prep_pkt(&h, bufs, nbufs, addr, addrlen)))
     return r;
 
   do
@@ -1319,7 +1317,8 @@ static int uv__udp_sendmsgv(int fd,
                             unsigned int count,
                             uv_buf_t* bufs[/*count*/],
                             unsigned int nbufs[/*count*/],
-                            struct sockaddr* addrs[/*count*/]) {
+                            struct sockaddr* addrs[/*count*/],
+                            unsigned int addrlens[/*count*/]) {
   unsigned int i;
   int nsent;
   int r;
@@ -1335,7 +1334,11 @@ static int uv__udp_sendmsgv(int fd,
       unsigned int n;
 
       for (n = 0; i < count && n < ARRAY_SIZE(m); i++, n++)
-        if ((r = uv__udp_prep_pkt(&m[n].msg_hdr, bufs[i], nbufs[i], addrs[i])))
+        if ((r = uv__udp_prep_pkt(&m[n].msg_hdr,
+                                  bufs[i],
+                                  nbufs[i],
+                                  addrs[i],
+                                  addrlens == NULL ? 0 : addrlens[i])))
           goto exit;
 
       do
@@ -1360,7 +1363,11 @@ static int uv__udp_sendmsgv(int fd,
 	 */
 
   for (i = 0; i < count; i++, nsent++)
-    if ((r = uv__udp_sendmsg1(fd, bufs[i], nbufs[i], addrs[i])))
+    if ((r = uv__udp_sendmsg1(fd,
+                              bufs[i],
+                              nbufs[i],
+                              addrs[i],
+                              addrlens == NULL ? 0 : addrlens[i])))
       goto exit;  /* goto to avoid unused label warning. */
 
 exit:
@@ -1381,6 +1388,7 @@ exit:
 static void uv__udp_sendmsg(uv_udp_t* handle) {
   static const int N = 20;
   struct sockaddr* addrs[N];
+  unsigned int addrlens[N];
   unsigned int nbufs[N];
   uv_buf_t* bufs[N];
   struct uv__queue* q;
@@ -1396,13 +1404,19 @@ again:
   do {
     req = uv__queue_data(q, uv_udp_send_t, queue);
     addrs[n] = &req->u.addr;
+    addrlens[n] = req->addrlen;
     nbufs[n] = req->nbufs;
     bufs[n] = req->bufs;
     q = uv__queue_next(q);
     n++;
   } while (n < N && q != &handle->write_queue);
 
-  n = uv__udp_sendmsgv(handle->io_watcher.fd, n, bufs, nbufs, addrs);
+  n = uv__udp_sendmsgv(handle->io_watcher.fd,
+                       n,
+                       bufs,
+                       nbufs,
+                       addrs,
+                       addrlens);
   while (n > 0) {
     q = uv__queue_head(&handle->write_queue);
     req = uv__queue_data(q, uv_udp_send_t, queue);
@@ -1446,5 +1460,5 @@ int uv__udp_try_send2(uv_udp_t* handle,
   if (fd == -1)
     return UV_EINVAL;
 
-  return uv__udp_sendmsgv(fd, count, bufs, nbufs, addrs);
+  return uv__udp_sendmsgv(fd, count, bufs, nbufs, addrs, NULL);
 }

--- a/vendor/libuv/src/unix/udp.c
+++ b/vendor/libuv/src/unix/udp.c
@@ -203,6 +203,7 @@ static int uv__udp_recvmmsg(uv_udp_t* handle, uv_buf_t* buf) {
         flags |= UV_UDP_PARTIAL;
 
       chunk_buf = uv_buf_init(iov[k].iov_base, iov[k].iov_len);
+      handle->recv_addrlen = msgs[k].msg_hdr.msg_namelen;
       handle->recv_cb(handle,
                       msgs[k].msg_len,
                       &chunk_buf,
@@ -275,6 +276,7 @@ static void uv__udp_recvmsg(uv_udp_t* handle) {
       if (h.msg_flags & MSG_TRUNC)
         flags |= UV_UDP_PARTIAL;
 
+      handle->recv_addrlen = h.msg_namelen;
       handle->recv_cb(handle, nread, &buf, (const struct sockaddr*) &peer, flags);
     }
     count--;

--- a/vendor/libuv/src/unix/udp.c
+++ b/vendor/libuv/src/unix/udp.c
@@ -1260,9 +1260,23 @@ static int uv__udp_prep_pkt(struct msghdr* h,
   case AF_INET6:
     h->msg_namelen = sizeof(struct sockaddr_in6);
     return 0;
-  case AF_UNIX:
+  case AF_UNIX: {
+#if defined(__linux__)
+    const struct sockaddr_un* un;
+    size_t path_len;
+
+    un = (const struct sockaddr_un*) addr;
+    if (un->sun_path[0] == '\0') {
+      path_len = sizeof(un->sun_path);
+      while (path_len > 1 && un->sun_path[path_len - 1] == '\0')
+        path_len--;
+      h->msg_namelen = offsetof(struct sockaddr_un, sun_path) + path_len;
+      return 0;
+    }
+#endif
     h->msg_namelen = sizeof(struct sockaddr_un);
     return 0;
+  }
   case AF_UNSPEC:
     h->msg_name = NULL;
     return 0;

--- a/vendor/libuv/src/uv-common.c
+++ b/vendor/libuv/src/uv-common.c
@@ -484,6 +484,27 @@ int uv__udp_check_before_send(uv_udp_t* handle, const struct sockaddr* addr) {
 }
 
 
+static int uv__udp_check_explicit_addrlen(uv_udp_t* handle,
+                                          const struct sockaddr* addr,
+                                          unsigned int addrlen) {
+  int max_addrlen;
+
+  max_addrlen = uv__udp_check_before_send(handle, addr);
+  if (max_addrlen < 0)
+    return max_addrlen;
+  if (addr == NULL)
+    return addrlen == 0 ? 0 : UV_EINVAL;
+#if defined(AF_UNIX) && !defined(_WIN32)
+  if (addr->sa_family == AF_UNIX)
+    return addrlen >= offsetof(struct sockaddr_un, sun_path) &&
+                   addrlen <= (unsigned int) max_addrlen
+        ? (int) addrlen
+        : UV_EINVAL;
+#endif
+  return addrlen == (unsigned int) max_addrlen ? (int) addrlen : UV_EINVAL;
+}
+
+
 int uv_udp_send(uv_udp_send_t* req,
                 uv_udp_t* handle,
                 const uv_buf_t bufs[],
@@ -500,6 +521,29 @@ int uv_udp_send(uv_udp_send_t* req,
 }
 
 
+int uv_udp_send_with_addrlen(uv_udp_send_t* req,
+                             uv_udp_t* handle,
+                             const uv_buf_t bufs[],
+                             unsigned int nbufs,
+                             const struct sockaddr* addr,
+                             unsigned int addrlen,
+                             uv_udp_send_cb send_cb) {
+  int checked_addrlen;
+
+  checked_addrlen = uv__udp_check_explicit_addrlen(handle, addr, addrlen);
+  if (checked_addrlen < 0)
+    return checked_addrlen;
+
+  return uv__udp_send(req,
+                      handle,
+                      bufs,
+                      nbufs,
+                      addr,
+                      checked_addrlen,
+                      send_cb);
+}
+
+
 int uv_udp_try_send(uv_udp_t* handle,
                     const uv_buf_t bufs[],
                     unsigned int nbufs,
@@ -511,6 +555,21 @@ int uv_udp_try_send(uv_udp_t* handle,
     return addrlen;
 
   return uv__udp_try_send(handle, bufs, nbufs, addr, addrlen);
+}
+
+
+int uv_udp_try_send_with_addrlen(uv_udp_t* handle,
+                                 const uv_buf_t bufs[],
+                                 unsigned int nbufs,
+                                 const struct sockaddr* addr,
+                                 unsigned int addrlen) {
+  int checked_addrlen;
+
+  checked_addrlen = uv__udp_check_explicit_addrlen(handle, addr, addrlen);
+  if (checked_addrlen < 0)
+    return checked_addrlen;
+
+  return uv__udp_try_send(handle, bufs, nbufs, addr, checked_addrlen);
 }
 
 

--- a/vendor/libuv/src/uv-data-getter-setters.c
+++ b/vendor/libuv/src/uv-data-getter-setters.c
@@ -86,6 +86,10 @@ size_t uv_udp_get_send_queue_count(const uv_udp_t* handle) {
   return handle->send_queue_count;
 }
 
+size_t uv_udp_get_recv_addrlen(const uv_udp_t* handle) {
+  return handle->recv_addrlen;
+}
+
 uv_pid_t uv_process_get_pid(const uv_process_t* proc) {
   return proc->pid;
 }

--- a/vendor/patches/.gitattributes
+++ b/vendor/patches/.gitattributes
@@ -1,0 +1,1 @@
+*.patch -whitespace

--- a/vendor/patches/libuv/0001-expose-udp-recv-address-length.patch
+++ b/vendor/patches/libuv/0001-expose-udp-recv-address-length.patch
@@ -1,0 +1,78 @@
+diff --git a/include/uv.h b/include/uv.h
+--- a/include/uv.h
++++ b/include/uv.h
+@@ -727,6 +727,8 @@ struct uv_udp_s {
+    * Number of send requests currently in the queue awaiting to be processed.
+    */
+   size_t send_queue_count;
++  /* Length of the source address passed to the current receive callback. */
++  size_t recv_addrlen;
+   UV_UDP_PRIVATE_FIELDS
+ };
+ 
+@@ -790,6 +792,7 @@ UV_EXTERN int uv_udp_using_recvmmsg(const uv_udp_t* handle);
+ UV_EXTERN int uv_udp_recv_stop(uv_udp_t* handle);
+ UV_EXTERN size_t uv_udp_get_send_queue_size(const uv_udp_t* handle);
+ UV_EXTERN size_t uv_udp_get_send_queue_count(const uv_udp_t* handle);
++UV_EXTERN size_t uv_udp_get_recv_addrlen(const uv_udp_t* handle);
+ 
+ 
+ /*
+diff --git a/src/unix/udp.c b/src/unix/udp.c
+--- a/src/unix/udp.c
++++ b/src/unix/udp.c
+@@ -203,6 +203,7 @@ static int uv__udp_recvmmsg(uv_udp_t* handle, uv_buf_t* buf) {
+         flags |= UV_UDP_PARTIAL;
+ 
+       chunk_buf = uv_buf_init(iov[k].iov_base, iov[k].iov_len);
++      handle->recv_addrlen = msgs[k].msg_hdr.msg_namelen;
+       handle->recv_cb(handle,
+                       msgs[k].msg_len,
+                       &chunk_buf,
+@@ -275,6 +276,7 @@ static void uv__udp_recvmsg(uv_udp_t* handle) {
+       if (h.msg_flags & MSG_TRUNC)
+         flags |= UV_UDP_PARTIAL;
+ 
++      handle->recv_addrlen = h.msg_namelen;
+       handle->recv_cb(handle, nread, &buf, (const struct sockaddr*) &peer, flags);
+     }
+     count--;
+@@ -1260,9 +1262,23 @@ static int uv__udp_prep_pkt(struct msghdr* h,
+   case AF_INET6:
+     h->msg_namelen = sizeof(struct sockaddr_in6);
+     return 0;
+-  case AF_UNIX:
++  case AF_UNIX: {
++#if defined(__linux__)
++    const struct sockaddr_un* un;
++    size_t path_len;
++
++    un = (const struct sockaddr_un*) addr;
++    if (un->sun_path[0] == '\0') {
++      path_len = sizeof(un->sun_path);
++      while (path_len > 1 && un->sun_path[path_len - 1] == '\0')
++        path_len--;
++      h->msg_namelen = offsetof(struct sockaddr_un, sun_path) + path_len;
++      return 0;
++    }
++#endif
+     h->msg_namelen = sizeof(struct sockaddr_un);
+     return 0;
++  }
+   case AF_UNSPEC:
+     h->msg_name = NULL;
+     return 0;
+diff --git a/src/uv-data-getter-setters.c b/src/uv-data-getter-setters.c
+--- a/src/uv-data-getter-setters.c
++++ b/src/uv-data-getter-setters.c
+@@ -86,6 +86,10 @@ size_t uv_udp_get_send_queue_count(const uv_udp_t* handle) {
+   return handle->send_queue_count;
+ }
+ 
++size_t uv_udp_get_recv_addrlen(const uv_udp_t* handle) {
++  return handle->recv_addrlen;
++}
++
+ uv_pid_t uv_process_get_pid(const uv_process_t* proc) {
+   return proc->pid;
+ }

--- a/vendor/patches/libuv/0001-expose-udp-recv-address-length.patch
+++ b/vendor/patches/libuv/0001-expose-udp-recv-address-length.patch
@@ -10,7 +10,30 @@ diff --git a/include/uv.h b/include/uv.h
    UV_UDP_PRIVATE_FIELDS
  };
  
-@@ -790,6 +792,7 @@ UV_EXTERN int uv_udp_using_recvmmsg(const uv_udp_t* handle);
+@@ -773,10 +775,22 @@ UV_EXTERN int uv_udp_send(uv_udp_send_t* req,
+                           unsigned int nbufs,
+                           const struct sockaddr* addr,
+                           uv_udp_send_cb send_cb);
++UV_EXTERN int uv_udp_send_with_addrlen(uv_udp_send_t* req,
++                                       uv_udp_t* handle,
++                                       const uv_buf_t bufs[],
++                                       unsigned int nbufs,
++                                       const struct sockaddr* addr,
++                                       unsigned int addrlen,
++                                       uv_udp_send_cb send_cb);
+ UV_EXTERN int uv_udp_try_send(uv_udp_t* handle,
+                               const uv_buf_t bufs[],
+                               unsigned int nbufs,
+                               const struct sockaddr* addr);
++UV_EXTERN int uv_udp_try_send_with_addrlen(uv_udp_t* handle,
++                                           const uv_buf_t bufs[],
++                                           unsigned int nbufs,
++                                           const struct sockaddr* addr,
++                                           unsigned int addrlen);
+ UV_EXTERN int uv_udp_try_send2(uv_udp_t* handle,
+                                unsigned int count,
+                                uv_buf_t* bufs[/*count*/],
+@@ -790,6 +804,7 @@ UV_EXTERN int uv_udp_using_recvmmsg(const uv_udp_t* handle);
  UV_EXTERN int uv_udp_recv_stop(uv_udp_t* handle);
  UV_EXTERN size_t uv_udp_get_send_queue_size(const uv_udp_t* handle);
  UV_EXTERN size_t uv_udp_get_send_queue_count(const uv_udp_t* handle);
@@ -18,10 +41,31 @@ diff --git a/include/uv.h b/include/uv.h
  
  
  /*
+diff --git a/include/uv/unix.h b/include/uv/unix.h
+--- a/include/uv/unix.h
++++ b/include/uv/unix.h
+@@ -275,6 +275,7 @@ typedef struct {
+     struct sockaddr addr;                                                     \
+     struct sockaddr_storage storage;                                          \
+   } u;                                                                        \
++  unsigned int addrlen;                                                       \
+   unsigned int nbufs;                                                         \
+   uv_buf_t* bufs;                                                             \
+   ssize_t status;                                                             \
 diff --git a/src/unix/udp.c b/src/unix/udp.c
 --- a/src/unix/udp.c
 +++ b/src/unix/udp.c
-@@ -203,6 +203,7 @@ static int uv__udp_recvmmsg(uv_udp_t* handle, uv_buf_t* buf) {
+@@ -50,7 +50,8 @@ static int uv__udp_maybe_deferred_bind(uv_udp_t* handle,
+ static int uv__udp_sendmsg1(int fd,
+                             const uv_buf_t* bufs,
+                             unsigned int nbufs,
+-                            const struct sockaddr* addr);
++                            const struct sockaddr* addr,
++                            unsigned int addrlen);
+ 
+ 
+ void uv__udp_close(uv_udp_t* handle) {
+@@ -203,6 +204,7 @@ static int uv__udp_recvmmsg(uv_udp_t* handle, uv_buf_t* buf) {
          flags |= UV_UDP_PARTIAL;
  
        chunk_buf = uv_buf_init(iov[k].iov_base, iov[k].iov_len);
@@ -29,7 +73,7 @@ diff --git a/src/unix/udp.c b/src/unix/udp.c
        handle->recv_cb(handle,
                        msgs[k].msg_len,
                        &chunk_buf,
-@@ -275,6 +276,7 @@ static void uv__udp_recvmsg(uv_udp_t* handle) {
+@@ -275,6 +277,7 @@ static void uv__udp_recvmsg(uv_udp_t* handle) {
        if (h.msg_flags & MSG_TRUNC)
          flags |= UV_UDP_PARTIAL;
  
@@ -37,31 +81,217 @@ diff --git a/src/unix/udp.c b/src/unix/udp.c
        handle->recv_cb(handle, nread, &buf, (const struct sockaddr*) &peer, flags);
      }
      count--;
-@@ -1260,9 +1262,23 @@ static int uv__udp_prep_pkt(struct msghdr* h,
-   case AF_INET6:
-     h->msg_namelen = sizeof(struct sockaddr_in6);
+@@ -602,6 +605,7 @@ int uv__udp_send(uv_udp_send_t* req,
+     req->u.storage.ss_family = AF_UNSPEC;
+   else
+     memcpy(&req->u.storage, addr, addrlen);
++  req->addrlen = addrlen;
+   req->send_cb = send_cb;
+   req->handle = handle;
+   req->nbufs = nbufs;
+@@ -660,7 +664,11 @@ int uv__udp_try_send(uv_udp_t* handle,
+     assert(handle->flags & UV_HANDLE_UDP_CONNECTED);
+   }
+ 
+-  err = uv__udp_sendmsg1(handle->io_watcher.fd, bufs, nbufs, addr);
++  err = uv__udp_sendmsg1(handle->io_watcher.fd,
++                         bufs,
++                         nbufs,
++                         addr,
++                         addrlen);
+   if (err > 0)
+     return uv__count_bufs(bufs, nbufs);
+ 
+@@ -1246,13 +1254,18 @@ int uv__udp_recv_stop(uv_udp_t* handle) {
+ static int uv__udp_prep_pkt(struct msghdr* h,
+                             const uv_buf_t* bufs,
+                             const unsigned int nbufs,
+-                            const struct sockaddr* addr) {
++                            const struct sockaddr* addr,
++                            unsigned int addrlen) {
+   memset(h, 0, sizeof(*h));
+   h->msg_name = (void*) addr;
+   h->msg_iov = (void*) bufs;
+   h->msg_iovlen = nbufs;
+   if (addr == NULL)
      return 0;
--  case AF_UNIX:
-+  case AF_UNIX: {
-+#if defined(__linux__)
-+    const struct sockaddr_un* un;
-+    size_t path_len;
-+
-+    un = (const struct sockaddr_un*) addr;
-+    if (un->sun_path[0] == '\0') {
-+      path_len = sizeof(un->sun_path);
-+      while (path_len > 1 && un->sun_path[path_len - 1] == '\0')
-+        path_len--;
-+      h->msg_namelen = offsetof(struct sockaddr_un, sun_path) + path_len;
-+      return 0;
-+    }
-+#endif
-     h->msg_namelen = sizeof(struct sockaddr_un);
-     return 0;
++  if (addrlen != 0) {
++    h->msg_namelen = addrlen;
++    return 0;
 +  }
-   case AF_UNSPEC:
-     h->msg_name = NULL;
-     return 0;
+   switch (addr->sa_family) {
+   case AF_INET:
+     h->msg_namelen = sizeof(struct sockaddr_in);
+@@ -1274,11 +1287,12 @@ static int uv__udp_prep_pkt(struct msghdr* h,
+ static int uv__udp_sendmsg1(int fd,
+                             const uv_buf_t* bufs,
+                             unsigned int nbufs,
+-                            const struct sockaddr* addr) {
++                            const struct sockaddr* addr,
++                            unsigned int addrlen) {
+   struct msghdr h;
+   int r;
+ 
+-  if ((r = uv__udp_prep_pkt(&h, bufs, nbufs, addr)))
++  if ((r = uv__udp_prep_pkt(&h, bufs, nbufs, addr, addrlen)))
+     return r;
+ 
+   do
+@@ -1303,7 +1317,8 @@ static int uv__udp_sendmsgv(int fd,
+                             unsigned int count,
+                             uv_buf_t* bufs[/*count*/],
+                             unsigned int nbufs[/*count*/],
+-                            struct sockaddr* addrs[/*count*/]) {
++                            struct sockaddr* addrs[/*count*/],
++                            unsigned int addrlens[/*count*/]) {
+   unsigned int i;
+   int nsent;
+   int r;
+@@ -1319,7 +1334,11 @@ static int uv__udp_sendmsgv(int fd,
+       unsigned int n;
+ 
+       for (n = 0; i < count && n < ARRAY_SIZE(m); i++, n++)
+-        if ((r = uv__udp_prep_pkt(&m[n].msg_hdr, bufs[i], nbufs[i], addrs[i])))
++        if ((r = uv__udp_prep_pkt(&m[n].msg_hdr,
++                                  bufs[i],
++                                  nbufs[i],
++                                  addrs[i],
++                                  addrlens == NULL ? 0 : addrlens[i])))
+           goto exit;
+ 
+       do
+@@ -1344,7 +1363,11 @@ static int uv__udp_sendmsgv(int fd,
+ 	 */
+ 
+   for (i = 0; i < count; i++, nsent++)
+-    if ((r = uv__udp_sendmsg1(fd, bufs[i], nbufs[i], addrs[i])))
++    if ((r = uv__udp_sendmsg1(fd,
++                              bufs[i],
++                              nbufs[i],
++                              addrs[i],
++                              addrlens == NULL ? 0 : addrlens[i])))
+       goto exit;  /* goto to avoid unused label warning. */
+ 
+ exit:
+@@ -1365,6 +1388,7 @@ exit:
+ static void uv__udp_sendmsg(uv_udp_t* handle) {
+   static const int N = 20;
+   struct sockaddr* addrs[N];
++  unsigned int addrlens[N];
+   unsigned int nbufs[N];
+   uv_buf_t* bufs[N];
+   struct uv__queue* q;
+@@ -1380,13 +1404,19 @@ again:
+   do {
+     req = uv__queue_data(q, uv_udp_send_t, queue);
+     addrs[n] = &req->u.addr;
++    addrlens[n] = req->addrlen;
+     nbufs[n] = req->nbufs;
+     bufs[n] = req->bufs;
+     q = uv__queue_next(q);
+     n++;
+   } while (n < N && q != &handle->write_queue);
+ 
+-  n = uv__udp_sendmsgv(handle->io_watcher.fd, n, bufs, nbufs, addrs);
++  n = uv__udp_sendmsgv(handle->io_watcher.fd,
++                       n,
++                       bufs,
++                       nbufs,
++                       addrs,
++                       addrlens);
+   while (n > 0) {
+     q = uv__queue_head(&handle->write_queue);
+     req = uv__queue_data(q, uv_udp_send_t, queue);
+@@ -1430,5 +1460,5 @@ int uv__udp_try_send2(uv_udp_t* handle,
+   if (fd == -1)
+     return UV_EINVAL;
+ 
+-  return uv__udp_sendmsgv(fd, count, bufs, nbufs, addrs);
++  return uv__udp_sendmsgv(fd, count, bufs, nbufs, addrs, NULL);
+ }
+diff --git a/src/uv-common.c b/src/uv-common.c
+--- a/src/uv-common.c
++++ b/src/uv-common.c
+@@ -484,6 +484,27 @@ int uv__udp_check_before_send(uv_udp_t* handle, const struct sockaddr* addr) {
+ }
+ 
+ 
++static int uv__udp_check_explicit_addrlen(uv_udp_t* handle,
++                                          const struct sockaddr* addr,
++                                          unsigned int addrlen) {
++  int max_addrlen;
++
++  max_addrlen = uv__udp_check_before_send(handle, addr);
++  if (max_addrlen < 0)
++    return max_addrlen;
++  if (addr == NULL)
++    return addrlen == 0 ? 0 : UV_EINVAL;
++#if defined(AF_UNIX) && !defined(_WIN32)
++  if (addr->sa_family == AF_UNIX)
++    return addrlen >= offsetof(struct sockaddr_un, sun_path) &&
++                   addrlen <= (unsigned int) max_addrlen
++        ? (int) addrlen
++        : UV_EINVAL;
++#endif
++  return addrlen == (unsigned int) max_addrlen ? (int) addrlen : UV_EINVAL;
++}
++
++
+ int uv_udp_send(uv_udp_send_t* req,
+                 uv_udp_t* handle,
+                 const uv_buf_t bufs[],
+@@ -500,6 +521,29 @@ int uv_udp_send(uv_udp_send_t* req,
+ }
+ 
+ 
++int uv_udp_send_with_addrlen(uv_udp_send_t* req,
++                             uv_udp_t* handle,
++                             const uv_buf_t bufs[],
++                             unsigned int nbufs,
++                             const struct sockaddr* addr,
++                             unsigned int addrlen,
++                             uv_udp_send_cb send_cb) {
++  int checked_addrlen;
++
++  checked_addrlen = uv__udp_check_explicit_addrlen(handle, addr, addrlen);
++  if (checked_addrlen < 0)
++    return checked_addrlen;
++
++  return uv__udp_send(req,
++                      handle,
++                      bufs,
++                      nbufs,
++                      addr,
++                      checked_addrlen,
++                      send_cb);
++}
++
++
+ int uv_udp_try_send(uv_udp_t* handle,
+                     const uv_buf_t bufs[],
+                     unsigned int nbufs,
+@@ -514,6 +558,21 @@ int uv_udp_try_send(uv_udp_t* handle,
+ }
+ 
+ 
++int uv_udp_try_send_with_addrlen(uv_udp_t* handle,
++                                 const uv_buf_t bufs[],
++                                 unsigned int nbufs,
++                                 const struct sockaddr* addr,
++                                 unsigned int addrlen) {
++  int checked_addrlen;
++
++  checked_addrlen = uv__udp_check_explicit_addrlen(handle, addr, addrlen);
++  if (checked_addrlen < 0)
++    return checked_addrlen;
++
++  return uv__udp_try_send(handle, bufs, nbufs, addr, checked_addrlen);
++}
++
++
+ int uv_udp_try_send2(uv_udp_t* handle,
+                      unsigned int count,
+                      uv_buf_t* bufs[/*count*/],
 diff --git a/src/uv-data-getter-setters.c b/src/uv-data-getter-setters.c
 --- a/src/uv-data-getter-setters.c
 +++ b/src/uv-data-getter-setters.c

--- a/vendor/update-libuv.sh
+++ b/vendor/update-libuv.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Replace vendor/libuv with a pristine upstream release tarball.
+# Replace vendor/libuv with an upstream release and reapply zuvloop's patches.
 set -euo pipefail
 
 version="${1:?usage: update-libuv.sh <version> <sha256>, e.g. 1.51.0 5f0557...}"
@@ -21,6 +21,7 @@ trap 'rm -rf "$tmp"' EXIT
 curl -fsSL "$url" -o "$tmp/libuv.tar.gz"
 printf '%s  %s\n' "$checksum" "$tmp/libuv.tar.gz" | shasum -a 256 -c -
 tar xzf "$tmp/libuv.tar.gz" -C "$tmp"
+patch --batch --forward -d "$tmp/libuv-v${version}" -p1 < "$here/patches/libuv/0001-expose-udp-recv-address-length.patch"
 rm -rf "$here/libuv"
 mv "$tmp/libuv-v${version}" "$here/libuv"
 

--- a/zig/addr.zig
+++ b/zig/addr.zig
@@ -95,8 +95,16 @@ pub fn toPython(sa: *const posix.sockaddr) py.Error!*py.Object {
     const family: c_int = sa.family;
     if (family == AF_UNIX) {
         const un: *const posix.sockaddr.un = @ptrCast(@alignCast(sa));
+        if (un.path[0] == 0) {
+            // libuv zeroes the sockaddr_storage before recvmsg but does not
+            // expose msg_namelen, so retain the abstract prefix and trim only
+            // the unused zero-filled tail.
+            var len = un.path.len;
+            while (len > 1 and un.path[len - 1] == 0) len -= 1;
+            return py.bytes(un.path[0..len]) orelse py.Error.Python;
+        }
         const len = std.mem.indexOfScalar(u8, &un.path, 0) orelse un.path.len;
-        return py.str(un.path[0..len]) orelse py.Error.Python;
+        return c.PyUnicode_DecodeFSDefaultAndSize(@ptrCast(&un.path), @intCast(len)) orelse py.Error.Python;
     }
     if (family != AF_INET and family != AF_INET6) return py.noneRef();
 

--- a/zig/addr.zig
+++ b/zig/addr.zig
@@ -90,18 +90,13 @@ pub fn fromPython(family: c_int, address: *py.Object, out: *Storage) py.Error!c_
     return @sizeOf(posix.sockaddr.in);
 }
 
-/// Builds the tuple `socket.getsockname()` would return for `sa`.
-pub fn toPython(sa: *const posix.sockaddr) py.Error!*py.Object {
+/// Builds the Python address that corresponds to `sa` and its kernel-reported length.
+pub fn toPython(sa: *const posix.sockaddr, sa_len: c_int) py.Error!*py.Object {
     const family: c_int = sa.family;
     if (family == AF_UNIX) {
         const un: *const posix.sockaddr.un = @ptrCast(@alignCast(sa));
         if (un.path[0] == 0) {
-            // libuv zeroes the sockaddr_storage before recvmsg but does not
-            // expose msg_namelen, so retain the abstract prefix and trim only
-            // the unused zero-filled tail.
-            var len = un.path.len;
-            while (len > 1 and un.path[len - 1] == 0) len -= 1;
-            return py.bytes(un.path[0..len]) orelse py.Error.Python;
+            return py.bytes(unixName(sa, sa_len)) orelse py.Error.Python;
         }
         const len = std.mem.indexOfScalar(u8, &un.path, 0) orelse un.path.len;
         return c.PyUnicode_DecodeFSDefaultAndSize(@ptrCast(&un.path), @intCast(len)) orelse py.Error.Python;

--- a/zig/addr.zig
+++ b/zig/addr.zig
@@ -94,6 +94,7 @@ pub fn fromPython(family: c_int, address: *py.Object, out: *Storage) py.Error!c_
 pub fn toPython(sa: *const posix.sockaddr, sa_len: c_int) py.Error!*py.Object {
     const family: c_int = sa.family;
     if (family == AF_UNIX) {
+        if (sa_len <= UN_BASE) return py.noneRef();
         const un: *const posix.sockaddr.un = @ptrCast(@alignCast(sa));
         if (un.path[0] == 0) {
             return py.bytes(unixName(sa, sa_len)) orelse py.Error.Python;

--- a/zig/addr.zig
+++ b/zig/addr.zig
@@ -99,8 +99,8 @@ pub fn toPython(sa: *const posix.sockaddr, sa_len: c_int) py.Error!*py.Object {
         if (un.path[0] == 0) {
             return py.bytes(unixName(sa, sa_len)) orelse py.Error.Python;
         }
-        const len = std.mem.indexOfScalar(u8, &un.path, 0) orelse un.path.len;
-        return c.PyUnicode_DecodeFSDefaultAndSize(@ptrCast(&un.path), @intCast(len)) orelse py.Error.Python;
+        const path = unixName(sa, sa_len);
+        return c.PyUnicode_DecodeFSDefaultAndSize(@ptrCast(path.ptr), @intCast(path.len)) orelse py.Error.Python;
     }
     if (family != AF_INET and family != AF_INET6) return py.noneRef();
 

--- a/zig/datagram.zig
+++ b/zig/datagram.zig
@@ -259,7 +259,7 @@ fn onSent(req: ?*uv.UdpSend, status: c_int) callconv(.c) void {
     if (self.write_buffer_size == 0 and self.flags & CLOSING != 0) shutdownAndClose(self);
 }
 
-fn queueSend(self: *Datagram, buf: uv.Buf, dest: ?*const std.posix.sockaddr) py.Error!void {
+fn queueSend(self: *Datagram, buf: uv.Buf, dest: ?*const std.posix.sockaddr, dest_len: c_uint) py.Error!void {
     const total = send_req_offset + uv.uv_req_size(.udp_send) + buf.len;
     const raw = alloc.alignedAlloc(u8, .@"16", total) catch return py.errNoMemory();
     const wr: *SendReq = @ptrCast(raw.ptr);
@@ -270,12 +270,13 @@ fn queueSend(self: *Datagram, buf: uv.Buf, dest: ?*const std.posix.sockaddr) py.
 
     const send_buf = uv.Buf{ .base = wr.payload(), .len = buf.len };
     py.incref(self);
-    const status = uv.uv_udp_send(
+    const status = uv.uv_udp_send_with_addrlen(
         wr.req(),
         self.udp(),
         @ptrCast(&send_buf),
         1,
         if (wr.has_dest) wr.dest.ptr() else null,
+        dest_len,
         onSent,
     );
     if (status < 0) {
@@ -373,8 +374,9 @@ fn sendto(self_obj: *py.Object, args: []const ?*py.Object, nargs: usize, kwnames
     const target = if (address) |a| (if (py.isNone(a)) null else address) else null;
     var dest: addr.Storage = .{};
     var dest_ptr: ?*const std.posix.sockaddr = null;
+    var dest_len: c_int = 0;
     if (target) |t| {
-        const dest_len = try addr.fromPython(self.family, t, &dest);
+        dest_len = try addr.fromPython(self.family, t, &dest);
         if (self.flags & CONNECTED != 0) {
             // Naming the peer is allowed, as it is for asyncio; naming anything
             // else is not.
@@ -404,7 +406,7 @@ fn sendto(self_obj: *py.Object, args: []const ?*py.Object, nargs: usize, kwnames
     const buf = uv.Buf{ .base = @ptrCast(view.buf), .len = @intCast(view.len) };
 
     if (self.write_buffer_size == 0) {
-        const sent = uv.uv_udp_try_send(self.udp(), @ptrCast(&buf), 1, dest_ptr);
+        const sent = uv.uv_udp_try_send_with_addrlen(self.udp(), @ptrCast(&buf), 1, dest_ptr, if (dest_ptr == null) 0 else @intCast(dest_len));
         if (sent >= 0) return py.noneRef();
         if (sent != uv.EAGAIN) {
             // asyncio reports a failed datagram to the protocol rather than
@@ -416,7 +418,7 @@ fn sendto(self_obj: *py.Object, args: []const ?*py.Object, nargs: usize, kwnames
             return py.noneRef();
         }
     }
-    try queueSend(self, buf, dest_ptr);
+    try queueSend(self, buf, dest_ptr, if (dest_ptr == null) 0 else @intCast(dest_len));
     return py.noneRef();
 }
 

--- a/zig/datagram.zig
+++ b/zig/datagram.zig
@@ -214,7 +214,7 @@ fn onRecv(
         return;
     };
     defer py.decref(data);
-    const sender = addr.toPython(from.?) catch {
+    const sender = addr.toPython(from.?, @intCast(uv.uv_udp_get_recv_addrlen(handle.?))) catch {
         // The datagram cannot be delivered without naming its sender, and a
         // receive failure is what `error_received` exists to report.
         const exc = c.PyErr_GetRaisedException() orelse return;

--- a/zig/dns.zig
+++ b/zig/dns.zig
@@ -258,7 +258,7 @@ fn buildResults(res: ?*std.c.addrinfo) py.Error!*py.Object {
             cachedEnum(&kind_cache, socket_kind, ai.socktype),
             c.PyLong_FromLong(ai.protocol),
             if (ai.canonname) |cn| py.strZ(cn) else py.str(""),
-            addr.toPython(sa) catch null,
+            addr.toPython(sa, 0) catch null,
         };
         for (fields, 0..) |field, i| {
             if (field == null) {

--- a/zig/dns.zig
+++ b/zig/dns.zig
@@ -258,7 +258,7 @@ fn buildResults(res: ?*std.c.addrinfo) py.Error!*py.Object {
             cachedEnum(&kind_cache, socket_kind, ai.socktype),
             c.PyLong_FromLong(ai.protocol),
             if (ai.canonname) |cn| py.strZ(cn) else py.str(""),
-            addr.toPython(sa, 0) catch null,
+            addr.toPython(sa, @intCast(ai.addrlen)) catch null,
         };
         for (fields, 0..) |field, i| {
             if (field == null) {

--- a/zig/uv.zig
+++ b/zig/uv.zig
@@ -289,6 +289,7 @@ pub extern fn uv_udp_bind(handle: *Udp, addr: *const std.posix.sockaddr, flags: 
 pub extern fn uv_udp_connect(handle: *Udp, addr: ?*const std.posix.sockaddr) c_int;
 pub extern fn uv_udp_getsockname(handle: *const Udp, name: *std.posix.sockaddr, namelen: *c_int) c_int;
 pub extern fn uv_udp_getpeername(handle: *const Udp, name: *std.posix.sockaddr, namelen: *c_int) c_int;
+pub extern fn uv_udp_get_recv_addrlen(handle: *const Udp) usize;
 pub extern fn uv_udp_send(req: *UdpSend, handle: *Udp, bufs: [*]const Buf, nbufs: c_uint, addr: ?*const std.posix.sockaddr, cb: UdpSendCb) c_int;
 pub extern fn uv_udp_try_send(handle: *Udp, bufs: [*]const Buf, nbufs: c_uint, addr: ?*const std.posix.sockaddr) c_int;
 pub extern fn uv_udp_recv_start(handle: *Udp, alloc_cb: AllocCb, recv_cb: UdpRecvCb) c_int;

--- a/zig/uv.zig
+++ b/zig/uv.zig
@@ -291,7 +291,9 @@ pub extern fn uv_udp_getsockname(handle: *const Udp, name: *std.posix.sockaddr, 
 pub extern fn uv_udp_getpeername(handle: *const Udp, name: *std.posix.sockaddr, namelen: *c_int) c_int;
 pub extern fn uv_udp_get_recv_addrlen(handle: *const Udp) usize;
 pub extern fn uv_udp_send(req: *UdpSend, handle: *Udp, bufs: [*]const Buf, nbufs: c_uint, addr: ?*const std.posix.sockaddr, cb: UdpSendCb) c_int;
+pub extern fn uv_udp_send_with_addrlen(req: *UdpSend, handle: *Udp, bufs: [*]const Buf, nbufs: c_uint, addr: ?*const std.posix.sockaddr, addrlen: c_uint, cb: UdpSendCb) c_int;
 pub extern fn uv_udp_try_send(handle: *Udp, bufs: [*]const Buf, nbufs: c_uint, addr: ?*const std.posix.sockaddr) c_int;
+pub extern fn uv_udp_try_send_with_addrlen(handle: *Udp, bufs: [*]const Buf, nbufs: c_uint, addr: ?*const std.posix.sockaddr, addrlen: c_uint) c_int;
 pub extern fn uv_udp_recv_start(handle: *Udp, alloc_cb: AllocCb, recv_cb: UdpRecvCb) c_int;
 pub extern fn uv_udp_recv_stop(handle: *Udp) c_int;
 pub extern fn uv_udp_set_broadcast(handle: *Udp, on: c_int) c_int;

--- a/zuvloop/_connect.py
+++ b/zuvloop/_connect.py
@@ -20,6 +20,7 @@ from ._server import Server
 
 # What `getaddrinfo` hands back: family, kind, protocol, canonical name, address.
 type _AddrInfo = tuple[int, int, int, str, tuple[str, int] | tuple[str, int, int, int]]
+type _DatagramAddress = tuple[str, int] | str | bytes
 _SSLArg = ssl_module.SSLContext | bool | None
 
 
@@ -538,8 +539,8 @@ class ConnectionOperations(SendfileOperations):
     async def create_datagram_endpoint(  # type: ignore[override]  # typeshed omits reuse_port
         self,
         protocol_factory: Callable[[], asyncio.BaseProtocol],
-        local_addr: tuple[str, int] | str | None = None,
-        remote_addr: tuple[str, int] | str | None = None,
+        local_addr: _DatagramAddress | None = None,
+        remote_addr: _DatagramAddress | None = None,
         *,
         family: int = 0,
         proto: int = 0,
@@ -579,8 +580,8 @@ class ConnectionOperations(SendfileOperations):
 
     async def _bind_datagram(
         self,
-        local_addr: tuple[str, int] | str | None,
-        remote_addr: tuple[str, int] | str | None,
+        local_addr: _DatagramAddress | None,
+        remote_addr: _DatagramAddress | None,
         family: int,
         proto: int,
         flags: int,
@@ -616,7 +617,7 @@ class ConnectionOperations(SendfileOperations):
         return sock, resolved_remote is not None
 
     async def _resolve_datagram(
-        self, address: tuple[str, int] | str | None, family: int, proto: int, flags: int
+        self, address: _DatagramAddress | None, family: int, proto: int, flags: int
     ) -> Any:
         if address is None:
             return None

--- a/zuvloop/_connect.py
+++ b/zuvloop/_connect.py
@@ -616,9 +616,7 @@ class ConnectionOperations(SendfileOperations):
             raise
         return sock, resolved_remote is not None
 
-    async def _resolve_datagram(
-        self, address: _DatagramAddress | None, family: int, proto: int, flags: int
-    ) -> Any:
+    async def _resolve_datagram(self, address: _DatagramAddress | None, family: int, proto: int, flags: int) -> Any:
         if address is None:
             return None
         if family == socket.AF_UNIX:


### PR DESCRIPTION
## Summary

- Return abstract AF_UNIX addresses as bytes so their leading NUL is preserved.
- Trim unused zero-filled sockaddr storage without applying filesystem decoding.
- Send the actual abstract address length through the vendored libuv UDP path.
- Extend Python typing to include byte-valued datagram addresses.

## Why

Abstract UNIX datagram addresses were decoded like filesystem paths and sent with a full sockaddr_un length, which changed their identity on Linux.

## Impact

Linux abstract datagram endpoints now round-trip and send correctly using their exact byte address.

## Validation

- macOS UNIX datagram tests: 3 passed, Linux-only case skipped.
- Full ReleaseSafe suite: 427 passed, 1 skipped.
- Linux Docker regression: 1 passed.
- Ruff, mypy, Zig formatting, and native build checks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves Linux abstract AF_UNIX datagram addresses and unnamed sender semantics by carrying kernel-reported sockaddr lengths end to end, including explicit destination lengths on send. Previously abstract names were decoded as filesystem paths and sent with a full `sockaddr_un`; unnamed senders surfaced a path. Now abstract names are bytes, unnamed senders are None, and we pass the exact source and destination lengths through `libuv` and Zig.

- API: `create_datagram_endpoint` accepts `bytes` for AF_UNIX `local_addr`/`remote_addr`; datagram callbacks may receive `bytes` for abstract senders and `None` for unnamed senders. Callers that assumed `str` must handle `bytes` and `None`.
- `libuv` (Linux): track source address length via `recv_addrlen` and expose it as `uv_udp_get_recv_addrlen`; add `uv_udp_send_with_addrlen`/`uv_udp_try_send_with_addrlen` and store per-send `addrlen` so AF_UNIX destinations use the exact length; other platforms unchanged.
- Zig: `addr.toPython(sa, sa_len)` now requires a length; returns `bytes` for abstract and `None` for unnamed; datagram receive uses `uv_udp_get_recv_addrlen`; datagram send uses the new `uv_udp_*_with_addrlen`; DNS paths pass resolver-reported lengths.
- Vendor: vendored `libuv` is upstream plus patches; `vendor/update-libuv.sh` reapplies `patches/libuv/0001-expose-udp-recv-address-length.patch` and fails if it no longer applies cleanly.
- Tests: add Linux-only cases that round-trip abstract names (including embedded NULs) and report `None` for unnamed senders; skipped on other platforms and excluded from macOS coverage.

<sup>Written for commit 0909d905e9d10dc0a9391c0efae578daeeb591f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for abstract Unix datagram socket addresses.
  * Preserved named sender addresses and correctly reports unnamed senders.
  * Datagram endpoints now accept and resolve broader address formats, including byte-based addresses.

* **Bug Fixes**
  * Improved address handling by using the kernel-reported address length.
  * Correctly trims abstract Unix socket names and distinguishes empty addresses from valid paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->