### PR TITLE
Use alls-green for the PR quality gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,16 +356,6 @@ jobs:
 
     steps:
       - name: Require every CI job
-        env:
-          CROSS_COMPILE: ${{ needs.cross-compile.result }}
-          DOCS: ${{ needs.docs.result }}
-          MUSL: ${{ needs.musl.result }}
-          RELEASE_SAFE: ${{ needs.release-safe.result }}
-          TEST: ${{ needs.test.result }}
-        run: |
-          for result in "$TEST" "$MUSL" "$CROSS_COMPILE" "$RELEASE_SAFE" "$DOCS"; do
-            if [ "$result" != success ]; then
-              echo "::error::A required CI job ended with: $result"
-              exit 1
-            fi
-          done
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
Replaces the hand-written shell aggregation in `PR quality gate` with `re-actors/alls-green` v1.2.2, pinned to its immutable commit SHA. The gate continues to require the complete test matrix, musl execution, cross-compiles, release-safe builds, and docs; the action evaluates the serialized `needs` context while the job runs under `if: always()`.

Validated with YAML parsing, aggregate dependency assertions, and `git diff --check`.