### PR TITLE
Close clients when serve_forever is cancelled

### DIFF
--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1697,27 +1697,24 @@ async def test_closing_a_server_releases_serve_forever() -> None:
         await asyncio.wait_for(task, 5)
 
 
-async def test_cancelling_serve_forever_waits_for_its_connections() -> None:
-    """asyncio closes and waits before re-raising, so "stopped" means stopped."""
+async def test_cancelling_serve_forever_closes_its_connections() -> None:
     loop = running_loop()
     server, port, _ = await start_echo()
     task = loop.create_task(server.serve_forever())
     await asyncio.sleep(0.02)
-    _reader, writer = await asyncio.open_connection("127.0.0.1", port)
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
     await asyncio.sleep(0.02)
 
     task.cancel()
-    stopping = asyncio.ensure_future(task)
-    await asyncio.sleep(0.05)
-    assert not stopping.done()  # still seeing the connection out
-
-    writer.close()
-    await writer.wait_closed()
     with pytest.raises(asyncio.CancelledError):
-        await asyncio.wait_for(stopping, 5)
+        await asyncio.wait_for(task, 5)
+    assert await asyncio.wait_for(reader.read(), 5) == b""
     assert not server.is_serving()
     with pytest.raises(ConnectionRefusedError):
         await asyncio.open_connection("127.0.0.1", port)
+
+    writer.close()
+    await writer.wait_closed()
 
 
 async def test_aborting_a_backed_up_transport_reports_no_reason() -> None:

--- a/zuvloop/_server.py
+++ b/zuvloop/_server.py
@@ -174,11 +174,9 @@ class Server(asyncio.AbstractServer):
         try:
             await self._serving_forever
         except asyncio.CancelledError:
-            # Whether the cancellation came from `close()` or from the caller,
-            # the connections still up are the server's to see out before it can
-            # honestly say it has stopped.
             try:
                 self.close()
+                self.close_clients()
                 await self.wait_closed()
             finally:
                 raise


### PR DESCRIPTION
## Summary

- Close the server and all connected clients when serve_forever is cancelled.
- Wait for listener and client shutdown to complete.
- Add an integration regression that observes prompt EOF on the client.

## Why

Cancellation previously stopped the serving coroutine but could leave accepted client connections alive.

## Impact

Cancelling serve_forever now performs a complete server shutdown and releases connected clients promptly.

## Validation

- Focused cancellation regressions: 2 passed.
- Full test suite: 427 passed.
- Ruff and mypy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cancelling `serve_forever` now closes all active client connections and waits for shutdown before re-raising. Previously, cancellation stopped accepting but could leave connected clients alive; clients now receive a prompt EOF.

- In `zuvloop._server.serve_forever`, on `CancelledError` we call `close()`, `close_clients()`, and await `wait_closed()` before re-raising.
- Updated test `test_cancelling_serve_forever_closes_its_connections` verifies EOF on the client and that new connections are refused post-shutdown.
- No API changes; cancellation semantics now guarantee listener and client closure.

<sup>Written for commit a2e6e5f3ca09b039cefd51c3561cd247437bf6b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/87?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

