### PR TITLE
Preserve accept retry backoff

### DIFF
--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1880,6 +1880,25 @@ async def test_serve_forever_on_a_closed_server_is_rejected() -> None:
         await server.serve_forever()
 
 
+async def test_serve_forever_starts_a_non_serving_server() -> None:
+    loop = running_loop()
+    server = await loop.create_server(Echo, "127.0.0.1", 0, start_serving=False)
+    port = server.sockets[0].getsockname()[1]
+    serving = loop.create_task(server.serve_forever())
+    await asyncio.sleep(0)
+
+    try:
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        writer.write(b"forever")
+        assert await reader.readexactly(7) == b"forever"
+        writer.close()
+        await writer.wait_closed()
+    finally:
+        serving.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await serving
+
+
 async def test_serve_forever_twice_is_rejected() -> None:
     server, _port, _ = await start_echo()
     loop = running_loop()

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -10,7 +10,7 @@ import struct
 import sys
 import tempfile
 from asyncio import constants, trsock
-from collections.abc import Iterator, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from pathlib import Path
 from typing import NoReturn
 
@@ -1301,10 +1301,16 @@ async def test_accept_resource_exhaustion_backs_off(error: int, monkeypatch: pyt
     server = Server(loop, [listener], Echo, None, 100, None, None)
     reports: list[tuple[str | None, BaseException | None]] = []
     previous_handler = loop.get_exception_handler()
+    retries: list[Callable[[], None]] = []
+
+    def capture_retry(delay: float, callback: Callable[[], None]) -> None:
+        assert delay == constants.ACCEPT_RETRY_DELAY
+        retries.append(callback)
+
     loop.set_exception_handler(
         lambda _loop, context: reports.append((context.get("message"), context.get("exception")))
     )
-    monkeypatch.setattr(constants, "ACCEPT_RETRY_DELAY", 0.02)
+    monkeypatch.setattr(loop, "call_later", capture_retry)
 
     try:
         await server.start_serving()
@@ -1319,13 +1325,23 @@ async def test_accept_resource_exhaustion_backs_off(error: int, monkeypatch: pyt
         assert message == "socket.accept() out of system resource"
         assert isinstance(reported_error, OSError)
         assert reported_error.errno == error
+        assert len(retries) == 1
 
+        # Neither public start path may bypass the resource-exhaustion delay.
+        await server.start_serving()
+        serving_forever = loop.create_task(server.serve_forever())
+        await asyncio.sleep(0)
+        assert listener.accepts == 1
+
+        retries.pop()()
         async with asyncio.timeout(1):
             while listener.accepts < 2:
                 await asyncio.sleep(0)
         assert listener.accepts >= 2
 
-        server.close()
+        serving_forever.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await serving_forever
         accepts_after_close = listener.accepts
         server._start_serving()
         assert listener.accepts == accepts_after_close

--- a/zuvloop/_server.py
+++ b/zuvloop/_server.py
@@ -70,7 +70,8 @@ class Server(asyncio.AbstractServer):
             self._loop.add_reader(sock.fileno(), self._accept, sock)
 
     async def start_serving(self) -> None:
-        self._start_serving()
+        if not self._serving:
+            self._start_serving()
         # Let the accept callbacks register before returning, matching asyncio.
         await asyncio.sleep(0)
 
@@ -194,7 +195,8 @@ class Server(asyncio.AbstractServer):
         if self._sockets is None:
             raise RuntimeError(f"server {self!r} is closed")
 
-        self._start_serving()
+        if not self._serving:
+            self._start_serving()
         self._serving_forever = self._loop.create_future()
         try:
             await self._serving_forever


### PR DESCRIPTION
Addresses the valid post-merge review on #88.\n\nWhen resource exhaustion removes a listener reader, repeated calls to `start_serving()` or a new `serve_forever()` must not re-register it before `ACCEPT_RETRY_DELAY`. The delayed `_start_serving()` callback remains the sole retry path.\n\nThe regression test captures the retry callback and verifies both public start paths preserve the backoff before explicitly firing it.\n\nValidation:\n- focused server tests: 12 passed\n- mypy\n- ruff check\n- ruff format --check\n- full suite: 454 passed, 2 skipped, with one unrelated subprocess cancellation race under separate investigation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves accept retry backoff after resource exhaustion and ensures `serve_forever()` starts a non-serving server without bypassing the delay. Previously, calling `start_serving()` or `serve_forever()` could re-add the reader immediately; now they only schedule the delayed `_start_serving()` retry when not already serving.

- Guard `start_serving()` and `serve_forever()` with `if not self._serving` before `_start_serving()`; keep the zero-sleep to match asyncio.
- Tests: capture `loop.call_later` to assert the delay equals `ACCEPT_RETRY_DELAY`, confirm neither public start path increments accepts until the captured callback runs, then verify normal accept resumes and `serve_forever()` cancels cleanly; add a test that `serve_forever()` starts a server created with `start_serving=False`.

<sup>Written for commit af81f23e9a8eaf89c4650313bd214f29fbcb2198. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/89?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

