### PR TITLE
Fix hash-locked wheel builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           uv pip compile .github/build-requirements.in --universal --generate-hashes \
             --no-header --output-file /tmp/build-constraints.txt
           tail -n +3 .github/build-constraints.txt | diff -u - /tmp/build-constraints.txt
-          uv build --sdist --build-constraints .github/build-constraints.txt \
+          uv build --sdist --wheel --build-constraints .github/build-constraints.txt \
             --require-hashes --out-dir /tmp/zuv-sdist
 
       # A wheel is compiled on whichever machine the job landed on, so a build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,8 +88,8 @@ jobs:
           # onto a wheel rather than fail, so this has to be the full history.
           fetch-depth: 0
 
-      # cibuildwheel's build[uv] frontend needs uv on PATH; the manylinux
-      # containers ship it, the macOS runners do not.
+      # cibuildwheel's uv frontend needs uv on PATH; the manylinux containers
+      # ship it, the macOS runners do not.
       - uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
         with:
           enable-cache: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,8 +106,11 @@ filterwarnings = ["error"]
 # a GIL to save.
 build = "cp314-*"
 skip = "*-musllinux_i686 *t-*"
-build-frontend = "build[uv]"
-environment = { UV_BUILD_CONSTRAINT = "$(pwd)/.github/build-constraints.txt", UV_REQUIRE_HASHES = "1" }
+# Let uv own the project build so hash checking applies only to the pinned build
+# requirements. Setting UV_REQUIRE_HASHES globally also affects cibuildwheel's
+# own bootstrap tools (for example, delocate) before the project build starts.
+build-frontend = { name = "uv", args = ["--require-hashes"] }
+environment = { UV_BUILD_CONSTRAINT = "$(pwd)/.github/build-constraints.txt" }
 test-requires = ["aiohttp", "anyio", "httptools", "hypothesis", "opentelemetry-sdk", "pytest", "uvicorn"]
 test-command = "pytest {project}/tests -q --import-mode=importlib"
 


### PR DESCRIPTION
## Summary

- use uv directly as cibuildwheel's project build frontend
- scope `--require-hashes` to the project build instead of exporting it to cibuildwheel's bootstrap tools
- exercise both the sdist and wheel hash-locked paths in pull request CI

## Root cause

The first `v0.0.6` publish run exported `UV_REQUIRE_HASHES=1` through cibuildwheel's global build environment. On macOS, that made cibuildwheel reject its own unpinned `delocate` bootstrap requirement before the project build. On Linux, the nested PEP 517 installer received the project's build requirements as unhashed command-line arguments and rejected them before applying the intended build constraint path.

The publish job remained gated and PyPI never received `0.0.6`; the failed GitHub release and tag were removed before this hotfix.

## Validation

- regenerated and diffed the universal hashed build constraints
- built the sdist and native wheel with `uv build --sdist --wheel --build-constraints .github/build-constraints.txt --require-hashes`
- ran cibuildwheel 4.2.0 for `cp314-manylinux_aarch64`
- built and repaired the manylinux wheel, installed it into a clean environment, and passed all 490 installed-wheel tests
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hash-locked wheel builds by switching `cibuildwheel` to the `uv` frontend and scoping hash checking to the project build. Previously we exported `UV_REQUIRE_HASHES=1` globally; macOS failed when `cibuildwheel` bootstrapped unpinned `delocate`, and Linux rejected unhashed PEP 517 args. We now pass `--require-hashes` only to `uv` during the project build.

**Review notes**
- pyproject: set `build-frontend = { name = "uv", args = ["--require-hashes"] }`; remove global `UV_REQUIRE_HASHES`; keep `UV_BUILD_CONSTRAINT`.
- CI: build both sdist and wheel with `uv` under `.github/build-constraints.txt` and `--require-hashes`.
- Local builds: ensure `uv` is on PATH; do not export `UV_REQUIRE_HASHES` globally.
- No runtime code changes.

<sup>Written for commit a6bf251c144d1360a7ea5ba100cfcb72e6d82f65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/93?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build verification to cover both source distributions and wheels.
  * Updated packaging configuration to enforce dependency hashes during builds while preserving build constraints.
  * Clarified wheel-build workflow documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->