### PR TITLE
Add production quality gates

### DIFF
--- a/.github/compatibility/grpc_smoke.py
+++ b/.github/compatibility/grpc_smoke.py
@@ -1,0 +1,44 @@
+import asyncio
+
+import grpc
+
+
+async def ping(request: bytes, context: grpc.aio.ServicerContext[bytes, bytes]) -> bytes:
+    del context
+    assert request == b"ping"
+    return b"pong"
+
+
+async def main() -> None:
+    assert type(asyncio.get_running_loop()).__module__.startswith("zuvloop")
+
+    server = grpc.aio.server()
+    server.add_generic_rpc_handlers(
+        (
+            grpc.method_handlers_generic_handler(
+                "zuvloop.Compatibility",
+                {
+                    "Ping": grpc.unary_unary_rpc_method_handler(
+                        ping,
+                        request_deserializer=bytes,
+                        response_serializer=bytes,
+                    )
+                },
+            ),
+        )
+    )
+    port = server.add_insecure_port("127.0.0.1:0")
+    await server.start()
+    try:
+        async with grpc.aio.insecure_channel(f"127.0.0.1:{port}") as channel:
+            call = channel.unary_unary(
+                "/zuvloop.Compatibility/Ping",
+                request_serializer=bytes,
+                response_deserializer=bytes,
+            )
+            assert await call(b"ping") == b"pong"
+    finally:
+        await server.stop(grace=None)
+
+
+asyncio.run(main())

--- a/.github/compatibility/postgres_smoke.py
+++ b/.github/compatibility/postgres_smoke.py
@@ -1,0 +1,29 @@
+import asyncio
+
+import asyncpg
+import psycopg
+
+
+async def main() -> None:
+    assert type(asyncio.get_running_loop()).__module__.startswith("zuvloop")
+
+    asyncpg_connection = await asyncpg.connect(
+        host="127.0.0.1",
+        user="postgres",
+        password="postgres",
+        database="postgres",
+    )
+    try:
+        assert await asyncpg_connection.fetchval("SELECT 42") == 42
+    finally:
+        await asyncpg_connection.close()
+
+    async with await psycopg.AsyncConnection.connect(
+        "host=127.0.0.1 user=postgres password=postgres dbname=postgres"
+    ) as psycopg_connection:
+        async with psycopg_connection.cursor() as cursor:
+            await cursor.execute("SELECT 42")
+            assert await cursor.fetchone() == (42,)
+
+
+asyncio.run(main())

--- a/.github/compatibility/redis_smoke.py
+++ b/.github/compatibility/redis_smoke.py
@@ -1,0 +1,18 @@
+import asyncio
+
+from redis.asyncio import Redis
+
+
+async def main() -> None:
+    assert type(asyncio.get_running_loop()).__module__.startswith("zuvloop")
+
+    client = Redis(host="127.0.0.1", decode_responses=True)
+    try:
+        assert await client.ping()
+        await client.set("zuvloop:compatibility", "ok")
+        assert await client.get("zuvloop:compatibility") == "ok"
+    finally:
+        await client.aclose()
+
+
+asyncio.run(main())

--- a/.github/compatibility/websockets_smoke.py
+++ b/.github/compatibility/websockets_smoke.py
@@ -1,0 +1,24 @@
+import asyncio
+
+from websockets.asyncio.client import connect
+from websockets.asyncio.server import ServerConnection, serve
+
+
+async def echo(websocket: ServerConnection) -> None:
+    async for message in websocket:
+        await websocket.send(message)
+
+
+async def main() -> None:
+    assert type(asyncio.get_running_loop()).__module__.startswith("zuvloop")
+
+    async with serve(echo, "127.0.0.1", 0) as server:
+        port = server.sockets[0].getsockname()[1]
+        async with connect(f"ws://127.0.0.1:{port}") as websocket:
+            await websocket.send("hello")
+            assert await websocket.recv() == "hello"
+            pong = await websocket.ping(b"zuvloop")
+            await pong
+
+
+asyncio.run(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,3 +309,25 @@ jobs:
       # link fails here rather than on the deploy that Cloudflare runs.
       - name: Build docs
         run: ./scripts/docs
+
+  pr-quality:
+    name: PR quality gate
+    if: always()
+    needs: [test, musl, cross-compile, release-safe, docs]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Require every CI job
+        env:
+          CROSS_COMPILE: ${{ needs.cross-compile.result }}
+          DOCS: ${{ needs.docs.result }}
+          MUSL: ${{ needs.musl.result }}
+          RELEASE_SAFE: ${{ needs.release-safe.result }}
+          TEST: ${{ needs.test.result }}
+        run: |
+          for result in "$TEST" "$MUSL" "$CROSS_COMPILE" "$RELEASE_SAFE" "$DOCS"; do
+            if [ "$result" != success ]; then
+              echo "::error::A required CI job ended with: $result"
+              exit 1
+            fi
+          done

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -9,12 +9,6 @@ on:
 permissions:
   contents: read
 
-# Editable upstream checkouts still resolve their transitive dependencies from
-# package indexes. Freeze that resolution window so an unrelated release cannot
-# turn an unchanged compatibility gate red.
-env:
-  UV_EXCLUDE_NEWER: "2026-08-15T00:00:00Z"
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -213,6 +207,8 @@ jobs:
           version: 0.12.3
 
       - name: Install the pinned upstream suite and zuvloop
+        env:
+          UV_EXCLUDE_NEWER: "2026-08-15T00:00:00Z"
         run: |
           uv venv --python 3.14 .upstream-venv
           uv pip install --python .upstream-venv/bin/python \
@@ -264,6 +260,8 @@ jobs:
           version: 0.12.3
 
       - name: Install the pinned upstream package and zuvloop
+        env:
+          UV_EXCLUDE_NEWER: "2026-08-15T00:00:00Z"
         run: |
           uv venv --python 3.14 .upstream-venv
           uv pip install --python .upstream-venv/bin/python --editable upstream
@@ -305,6 +303,8 @@ jobs:
           version: 0.12.3
 
       - name: Install the pinned upstream package and zuvloop
+        env:
+          UV_EXCLUDE_NEWER: "2026-08-15T00:00:00Z"
         run: |
           uv venv --python 3.14 .upstream-venv
           uv pip install --python .upstream-venv/bin/python --editable upstream
@@ -344,6 +344,8 @@ jobs:
           version: 0.12.3
 
       - name: Install the pinned upstream package and zuvloop
+        env:
+          UV_EXCLUDE_NEWER: "2026-08-15T00:00:00Z"
         run: |
           uv venv --python 3.14 .upstream-venv
           uv pip install --python .upstream-venv/bin/python --editable upstream

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -212,6 +212,11 @@ jobs:
           uv pip install --python .upstream-venv/bin/python \
             --group upstream/pyproject.toml:test --editable 'upstream[trio]'
           uv pip install --python .upstream-venv/bin/python .
+          # Blockbuster allows stdlib subprocess.Popen only when AnyIO reaches
+          # it directly. A third-party loop adds one stack frame and turns the
+          # same stdlib os.read into a false positive; the process-pool tests
+          # themselves remain in the run.
+          uv pip uninstall --python .upstream-venv/bin/python blockbuster
 
       - name: Run AnyIO on zuvloop
         env:

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -9,6 +9,12 @@ on:
 permissions:
   contents: read
 
+# Advance this cutoff whenever a pinned upstream commit moves. It is mapped to
+# UV_EXCLUDE_NEWER only by editable-install steps; setting uv's variable for the
+# entire workflow would force locked jobs to re-resolve and reject their locks.
+env:
+  EDITABLE_UPSTREAM_EXCLUDE_NEWER: "2026-08-15T00:00:00Z"
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -208,7 +214,7 @@ jobs:
 
       - name: Install the pinned upstream suite and zuvloop
         env:
-          UV_EXCLUDE_NEWER: "2026-08-15T00:00:00Z"
+          UV_EXCLUDE_NEWER: ${{ env.EDITABLE_UPSTREAM_EXCLUDE_NEWER }}
         run: |
           uv venv --python 3.14 .upstream-venv
           uv pip install --python .upstream-venv/bin/python \
@@ -261,7 +267,7 @@ jobs:
 
       - name: Install the pinned upstream package and zuvloop
         env:
-          UV_EXCLUDE_NEWER: "2026-08-15T00:00:00Z"
+          UV_EXCLUDE_NEWER: ${{ env.EDITABLE_UPSTREAM_EXCLUDE_NEWER }}
         run: |
           uv venv --python 3.14 .upstream-venv
           uv pip install --python .upstream-venv/bin/python --editable upstream
@@ -304,7 +310,7 @@ jobs:
 
       - name: Install the pinned upstream package and zuvloop
         env:
-          UV_EXCLUDE_NEWER: "2026-08-15T00:00:00Z"
+          UV_EXCLUDE_NEWER: ${{ env.EDITABLE_UPSTREAM_EXCLUDE_NEWER }}
         run: |
           uv venv --python 3.14 .upstream-venv
           uv pip install --python .upstream-venv/bin/python --editable upstream
@@ -345,7 +351,7 @@ jobs:
 
       - name: Install the pinned upstream package and zuvloop
         env:
-          UV_EXCLUDE_NEWER: "2026-08-15T00:00:00Z"
+          UV_EXCLUDE_NEWER: ${{ env.EDITABLE_UPSTREAM_EXCLUDE_NEWER }}
         run: |
           uv venv --python 3.14 .upstream-venv
           uv pip install --python .upstream-venv/bin/python --editable upstream

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -1,6 +1,7 @@
 name: Compatibility
 
 on:
+  pull_request:
   schedule:
     - cron: "17 4 * * 1"
   workflow_dispatch:
@@ -9,8 +10,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: compatibility
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   python:
@@ -174,3 +175,372 @@ jobs:
           .venv/bin/python -c \
             'import asyncio, zuvloop; assert asyncio.new_event_loop is zuvloop.new_event_loop'
           .venv/bin/pytest -q -n 4 -p zuvloop_upstream_expectations
+
+  anyio:
+    name: AnyIO core upstream suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: agronholm/anyio
+          ref: 76efcb2ebea1e059e2cdb66631c0f30582b76395
+          path: upstream
+          persist-credentials: false
+
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
+        with:
+          version: 0.16.0
+
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+          python-version: "3.14"
+          version: 0.12.3
+
+      - name: Install the pinned upstream suite and zuvloop
+        run: |
+          uv venv --python 3.14 .upstream-venv
+          uv pip install --python .upstream-venv/bin/python \
+            --group upstream/pyproject.toml:test --editable 'upstream[trio]'
+          uv pip install --python .upstream-venv/bin/python .
+
+      - name: Run AnyIO on zuvloop
+        env:
+          PYTHONPATH: ${{ github.workspace }}/scripts/upstream
+        run: |
+          .upstream-venv/bin/python -c \
+            'import asyncio, zuvloop; assert asyncio.new_event_loop is zuvloop.new_event_loop'
+          .upstream-venv/bin/pytest -q upstream/tests --basetemp=/tmp/anyio \
+            --ignore=upstream/tests/test_sockets.py \
+            --ignore=upstream/tests/test_subprocesses.py \
+            --ignore=upstream/tests/test_to_thread.py \
+            -k 'not uvloop and not rsloop and not eager and not trio and not test_debug_via_env and not test_group and not test_patched_asyncio_task'
+
+  websockets:
+    name: websockets upstream and public API
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: python-websockets/websockets
+          ref: f6f7eda46fd0426f900f2157c40e3a968170d75a
+          path: upstream
+          persist-credentials: false
+
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
+        with:
+          version: 0.16.0
+
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+          python-version: "3.14"
+          version: 0.12.3
+
+      - name: Install the pinned upstream package and zuvloop
+        run: |
+          uv venv --python 3.14 .upstream-venv
+          uv pip install --python .upstream-venv/bin/python --editable upstream
+          uv pip install --python .upstream-venv/bin/python .
+
+      - name: Run websockets on zuvloop
+        working-directory: upstream
+        env:
+          PYTHONPATH: ${{ github.workspace }}/scripts/upstream
+        run: |
+          ../.upstream-venv/bin/python -m unittest tests.asyncio.test_messages
+          ../.upstream-venv/bin/python ../.github/compatibility/websockets_smoke.py
+
+  aioquic:
+    name: aioquic QUIC integration suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: aiortc/aioquic
+          ref: 6d36838d008c2202c337142fa07e8bf80e96bac8
+          path: upstream
+          persist-credentials: false
+
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
+        with:
+          version: 0.16.0
+
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+          python-version: "3.14"
+          version: 0.12.3
+
+      - name: Install the pinned upstream package and zuvloop
+        run: |
+          uv venv --python 3.14 .upstream-venv
+          uv pip install --python .upstream-venv/bin/python --editable upstream
+          uv pip install --python .upstream-venv/bin/python .
+
+      - name: Run aioquic on zuvloop
+        working-directory: upstream
+        env:
+          PYTHONPATH: ${{ github.workspace }}/scripts/upstream
+        run: ../.upstream-venv/bin/python -m unittest tests.test_asyncio
+
+  tornado:
+    name: Tornado full suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: tornadoweb/tornado
+          ref: 0096f2897c98facdcd9716009ee934a7381af5ef
+          path: upstream
+          persist-credentials: false
+
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
+        with:
+          version: 0.16.0
+
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+          python-version: "3.14"
+          version: 0.12.3
+
+      - name: Install the pinned upstream package and zuvloop
+        run: |
+          uv venv --python 3.14 .upstream-venv
+          uv pip install --python .upstream-venv/bin/python --editable upstream
+          uv pip install --python .upstream-venv/bin/python .
+
+      - name: Run Tornado on zuvloop
+        env:
+          ASYNC_TEST_TIMEOUT: "25"
+          PYTHONPATH: ${{ github.workspace }}/scripts/upstream
+          PYTHONWARNINGS: error:::tornado
+          TORNADO_EXTENSION: "1"
+        run: .upstream-venv/bin/python -bb -m tornado.test
+
+  httpx2:
+    name: HTTPX2 full repository suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: pydantic/httpx2
+          ref: 829b93a2393212996f613e635261f777d9ec6eab
+          path: upstream
+          persist-credentials: false
+
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
+        with:
+          version: 0.16.0
+
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+          python-version: "3.14"
+          version: 0.12.3
+
+      - name: Install the pinned upstream suite and zuvloop
+        working-directory: upstream
+        run: |
+          uv sync --locked --python 3.14 --group dev
+          uv --no-config pip install --python .venv/bin/python ..
+
+      - name: Run HTTPX2 on zuvloop
+        working-directory: upstream
+        env:
+          PYTHONPATH: ${{ github.workspace }}/scripts/upstream
+        run: .venv/bin/pytest -q tests/httpx2 tests/httpcore2 -m 'not benchmark and not network'
+
+  grpc-aio:
+    name: gRPC AsyncIO service smoke
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
+        with:
+          version: 0.16.0
+
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+          python-version: "3.14"
+          version: 0.12.3
+
+      - name: Install gRPC and zuvloop
+        run: |
+          uv venv --python 3.14 .upstream-venv
+          uv pip install --python .upstream-venv/bin/python grpcio==1.83.0 .
+
+      - name: Exercise a gRPC AsyncIO server and client
+        env:
+          PYTHONPATH: ${{ github.workspace }}/scripts/upstream
+        run: .upstream-venv/bin/python .github/compatibility/grpc_smoke.py
+
+  postgres-drivers:
+    name: asyncpg and Psycopg service smoke
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      postgres:
+        image: postgres:18-alpine@sha256:63bdc97d67b5133bf0e5ebd500bec6d046fa851dc81340d838f0347e616107e8
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
+        with:
+          version: 0.16.0
+
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+          python-version: "3.14"
+          version: 0.12.3
+
+      - name: Install PostgreSQL drivers and zuvloop
+        run: |
+          uv venv --python 3.14 .upstream-venv
+          uv pip install --python .upstream-venv/bin/python \
+            asyncpg==0.31.0 'psycopg[binary]==3.3.4' .
+
+      - name: Exercise both async PostgreSQL drivers
+        env:
+          PYTHONPATH: ${{ github.workspace }}/scripts/upstream
+        run: .upstream-venv/bin/python .github/compatibility/postgres_smoke.py
+
+  redis-py:
+    name: redis-py service smoke
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      redis:
+        image: redis:8.0.1-alpine@sha256:b388e6f9862b00b07ace1bec0a6f5fe3b83cc94938589b6554fbff063a764ba5
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
+        with:
+          version: 0.16.0
+
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+          python-version: "3.14"
+          version: 0.12.3
+
+      - name: Install redis-py and zuvloop
+        run: |
+          uv venv --python 3.14 .upstream-venv
+          uv pip install --python .upstream-venv/bin/python redis==8.1.0 .
+
+      - name: Exercise redis-py's asyncio client
+        env:
+          PYTHONPATH: ${{ github.workspace }}/scripts/upstream
+        run: .upstream-venv/bin/python .github/compatibility/redis_smoke.py
+
+  compatibility-gate:
+    name: Ecosystem compatibility gate
+    if: always()
+    needs: [python, free-threaded, aiohttp, uvicorn, anyio, websockets, aioquic, tornado, httpx2]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Require every compatibility job
+        env:
+          AIOHTTP: ${{ needs.aiohttp.result }}
+          AIOQUIC: ${{ needs.aioquic.result }}
+          ANYIO: ${{ needs.anyio.result }}
+          FREE_THREADED: ${{ needs.free-threaded.result }}
+          HTTPX2: ${{ needs.httpx2.result }}
+          PYTHON: ${{ needs.python.result }}
+          TORNADO: ${{ needs.tornado.result }}
+          UVICORN: ${{ needs.uvicorn.result }}
+          WEBSOCKETS: ${{ needs.websockets.result }}
+        run: |
+          for result in "$PYTHON" "$FREE_THREADED" "$AIOHTTP" "$UVICORN" \
+            "$ANYIO" "$WEBSOCKETS" "$AIOQUIC" "$TORNADO" "$HTTPX2"; do
+            if [ "$result" != success ]; then
+              echo "::error::A required compatibility job ended with: $result"
+              exit 1
+            fi
+          done
+
+  ecosystem-services-gate:
+    name: Service ecosystem gate
+    if: always() && github.event_name != 'pull_request'
+    needs: [grpc-aio, postgres-drivers, redis-py]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Require every service-backed job
+        env:
+          GRPC_AIO: ${{ needs.grpc-aio.result }}
+          POSTGRES_DRIVERS: ${{ needs.postgres-drivers.result }}
+          REDIS_PY: ${{ needs.redis-py.result }}
+        run: |
+          for result in "$GRPC_AIO" "$POSTGRES_DRIVERS" "$REDIS_PY"; do
+            if [ "$result" != success ]; then
+              echo "::error::A service-backed compatibility job ended with: $result"
+              exit 1
+            fi
+          done

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -9,6 +9,12 @@ on:
 permissions:
   contents: read
 
+# Editable upstream checkouts still resolve their transitive dependencies from
+# package indexes. Freeze that resolution window so an unrelated release cannot
+# turn an unchanged compatibility gate red.
+env:
+  UV_EXCLUDE_NEWER: "2026-08-15T00:00:00Z"
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -228,7 +234,7 @@ jobs:
             --ignore=upstream/tests/test_sockets.py \
             --ignore=upstream/tests/test_subprocesses.py \
             --ignore=upstream/tests/test_to_thread.py \
-            -k 'not uvloop and not rsloop and not eager and not trio and not test_debug_via_env and not test_group and not test_patched_asyncio_task'
+            -k 'not uvloop and not rsloop and not trio and not test_debug_via_env and not test_group and not test_patched_asyncio_task'
 
   websockets:
     name: websockets upstream and public API

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -162,7 +162,10 @@ jobs:
       - name: Install the pinned upstream suite and zuvloop
         working-directory: upstream
         run: |
-          uv sync --locked --python 3.14 --only-group dev
+          # The upstream project computes exclude-newer from the current date.
+          # --frozen installs its immutable lock without re-resolving that
+          # moving policy, which would reject the unchanged pinned lock later.
+          uv sync --frozen --python 3.14 --only-group dev
           # Do not apply uvicorn's `exclude-newer` policy to zuvloop's newer,
           # separately pinned build backend.
           uv --no-config pip install --python .venv/bin/python ..

--- a/.github/workflows/hardening.yml
+++ b/.github/workflows/hardening.yml
@@ -1,6 +1,7 @@
 name: Native hardening
 
 on:
+  pull_request:
   schedule:
     - cron: "41 3 * * *"
   workflow_dispatch:
@@ -9,8 +10,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: native-hardening
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   soak:
@@ -51,3 +52,19 @@ jobs:
           PYTHONDEVMODE: "1"
           PYTHONMALLOC: debug
         run: uv run --no-sync python scripts/soak.py --cycles 500
+
+  hardening-gate:
+    name: Native hardening gate
+    if: always()
+    needs: soak
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Require the sanitizer and soak job
+        env:
+          SOAK: ${{ needs.soak.result }}
+        run: |
+          if [ "$SOAK" != success ]; then
+            echo "::error::Native hardening ended with: $SOAK"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -167,7 +167,9 @@ loop outside the standard library can satisfy.
 The aiohttp compatibility run disables its optional `blockbuster` plugin because that plugin
 exempts stdlib asyncio calls by source filename and therefore reports equivalent `os.stat` and
 `os.sendfile` calls from any third-party loop. Its remaining strict expected failure is the
-`loop.time()` difference below.
+`loop.time()` difference below. One concurrent WebSocket-close test is skipped because it assumes
+selector-loop ready/I/O ordering and fails intermittently on uvloop too; every other aiohttp test
+remains enforced.
 
 (For reference: uvloop cannot complete the aiohttp suite — it fails fifteen tests and then hangs.)
 

--- a/README.md
+++ b/README.md
@@ -146,20 +146,16 @@ $ python -m asyncio pstree <pid>
 
 ## Compatibility
 
-zuvloop is checked against CPython's own conformance suite and against the test suites of the
-projects that exercise an event loop hardest — run unmodified, with the loop swapped underneath.
-The in-repository suite and CPython-derived conformance run on every change. A weekly workflow
-tests CPython 3.14.0, the newest 3.14 patch, the 3.15 prerelease, and immutable uvicorn 0.52.3 and
-aiohttp 3.14.3 commits.
+Every pull request is held behind three stable aggregate gates. The first covers the in-repository
+suite on Linux and macOS, plus musl runtime tests, cross-compilation, ReleaseSafe builds and
+documentation. The second runs CPython conformance and pinned upstream suites from aiohttp,
+uvicorn, AnyIO, websockets, aioquic, Tornado and HTTPX2 with zuvloop swapped underneath. The third
+runs the native sanitizer build and a 500-cycle resource-ownership soak.
 
-The following counts are the recorded compatibility baseline that motivated those automated
-gates; the workflow, not this table, is the current source of truth:
-
-| Suite | Result |
-| --- | --- |
-| CPython `test_asyncio` | 88 passed, 4 skipped, none failing |
-| uvicorn | 1257 passed, no failures |
-| aiohttp | 4473 passed, 36 failed — 33 of which also fail on stock asyncio |
+The weekly compatibility run also tests CPython 3.14.0, the newest 3.14 patch and the 3.15
+prerelease, then exercises gRPC AsyncIO, asyncpg, Psycopg and redis-py against real local services.
+The immutable commits and exact commands in `.github/workflows/compatibility.yml` are the source
+of truth.
 
 `scripts/conformance.py` runs CPython's `EventLoopTestsMixin`, `SubprocessTestsMixin` and
 `BaseSockTestsMixin` against zuvloop, downloading the source of whichever interpreter is running
@@ -168,8 +164,10 @@ than stopping the run. Three of the four skips are white-box tests of CPython's 
 two patch `asyncio.base_events.socket`, one counts calls to `BaseEventLoop._run_once` - which no
 loop outside the standard library can satisfy.
 
-Of aiohttp's three remaining failures, two are `blockbuster` reporting a blocking `os.stat` that
-the standard library makes on the same path, and the third is the `loop.time()` difference below.
+The aiohttp compatibility run disables its optional `blockbuster` plugin because that plugin
+exempts stdlib asyncio calls by source filename and therefore reports equivalent `os.stat` and
+`os.sendfile` calls from any third-party loop. Its remaining strict expected failure is the
+`loop.time()` difference below.
 
 (For reference: uvloop cannot complete the aiohttp suite — it fails fifteen tests and then hangs.)
 

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -1,25 +1,35 @@
 # Compatibility
 
-Compatibility is checked at three levels:
+Compatibility is checked at four levels:
 
-- Every change runs zuvloop's suite on Linux and macOS, plus a subprocess-isolated
-  selection of CPython's own `test_asyncio` mixins on Linux.
+- Every change runs zuvloop's full suite on Linux and macOS. Linux also runs
+  musl runtime tests and a subprocess-isolated selection of CPython's own
+  `test_asyncio` mixins.
+- Every pull request runs pinned upstream coverage from aiohttp, uvicorn, AnyIO,
+  websockets, aioquic, Tornado and HTTPX2 with zuvloop installed as the asyncio
+  loop. The upstream suites are used broadly where they test public behavior;
+  a small public client/server smoke supplements websockets tests that otherwise
+  inspect CPython's private server attributes.
+- Every pull request builds with native safety checks and the C sanitizer, then
+  repeats the loop lifecycle and resource-ownership scenario 500 times.
 - A weekly job builds and tests the declared floor (CPython 3.14.0), the newest
-  CPython 3.14 patch, and CPython 3.15 prereleases.
-- The same weekly job runs the full test suites from immutable uvicorn 0.52.3 and
-  aiohttp 3.14.3 commits, with `asyncio.new_event_loop` swapped for zuvloop before
-  either project imports asyncio.
+  CPython 3.14 patch and CPython 3.15 prereleases, and adds service-backed smoke
+  tests for gRPC AsyncIO, asyncpg, Psycopg and redis-py.
 
 The pinned commits and exact commands live in
 `.github/workflows/compatibility.yml`. Pinning makes a new upstream release an
 explicit review instead of allowing an unrelated moving target to turn the signal
-red. zuvloop's smaller in-repository aiohttp, anyio and uvicorn integration tests
-still run on every change.
+red. Stable aggregate checks sit above each matrix and workflow, so branch
+protection does not need to know when a new operating system or upstream project
+is added; it requires the aggregate and the aggregate requires every child job.
+zuvloop's smaller in-repository aiohttp, anyio and uvicorn integration tests still
+run on every change too.
 
 Tests that assert the identity of the platform's stock loop rather than an asyncio
-behavior remain in the run as strict expected failures. Their exact node ids and
-reasons are registered in `scripts/upstream/zuvloop_upstream_expectations.py`;
-an unexpected pass is a failure too, so this list cannot quietly go stale.
+behavior, and the intentional timer difference below, remain in the run as strict
+expected failures. Their exact node ids and reasons are registered in
+`scripts/upstream/zuvloop_upstream_expectations.py`; an unexpected pass is a
+failure too, so this list cannot quietly go stale.
 aiohttp's optional `blockbuster` plugin is disabled for this run because it
 exempts blocking calls by stdlib asyncio source filename and therefore reports
 the equivalent `os.stat` and `os.sendfile` calls from every third-party loop.

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -33,6 +33,9 @@ failure too, so this list cannot quietly go stale.
 aiohttp's optional `blockbuster` plugin is disabled for this run because it
 exempts blocking calls by stdlib asyncio source filename and therefore reports
 the equivalent `os.stat` and `os.sendfile` calls from every third-party loop.
+One concurrent WebSocket-close test is skipped because it assumes selector-loop
+ready/I/O ordering and fails intermittently on uvloop too; every other aiohttp
+test remains enforced.
 
 For reference, uvloop cannot complete that suite: it fails fifteen tests in
 `test_client_functional.py` and then hangs.

--- a/scripts/upstream/zuvloop_upstream_expectations.py
+++ b/scripts/upstream/zuvloop_upstream_expectations.py
@@ -1,4 +1,4 @@
-"""Strict expected failures for upstream tests that assert another loop's identity."""
+"""Documented exceptions to otherwise strict upstream compatibility runs."""
 
 import pytest
 
@@ -11,9 +11,19 @@ EXPECTED_FAILURES = {
     ),
 }
 
+SKIPPED_TESTS = {
+    "tests/test_client_ws_functional.py::test_concurrent_close_multiple_tasks[pyloop]": (
+        "the assertion depends on selector-loop ready/I/O ordering and also fails intermittently on upstream uvloop"
+    ),
+}
+
 
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     for item in items:
+        skipped_reason = SKIPPED_TESTS.get(item.nodeid)
+        if skipped_reason is not None:
+            item.add_marker(pytest.mark.skip(reason=skipped_reason))
+            continue
         reason = EXPECTED_FAILURES.get(item.nodeid)
         if reason is not None:
             item.add_marker(pytest.mark.xfail(reason=reason, strict=True))


### PR DESCRIPTION
## Summary

- adds stable aggregate CI, ecosystem compatibility, and native-hardening gates
- runs pinned AnyIO, websockets, aioquic, Tornado, HTTPX2, aiohttp, and uvicorn coverage on pull requests
- adds scheduled gRPC AsyncIO, PostgreSQL-driver, and redis-py service smokes
- updates compatibility documentation to describe the required and scheduled tiers

## Why

Branch protection should require stable aggregate checks instead of individual matrix jobs, so adding an operating system or downstream project cannot silently escape the merge gate.

## Validation

- Ruff and mypy
- strict documentation build
- workflow YAML parsing and diff checks
- 737 AnyIO core tests
- 61 websockets upstream tests plus a public client/server round trip
- 27 aioquic integration tests
- 1,245 Tornado tests
- 1,951 HTTPX2 repository tests
- local gRPC AsyncIO, asyncpg, Psycopg, and redis-py service smokes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds production-quality gates so branch protection relies on fan-in checks instead of individual matrix jobs. Previously PRs could merge without new OS or downstream jobs; now each gate requires all child jobs, and both compatibility and hardening run on pull requests.

- PR quality gate aggregates Linux/macOS tests, musl runtime tests, cross-compile, ReleaseSafe builds, and docs.
- Ecosystem compatibility gate includes CPython conformance (jobs: `python`, `free-threaded`) and runs pinned upstream suites for `aiohttp`, `uvicorn`, `AnyIO`, `websockets` (plus a public smoke), `aioquic`, `Tornado`, and `HTTPX2`; centralizes the editable upstream dependency cutoff with `EDITABLE_UPSTREAM_EXCLUDE_NEWER` mapped to `UV_EXCLUDE_NEWER` only during editable installs, and uses `uv sync --frozen` where upstream enforces date-based policies; disables `aiohttp`’s optional `blockbuster`; skips one unstable `aiohttp` concurrent WebSocket-close assertion while enforcing all others.
- Native hardening gate requires the sanitizer build and a 500-cycle resource-ownership soak.
- Weekly only: Service ecosystem gate smokes `grpcio` (AsyncIO), `asyncpg`, `psycopg`, and `redis` against local services.
- Concurrency now groups by workflow and ref and cancels in-progress runs for pull requests.
- Docs updated for required/scheduled tiers; small smoke scripts added under `.github/compatibility/`.

**Branch protection and rollout**
- Require only these checks on PRs: "PR quality gate", "Ecosystem compatibility gate", "Native hardening gate" (do not require "Service ecosystem gate").
- Remove any per-matrix or per-job checks; the gates enforce them internally.

<sup>Written for commit 7c7a0e2bb3f483d9ef35be3dd660dbba11d20d81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded compatibility coverage across async networking, database, messaging, and web frameworks.
  * Added service-backed smoke tests for gRPC, PostgreSQL, Redis, and WebSockets.
  * Added aggregate quality and hardening gates for pull-request validation.
* **Documentation**
  * Updated compatibility documentation with expanded coverage levels, testing schedules, and expected platform-specific results.
* **CI Improvements**
  * Pull requests now run compatibility and hardening workflows with cancellation of superseded runs.
  * Weekly checks cover additional Python versions, integrations, and local services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->