### PR TITLE
Simplify accept retry handling

### DIFF
--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -12,7 +12,7 @@ import tempfile
 from asyncio import constants, trsock
 from collections.abc import Iterator, Sequence
 from pathlib import Path
-from typing import NoReturn, cast
+from typing import NoReturn
 
 import pytest
 
@@ -81,24 +81,18 @@ class Collector(asyncio.Protocol):
         self.done.set_result(bytes(self.received))
 
 
-class ExhaustedListener:
+class ExhaustedListener(socket.socket):
     def __init__(self, sock: socket.socket, error: int) -> None:
-        self.sock = sock
+        super().__init__(fileno=sock.detach())
         self.error = error
         self.accepts = 0
 
-    def listen(self, _backlog: int) -> None:
+    def listen(self, _backlog: int = 0, /) -> None:
         pass
-
-    def fileno(self) -> int:
-        return self.sock.fileno()
 
     def accept(self) -> NoReturn:
         self.accepts += 1
         raise OSError(self.error, os.strerror(self.error))
-
-    def close(self) -> None:
-        self.sock.close()
 
 
 async def start_echo(backlog: int = 100) -> tuple[zuvloop.Server, int, list[Echo]]:
@@ -1304,7 +1298,7 @@ async def test_accept_resource_exhaustion_backs_off(error: int, monkeypatch: pyt
     loop = running_loop()
     listener_sock, notifier = socket.socketpair()
     listener = ExhaustedListener(listener_sock, error)
-    server = Server(loop, [cast("socket.socket", listener)], Echo, None, 100, None, None)
+    server = Server(loop, [listener], Echo, None, 100, None, None)
     reports: list[tuple[str | None, BaseException | None]] = []
     previous_handler = loop.get_exception_handler()
     loop.set_exception_handler(
@@ -1333,7 +1327,7 @@ async def test_accept_resource_exhaustion_backs_off(error: int, monkeypatch: pyt
 
         server.close()
         accepts_after_close = listener.accepts
-        server._retry_accept(cast("socket.socket", listener))
+        server._start_serving()
         assert listener.accepts == accepts_after_close
     finally:
         server.close()
@@ -1345,7 +1339,7 @@ async def test_accept_other_oserror_is_reported() -> None:
     loop = running_loop()
     listener_sock, notifier = socket.socketpair()
     listener = ExhaustedListener(listener_sock, errno.EINVAL)
-    server = Server(loop, [cast("socket.socket", listener)], Echo, None, 100, None, None)
+    server = Server(loop, [listener], Echo, None, 100, None, None)
     reports: list[tuple[str | None, BaseException | None, trsock.TransportSocket | None]] = []
     previous_handler = loop.get_exception_handler()
     loop.set_exception_handler(
@@ -1353,7 +1347,7 @@ async def test_accept_other_oserror_is_reported() -> None:
     )
 
     try:
-        loop.call_soon(server._accept, cast("socket.socket", listener))
+        loop.call_soon(server._accept, listener)
         await asyncio.sleep(0)
 
         assert listener.accepts == 1
@@ -1370,17 +1364,17 @@ async def test_accept_other_oserror_is_reported() -> None:
         loop.set_exception_handler(previous_handler)
 
 
-async def test_retry_accept_ignores_a_closed_listener() -> None:
+async def test_start_serving_ignores_a_closed_server() -> None:
     loop = running_loop()
     listener_sock, notifier = socket.socketpair()
     listener = ExhaustedListener(listener_sock, errno.EMFILE)
-    server = Server(loop, [cast("socket.socket", listener)], Echo, None, 100, None, None)
+    server = Server(loop, [listener], Echo, None, 100, None, None)
 
     try:
         server._start_serving()
         loop.remove_reader(listener.fileno())
-        listener.close()
-        server._retry_accept(cast("socket.socket", listener))
+        server.close()
+        server._start_serving()
         await asyncio.sleep(0)
         assert listener.accepts == 0
     finally:
@@ -1392,7 +1386,7 @@ async def test_accept_resource_handler_can_close_server(monkeypatch: pytest.Monk
     loop = running_loop()
     listener_sock, notifier = socket.socketpair()
     listener = ExhaustedListener(listener_sock, errno.EMFILE)
-    server = Server(loop, [cast("socket.socket", listener)], Echo, None, 100, None, None)
+    server = Server(loop, [listener], Echo, None, 100, None, None)
     reports: list[tuple[str | None, trsock.TransportSocket | None]] = []
     previous_handler = loop.get_exception_handler()
 

--- a/zuvloop/_server.py
+++ b/zuvloop/_server.py
@@ -59,25 +59,20 @@ class Server(asyncio.AbstractServer):
         return self._serving
 
     def _start_serving(self) -> None:
-        if self._serving or self._sockets is None:
+        sockets = self._sockets
+        if sockets is None:
             return
-        self._serving = True
-        for sock in self._sockets:
-            sock.listen(self._backlog)
+        if not self._serving:
+            self._serving = True
+            for sock in sockets:
+                sock.listen(self._backlog)
+        for sock in sockets:
             self._loop.add_reader(sock.fileno(), self._accept, sock)
 
     async def start_serving(self) -> None:
         self._start_serving()
         # Let the accept callbacks register before returning, matching asyncio.
         await asyncio.sleep(0)
-
-    def _retry_accept(self, sock: socket.socket) -> None:
-        sockets = self._sockets
-        if not self._serving or sockets is None or sock not in sockets:
-            return
-        fd = sock.fileno()
-        if fd != -1:
-            self._loop.add_reader(fd, self._accept, sock)
 
     def _accept(self, sock: socket.socket) -> None:
         for _ in range(self._backlog):
@@ -95,7 +90,7 @@ class Server(asyncio.AbstractServer):
                             "socket": trsock.TransportSocket(sock),
                         }
                     )
-                    self._loop.call_later(constants.ACCEPT_RETRY_DELAY, self._retry_accept, sock)
+                    self._loop.call_later(constants.ACCEPT_RETRY_DELAY, self._start_serving)
                     return
                 self._loop.call_exception_handler(
                     {


### PR DESCRIPTION
## Summary

- reuse the existing server-start callback when accept retries are scheduled
- remove the one-use private retry method
- make the exhaustion test listener a real socket subclass, eliminating the casts introduced by #78

## Why

The resource-exhaustion backoff remains unchanged, but the implementation now mirrors asyncio more closely and follows the repository rules against one-use private helpers and typing.cast.

## Validation

- 450 passed, 2 skipped
- mypy
- ruff check
- ruff format --check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies accept retry by scheduling the existing server-start path instead of a one-off per-socket retry. Previously `_retry_accept` re-armed a single listener; now we call `_start_serving`, which safely re-adds readers for all active listeners and is a no-op after server close.

**Notes for reviewers**
- `_start_serving` only calls `listen()` on first start, but always re-adds readers; it returns early if `_sockets` is `None`. Retries now use `loop.call_later(..., self._start_serving)` to mirror asyncio.
- Removes the one-use private `_retry_accept` and related casts in tests; `ExhaustedListener` is now a `socket.socket` subclass.
- Behavior is unchanged for backoff timing and error reporting; the retry scope is now all listeners instead of a single socket.
- Validation: 450 passed, 2 skipped; mypy; ruff check; ruff format --check.

<sup>Written for commit bc04b749db2a0277e7c21cb2fc48f1bcfacf2ace. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/88?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server recovery when system resources are temporarily exhausted, allowing serving to restart more reliably.
  * Fixed edge cases where restarting a closed server could incorrectly accept connections.
  * Improved socket handling during server startup to ensure all listeners become active consistently.
* **Tests**
  * Expanded coverage for server restart behavior, connection acceptance, and handling of ordinary socket errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->