### PR TITLE
Repair release and dependency maintenance

### DIFF
--- a/.github/aiohttp-compatibility-requirements.in
+++ b/.github/aiohttp-compatibility-requirements.in
@@ -1,4 +1,4 @@
--r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+-r aiohttp-upstream-test-requirements.txt
 
 aiohttp==3.14.3
 opentelemetry-api>=1.23

--- a/.github/aiohttp-compatibility-requirements.txt
+++ b/.github/aiohttp-compatibility-requirements.txt
@@ -3,12 +3,12 @@
 aiodns==4.0.4 \
     --hash=sha256:c24dd605bac70a1676ce503f967a98483ff163507198557d8e9db16267e6cfd2 \
     --hash=sha256:cb10e0c0d2591636716ad2fe402e977c16d71bdaf76bb8cb49e8a6633596f736
-    # via -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    # via -r .github/aiohttp-upstream-test-requirements.txt
 aiohappyeyeballs==2.6.2 \
     --hash=sha256:4708045e2d7a6c6bdf8aafa8ed39649eaf926a4543b54560659129e3365953c4 \
     --hash=sha256:e202810ee718bd01fc6ef49e8ea53d023d5cb6b581076d7925aa499fa55dbe64
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   aiohttp
 aiohttp==3.14.3 \
     --hash=sha256:03cd2bde3d7f085b64e549c985f4bb928cad7e8ecf5323bfca320db548d81b39 \
@@ -135,13 +135,13 @@ aiosignal==1.4.0 \
     --hash=sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e \
     --hash=sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   aiohttp
 annotated-types==0.7.0 \
     --hash=sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53 \
     --hash=sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   pydantic
 ast-serialize==0.5.0 \
     --hash=sha256:061ee58bdb52341c8201a6df41182a977736bae3b7ded87ca7176ca25a8a47ab \
@@ -178,18 +178,18 @@ ast-serialize==0.5.0 \
     --hash=sha256:f66173891548c9f2726bf27957b41cabce12fa679dc6da505ddbde4d4b3b31cf \
     --hash=sha256:f8015cd071ac1339924ee2b8098c93e00e155f30a16f40ec9816fcf84f4753f6
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   mypy
 attrs==26.1.0 \
     --hash=sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309 \
     --hash=sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   aiohttp
 blockbuster==1.5.26 \
     --hash=sha256:cc3ce8c70fa852a97ee3411155f31e4ad2665cd1c6c7d2f8bb1851dab61dc629 \
     --hash=sha256:f8e53fb2dd4b6c6ec2f04907ddbd063ca7cd1ef587d24448ef4e50e81e3a79bb
-    # via -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    # via -r .github/aiohttp-upstream-test-requirements.txt
 brotli==1.2.0 \
     --hash=sha256:022426c9e99fd65d9475dce5c195526f04bb8be8907607e27e747893f6ee3e24 \
     --hash=sha256:072e7624b1fc4d601036ab3f4f27942ef772887e876beff0301d261210bca97f \
@@ -291,7 +291,7 @@ brotli==1.2.0 \
     --hash=sha256:f8d635cafbbb0c61327f942df2e3f474dde1cff16c3cd0580564774eaba1ee13 \
     --hash=sha256:fc1530af5c3c275b8524f2e24841cbe2599d74462455e9bae5109e9ff42e9361 \
     --hash=sha256:ff09cd8c5eec3b9d02d2408db41be150d8891c5566addce57513bf546e3d6c6d
-    # via -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    # via -r .github/aiohttp-upstream-test-requirements.txt
 cffi==2.0.0 \
     --hash=sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb \
     --hash=sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b \
@@ -378,14 +378,14 @@ cffi==2.0.0 \
     --hash=sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453 \
     --hash=sha256:fe562eb1a64e67dd297ccc4f5addea2501664954f2692b69a76449ec7913ecbf
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   cryptography
     #   pycares
 click==8.4.1 \
     --hash=sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2 \
     --hash=sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   wait-for-it
 coverage==7.14.1 \
     --hash=sha256:0177614a0370f227888b4e436a7c55686d6a9f90eb1ade2b624ba685a1686e86 \
@@ -495,80 +495,77 @@ coverage==7.14.1 \
     --hash=sha256:fc459e5d73be2d6332fcfe8dbf3d8994671fe33c700f4565988ecfa511547253 \
     --hash=sha256:fd86572566fb40189a8260446158235159bc7a82dfbc87a3b39cf4fb57fcec1c
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   pytest-cov
-cryptography==48.0.0 \
-    --hash=sha256:0890f502ddf7d9c6426129c3f49f5c0a39278ed7cd6322c8755ffca6ee675a13 \
-    --hash=sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6 \
-    --hash=sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8 \
-    --hash=sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25 \
-    --hash=sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c \
-    --hash=sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832 \
-    --hash=sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12 \
-    --hash=sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c \
-    --hash=sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7 \
-    --hash=sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c \
-    --hash=sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec \
-    --hash=sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5 \
-    --hash=sha256:4defde8685ae324a9eb9d818717e93b4638ef67070ac9bc15b8ca85f63048355 \
-    --hash=sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c \
-    --hash=sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741 \
-    --hash=sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86 \
-    --hash=sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321 \
-    --hash=sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a \
-    --hash=sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7 \
-    --hash=sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920 \
-    --hash=sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e \
-    --hash=sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff \
-    --hash=sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd \
-    --hash=sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3 \
-    --hash=sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f \
-    --hash=sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602 \
-    --hash=sha256:84cf79f0dc8b36ac5da873481716e87aef31fcfa0444f9e1d8b4b2cece142855 \
-    --hash=sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18 \
-    --hash=sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a \
-    --hash=sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336 \
-    --hash=sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239 \
-    --hash=sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74 \
-    --hash=sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a \
-    --hash=sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c \
-    --hash=sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4 \
-    --hash=sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c \
-    --hash=sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f \
-    --hash=sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4 \
-    --hash=sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db \
-    --hash=sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166 \
-    --hash=sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5 \
-    --hash=sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f \
-    --hash=sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae \
-    --hash=sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20 \
-    --hash=sha256:db63bf618e5dea46c07de12e900fe1cdd2541e6dc9dbae772a70b7d4d4765f6a \
-    --hash=sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057 \
-    --hash=sha256:ecde28a596bead48b0cfd2a1b4416c3d43074c2d785e3a398d7ec1fc4d0f7fbb \
-    --hash=sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c \
-    --hash=sha256:fdfef35d751d510fcef5252703621574364fec16418c4a1e5e1055248401054b
+cryptography==50.0.0 \
+    --hash=sha256:031e2d5dd4bb9caa3ca9c82e5a197fd8ae680232cee62603d1a813f3f07e3d03 \
+    --hash=sha256:06a32a980526a6ab9a4b9bf8f7385800791e2bb960903cb6b530e4817509a3b7 \
+    --hash=sha256:07479a1cb08219ab719147e742e76090c9c773321959bb94946fffdd397a6437 \
+    --hash=sha256:07949c449a1abcf60d1ee6e88956d89404c7df3c8258f46589e912988e551987 \
+    --hash=sha256:105110f43a471dbd0060b9c9516cb8a6a79233631a04cc2ba16f28323ac6e025 \
+    --hash=sha256:11b74db56cdbe3cdee6e3f6982ecb70334fa10dce99ed58bf7894aaaa3b2a037 \
+    --hash=sha256:12b9c6996425c76ea6c457ace4f3073e715b8c545add07cd1a8f3a4f90691269 \
+    --hash=sha256:1489e263a8048bb8b6a8bac662eb2d402ea5d2b7b4699b72f385f1e2772db105 \
+    --hash=sha256:19736989797678c6af1e55cd49055cdbcb55d8f6b5583ac5335f933aba9101dc \
+    --hash=sha256:1b4a266766514614f8aa60416e71f2fc6e575d36e7bdc90f644fadb2f4b75b95 \
+    --hash=sha256:2a8183b489dc1f7f80f135780fadc1108f14b31b8a40411c7a5b17425f65f28b \
+    --hash=sha256:37fdb0d0111f1e2ff07139dfb79f1b49531f8e213c46f1163dd7642979b58c47 \
+    --hash=sha256:3f5735ffe4996d28b809371756219f5354864902a3b9e7c0b9ee87041209fc9c \
+    --hash=sha256:49e7d93abdbd2990caced757e5fade25302f719c3c8fb6e6fff2dde98999fc41 \
+    --hash=sha256:5e34edd123674534acd70147f0ca331eaa2c74e6325fb2028c886aa26ba0b68c \
+    --hash=sha256:62598a8a57f815db4c6259a4e97d857dab56697e7de8e8ab02352ab74da1995d \
+    --hash=sha256:65c2c3add92b45fd0709db8594536aea39c2a67af0e27ffcf049c498501140b7 \
+    --hash=sha256:6ba6a53445bd3cfa809ef3ef5f1589aa6ba08784a1d962bf47d0940e871dab1c \
+    --hash=sha256:6e7d61120573a7f2cd94cc095f9e81f6967c61ccdf194285aa143ecec8e0b708 \
+    --hash=sha256:7cec5b856506da6defb290f30c9ee687d5f5e8cb0bd3f6459dde43b0b4fa40ef \
+    --hash=sha256:80b63928fa35083b33966ce1efb70e5b9607181e49dcd1c22c8c005e319f667f \
+    --hash=sha256:82148ec5bddac30b51a5b3c1945075f896fa022cb93f8e4a01e9f6ee95292c5f \
+    --hash=sha256:828743d939e9629bc267b8e2d08d8bb67cd4319c771a33d4b18b22dd8fb7440a \
+    --hash=sha256:8d89f3976b10b4ce31118de72329025f70d2c6ead14a8217c5514dd2c6d5a78f \
+    --hash=sha256:8eb5e1172eb569ea8a872796576e6a67c276351728b6455d5beb01242b027c6a \
+    --hash=sha256:900131fafd8aead39ac7dd3a7e833be754c17a95cfd91221636949fe4eb0aa8a \
+    --hash=sha256:910d11e1a385c654bf738bf3e6b8e6ed5de0f5610fcae2be9e5b398d8081d20e \
+    --hash=sha256:910e1d2668e7de9648f2bcee30e180db2a6b15c30f887d7c4c93ddf96e3992e3 \
+    --hash=sha256:9aa87839c383bdbab6ef865787a1fb877af8dd03464c4400322726feaaadfc6d \
+    --hash=sha256:a1b30560f2acc95aa8b2e06e716a13dbfc97314747b80d9707e307f77b40d6b3 \
+    --hash=sha256:a91296cb61e8df6f86d0c19cc4068228da256bf59bf86049fbd821084565327f \
+    --hash=sha256:b42a28c1844fd9de8f3f7d540e36b66f3a9c83fceac7170ebc7a6a19edd9dcae \
+    --hash=sha256:bd1c592e4d5974f0d08d4888e432157adba757c66da0246918e43677fafa2d30 \
+    --hash=sha256:c87f62a3d3b9888ed0fdde100ec06aa61ca9cd44bad9057d1dff9a516b5f5bb9 \
+    --hash=sha256:c99c003e088647b8a5b7c145d6f78c335f6348332b62e142d411c4b63d1460b9 \
+    --hash=sha256:ccdc4a71a4dabae05de219404f9f4abc38e3b58422177ff93d0da05967dafa07 \
+    --hash=sha256:d24fead1d4d076e1bfb006dcec392074a3cd8d7b4fc8a595aa64073b2b7a96ba \
+    --hash=sha256:d58c3db7cd6eed54e6c06744db55456b65ebd7492ddeae9c1e93cfca7aa857d3 \
+    --hash=sha256:d764dcf130c428ef66786f866dd750f53182bc608813489915e9fc106bb0c82f \
+    --hash=sha256:df2a58a472f332225671c35b0a830208b86d004f82baa8530fa3782c85646533 \
+    --hash=sha256:e722f16708d854fe924790e051061f6704a472c3bac347b6fd88033ea8dd0dc5 \
+    --hash=sha256:ecfed7367f965a0328cfbdd70da860f15441f002f613185668c6e6ebf5a0ac11 \
+    --hash=sha256:eeac2acb5a20ed25e0ad6d1df9891a520b78b404266b6d11778f25d5d691a6c9 \
+    --hash=sha256:f59e38625469987d7ef6d495323c55e7db6c212eaf6112267e0d3b565a2e9c9f \
+    --hash=sha256:f89831ef99dd7dd169ab06d63a831adb9e20a87aac6d380266bbda5823349169 \
+    --hash=sha256:fd9192b7b70c573d7f214eb1ae35e00d359f6f5e4b27c7e21e30de1fc6204645
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   trustme
 exceptiongroup==1.3.1 \
     --hash=sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219 \
     --hash=sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598
-    # via -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    # via -r .github/aiohttp-upstream-test-requirements.txt
 execnet==2.1.2 \
     --hash=sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd \
     --hash=sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   pytest-xdist
 forbiddenfruit==0.1.4 \
     --hash=sha256:e3f7e66561a29ae129aac139a85d610dbf3dd896128187ed5454b6421f624253
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   blockbuster
 freezegun==1.5.5 \
     --hash=sha256:ac7742a6cc6c25a2c35e9292dfd554b897b517d2dec26891a2e8debf205cb94a \
     --hash=sha256:cd557f4a75cf074e84bc374249b9dd491eaeacd61376b9eb3c423282211619d2
-    # via -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    # via -r .github/aiohttp-upstream-test-requirements.txt
 frozenlist==1.8.0 \
     --hash=sha256:0325024fe97f94c41c08872db482cf8ac4800d80e79222c6b0b7b162d5b13686 \
     --hash=sha256:032efa2674356903cd0261c4317a561a6850f3ac864a63fc1583147fb05a79b0 \
@@ -701,25 +698,25 @@ frozenlist==1.8.0 \
     --hash=sha256:fb30f9626572a76dfe4293c7194a09fb1fe93ba94c7d4f720dfae3b646b45027 \
     --hash=sha256:fe3c58d2f5db5fbd18c2987cba06d51b0529f52bc3a6cdc33d3f4eab725104bd
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   aiohttp
     #   aiosignal
 gunicorn==26.0.0 \
     --hash=sha256:40233d26a5f0d1872916188c276e21641155111c2853f0c2cd55260aec0d24fc \
     --hash=sha256:ca9346f85e3a4aeeb64d491045c16b9a35647abd37ea15efe53080eb8b090baf
-    # via -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    # via -r .github/aiohttp-upstream-test-requirements.txt
 idna==3.17 \
     --hash=sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c \
     --hash=sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   trustme
     #   yarl
 iniconfig==2.3.0 \
     --hash=sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730 \
     --hash=sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   pytest
 librt==0.11.0 \
     --hash=sha256:05fb8fb2ab90e21c8d12ea240d744ad514da9baf381ebfa70d91d20d21713175 \
@@ -813,19 +810,19 @@ librt==0.11.0 \
     --hash=sha256:fa475675db22290c3158e1d42326d0f5a65f04f44a0e68c3630a25b53560fb9c \
     --hash=sha256:ff0fbaf5f44a21beeb0110f2ab64f45135a9536a834b79c0d1ef018f2786bbfa
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   mypy
 markdown-it-py==4.2.0 \
     --hash=sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49 \
     --hash=sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   rich
 mdurl==0.1.2 \
     --hash=sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8 \
     --hash=sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   markdown-it-py
 multidict==6.7.1 \
     --hash=sha256:026d264228bcd637d4e060844e39cdc60f86c479e463d49075dedc21b18fbbe0 \
@@ -975,7 +972,7 @@ multidict==6.7.1 \
     --hash=sha256:fc5907494fccf3e7d3f94f95c91d6336b092b5fc83811720fae5e2765890dfba \
     --hash=sha256:fcee94dfbd638784645b066074b338bc9cc155d4b4bffa4adce1615c5a426c19
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   aiohttp
     #   yarl
 mypy==2.1.0 \
@@ -1023,12 +1020,12 @@ mypy==2.1.0 \
     --hash=sha256:ecfe70d43775ab99562ab128ce49854a362044c9f894961f68f898c23cb7429d \
     --hash=sha256:fcaa0e479066e31f7cceb6a3bea39cb22b2ff51a6b2f24f193d19179ba17c389 \
     --hash=sha256:ff715050c127d724fd260a2e666e7747fdd83511c0c47d449d98238970aef780
-    # via -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    # via -r .github/aiohttp-upstream-test-requirements.txt
 mypy-extensions==1.1.0 \
     --hash=sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505 \
     --hash=sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   mypy
 opentelemetry-api==1.44.0 \
     --hash=sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a \
@@ -1038,24 +1035,24 @@ packaging==26.2 \
     --hash=sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e \
     --hash=sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   gunicorn
     #   pytest
 pathspec==1.1.1 \
     --hash=sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a \
     --hash=sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   mypy
 pkgconfig==1.6.0 \
     --hash=sha256:4a5a6631ce937fafac457104a40d558785a658bbdca5c49b6295bc3fd651907f \
     --hash=sha256:98e71754855e9563838d952a160eb577edabb57782e49853edb5381927e6bea1
-    # via -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    # via -r .github/aiohttp-upstream-test-requirements.txt
 pluggy==1.6.0 \
     --hash=sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3 \
     --hash=sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   pytest
     #   pytest-cov
 propcache==0.5.2 \
@@ -1181,13 +1178,13 @@ propcache==0.5.2 \
     --hash=sha256:fc88b26f08d634f7bc819a7852e5214f5802641ab8d9fd5326892292eee1993e \
     --hash=sha256:fe67a3d11cd9b4efabfa45c3d00ffba2b26811442a73a581a94b67c2b5faccf6
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   aiohttp
     #   yarl
 proxy-py==2.4.10 \
     --hash=sha256:41b9e9d3aae6f80e2304d3726e8e9c583a510d8de224eada53d115f48a63a9ce \
     --hash=sha256:ef3a31f6ef3be6ff78559c0e68198523bfe2fb1e820bb16686750c1bb5baf9e8
-    # via -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    # via -r .github/aiohttp-upstream-test-requirements.txt
 pycares==5.0.1 \
     --hash=sha256:07260c6c0eff8aa809d6cd64010303098c7d0fe79176aba207d747c9ffc7a95a \
     --hash=sha256:07711acb0ef75758f081fb7436acaccc91e8afd5ae34fd35d4edc44297e81f27 \
@@ -1275,19 +1272,19 @@ pycares==5.0.1 \
     --hash=sha256:faa093af3bea365947325ec23ed24efe81dcb0efc1be7e19a36ba37108945237 \
     --hash=sha256:fe9ce4361809903261c4b055284ba91d94adedfd2202e0257920b9085d505e37
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   aiodns
 pycparser==3.0 \
     --hash=sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29 \
     --hash=sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   cffi
 pydantic==2.13.4 \
     --hash=sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba \
     --hash=sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   python-on-whales
 pydantic-core==2.46.4 \
     --hash=sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0 \
@@ -1411,20 +1408,20 @@ pydantic-core==2.46.4 \
     --hash=sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff \
     --hash=sha256:fd8b3d9fd264be37976686c7f65cd52a83f5e84f4bfd2adf9c1d469676bbb6ae
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   pydantic
 pygments==2.20.0 \
     --hash=sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f \
     --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   pytest
     #   rich
 pytest==9.0.3 \
     --hash=sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9 \
     --hash=sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   pytest-codspeed
     #   pytest-cov
     #   pytest-mock
@@ -1460,48 +1457,48 @@ pytest-codspeed==5.0.3 \
     --hash=sha256:f56d0339cd98d26f6e561987be25bdd2761a5d53d8f73493b1ebe02d0d451093 \
     --hash=sha256:f852bee785a7a124cb1720b1915670c6742af87747dc4d838f3ffdbd365ce9d9 \
     --hash=sha256:fe2ea83c924c2250675b75686c3ee456b8cf0208d83d552e182a195fdf467378
-    # via -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    # via -r .github/aiohttp-upstream-test-requirements.txt
 pytest-cov==7.1.0 \
     --hash=sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2 \
     --hash=sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678
-    # via -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    # via -r .github/aiohttp-upstream-test-requirements.txt
 pytest-mock==3.15.1 \
     --hash=sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d \
     --hash=sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f
-    # via -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    # via -r .github/aiohttp-upstream-test-requirements.txt
 pytest-timeout==2.4.0 \
     --hash=sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a \
     --hash=sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2
-    # via -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    # via -r .github/aiohttp-upstream-test-requirements.txt
 pytest-xdist==3.8.0 \
     --hash=sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88 \
     --hash=sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1
-    # via -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    # via -r .github/aiohttp-upstream-test-requirements.txt
 python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
     --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   freezegun
 python-on-whales==0.81.0 \
     --hash=sha256:6d5f81f56d0f95fd311a7cce29a01a1a60841074e4936000dc5f2dc9a7ffafac \
     --hash=sha256:bb6172014e3fe949f908092748bddf34df758cb92c2c3d0536b75bf236abce1b
-    # via -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    # via -r .github/aiohttp-upstream-test-requirements.txt
 rich==15.0.0 \
     --hash=sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb \
     --hash=sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   pytest-codspeed
 setuptools-git==1.2 \
     --hash=sha256:e7764dccce7d97b4b5a330d7b966aac6f9ac026385743fd6cedad553f2494cfa \
     --hash=sha256:ff64136da01aabba76ae88b050e7197918d8b2139ccbf6144e14d472b9c40445
-    # via -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    # via -r .github/aiohttp-upstream-test-requirements.txt
 six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   python-dateutil
 tomli==2.4.1 \
     --hash=sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853 \
@@ -1551,11 +1548,11 @@ tomli==2.4.1 \
     --hash=sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf \
     --hash=sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9 \
     --hash=sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049
-    # via -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    # via -r .github/aiohttp-upstream-test-requirements.txt
 trustme==1.2.1 \
     --hash=sha256:6528ba2bbc7f2db41f33825c8dd13e3e3eb9d334ba0f909713c8c3139f4ae47f \
     --hash=sha256:d768e5fc57c86dfc5ec9365102e9b092541cd6954b35d8c1eea01a84f35a762a
-    # via -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    # via -r .github/aiohttp-upstream-test-requirements.txt
 typing-extensions==4.16.0 \
     --hash=sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8 \
     --hash=sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5
@@ -1571,7 +1568,7 @@ typing-inspection==0.4.2 \
     --hash=sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7 \
     --hash=sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   pydantic
 uvloop==0.22.1 \
     --hash=sha256:017bd46f9e7b78e81606329d07141d3da446f8798c6baeec124260e22c262772 \
@@ -1623,11 +1620,11 @@ uvloop==0.22.1 \
     --hash=sha256:ea721dd3203b809039fcc2983f14608dae82b212288b346e0bfe46ec2fab0b7c \
     --hash=sha256:ef6f0d4cc8a9fa1f6a910230cd53545d9a14479311e87e3cb225495952eb672c \
     --hash=sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42
-    # via -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    # via -r .github/aiohttp-upstream-test-requirements.txt
 wait-for-it==2.3.0 \
     --hash=sha256:22ddbf08d6fe1b5f59b3807d539a932df7cab3de2823cb8b63591f81fa666c38 \
     --hash=sha256:bc6eaeb0912cf4d59c824067f36c73739bb7a6182912ec8984f2fb3447ef68c0
-    # via -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    # via -r .github/aiohttp-upstream-test-requirements.txt
 yarl==1.24.2 \
     --hash=sha256:0063adad533e57171b79db3943b229d40dfafeeee579767f96541f106bac5f1b \
     --hash=sha256:044a09d8401fcf8681977faef6d286b8ade1e2d2e9dceda175d1cfa5ca496f30 \
@@ -1734,7 +1731,7 @@ yarl==1.24.2 \
     --hash=sha256:f9a1e9b622ca284143aab5d885848686dcd85453bb1ca9abcdb7503e64dc0056 \
     --hash=sha256:fecd17873a096036c1c87ab3486f1aef7f269ada7f23f7f856f93b1cc7744f14
     # via
-    #   -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    #   -r .github/aiohttp-upstream-test-requirements.txt
     #   aiohttp
 zlib-ng==1.0.0 \
     --hash=sha256:0175e33a1faf96f184cfa4c0aa542ce4146acca02f4f3420ce50e0541c926d80 \
@@ -1787,4 +1784,4 @@ zlib-ng==1.0.0 \
     --hash=sha256:f903cb4d076ced4628284a76e5aed7b2a9e61a3c1fbe9416feaed1239d6b36ef \
     --hash=sha256:f9579c0ff6f64c5932b8a3f8316fd8d500a190a227cb9801bc3dc558aae03f96 \
     --hash=sha256:fef21e3c5528e008ac4fc7932d373ba9854090830731db9051c2a9344ae26579
-    # via -r https://raw.githubusercontent.com/aio-libs/aiohttp/5e392ce0456f5235a4ee6ad46f0e806df2f15873/requirements/test.txt
+    # via -r .github/aiohttp-upstream-test-requirements.txt

--- a/.github/aiohttp-upstream-test-requirements.txt
+++ b/.github/aiohttp-upstream-test-requirements.txt
@@ -1,0 +1,64 @@
+# Reviewed snapshot of aiohttp's generated test requirements at
+# 5e392ce0456f5235a4ee6ad46f0e806df2f15873. Keep the commit and this file in
+# sync when the pinned upstream suite moves. cryptography is updated from the
+# upstream 48.0.0 pin to 50.0.0 to include the current security fixes.
+
+aiodns==4.0.4 ; sys_platform != "android" and sys_platform != "ios"
+aiohappyeyeballs==2.6.2
+aiosignal==1.4.0
+annotated-types==0.7.0
+ast-serialize==0.5.0
+async-timeout==5.0.1 ; python_version < "3.11"
+attrs==26.1.0
+backports-zstd==1.3.0 ; platform_python_implementation == "CPython" and python_version < "3.14" and sys_platform != "android" and sys_platform != "ios"
+blockbuster==1.5.26
+brotli==1.2.0 ; platform_python_implementation == "CPython" and sys_platform != "android" and sys_platform != "ios"
+cffi==2.0.0
+click==8.4.1
+coverage==7.14.1
+cryptography==50.0.0
+exceptiongroup==1.3.1
+execnet==2.1.2
+forbiddenfruit==0.1.4
+freezegun==1.5.5
+frozenlist==1.8.0
+gunicorn==26.0.0
+idna==3.17
+iniconfig==2.3.0
+isal==1.8.0 ; python_version < "3.14" and implementation_name == "cpython"
+librt==0.11.0
+markdown-it-py==4.2.0
+mdurl==0.1.2
+multidict==6.7.1
+mypy==2.1.0 ; implementation_name == "cpython"
+mypy-extensions==1.1.0
+packaging==26.2
+pathspec==1.1.1
+pkgconfig==1.6.0
+pluggy==1.6.0
+propcache==0.5.2
+proxy-py==2.4.10
+pycares==5.0.1
+pycparser==3.0
+pydantic==2.13.4
+pydantic-core==2.46.4
+pygments==2.20.0
+pytest==9.0.3
+pytest-codspeed==5.0.3
+pytest-cov==7.1.0
+pytest-mock==3.15.1
+pytest-timeout==2.4.0
+pytest-xdist==3.8.0
+python-dateutil==2.9.0.post0
+python-on-whales==0.81.0
+rich==15.0.0
+setuptools-git==1.2
+six==1.17.0
+tomli==2.4.1
+trustme==1.2.1 ; platform_machine != "i686"
+typing-extensions==4.15.0 ; python_version < "3.13"
+typing-inspection==0.4.2
+uvloop==0.22.1 ; platform_system != "Windows" and implementation_name == "cpython"
+wait-for-it==2.3.0
+yarl==1.24.2
+zlib-ng==1.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,16 +48,6 @@ jobs:
           enable-cache: true
           version: 0.12.3
 
-      # Exercise the same builder and architecture selection used by Publish.
-      # A normal `uv sync` does not cover cibuildwheel's environment handling,
-      # which is platform-specific on Windows.
-      - name: Build and test the release wheel
-        if: runner.os == 'Windows'
-        uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
-        env:
-          CIBW_ARCHS: ${{ matrix.os == 'windows-11-arm' && 'ARM64' || 'AMD64' }}
-          HATCH_ZIG_TARGET: ${{ matrix.os == 'windows-11-arm' && 'aarch64-windows' || '' }}
-
       - name: Install
         env:
           HATCH_ZIG_TARGET: ${{ matrix.os == 'windows-11-arm' && 'aarch64-windows' || '' }}
@@ -144,6 +134,47 @@ jobs:
             uv run pytest "$f" --timeout=120 --timeout-method=thread || rc=1
           done
           exit $rc
+
+
+  # A normal `uv sync` does not cover cibuildwheel's environment handling. Keep
+  # this separate from `test`: an ARM64 wheel takes several minutes to compile,
+  # and serializing both jobs would consume the test job's hang timeout.
+  release-windows:
+    name: "release wheel (${{ matrix.archs }} on ${{ matrix.os }})"
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            archs: AMD64
+            target: ""
+          - os: windows-11-arm
+            archs: ARM64
+            target: aarch64-windows
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+          version: 0.12.3
+
+      - name: Install x86-64 Zig under emulation
+        if: matrix.archs == 'ARM64'
+        shell: pwsh
+        run: ./scripts/setup-zig-x86_64-windows.ps1
+
+      - name: Build and test the release wheel
+        uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
+        env:
+          CIBW_ARCHS: ${{ matrix.archs }}
+          HATCH_ZIG_TARGET: ${{ matrix.target }}
 
 
   # musl has only ever been compiled for, never run. It is a different libc under
@@ -361,7 +392,7 @@ jobs:
   pr-quality:
     name: PR quality gate
     if: always()
-    needs: [test, musl, cross-compile, release-safe, docs]
+    needs: [test, release-windows, musl, cross-compile, release-safe, docs]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,16 @@ jobs:
           enable-cache: true
           version: 0.12.3
 
+      # Exercise the same builder and architecture selection used by Publish.
+      # A normal `uv sync` does not cover cibuildwheel's environment handling,
+      # which is platform-specific on Windows.
+      - name: Build and test the release wheel
+        if: runner.os == 'Windows'
+        uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
+        env:
+          CIBW_ARCHS: ${{ matrix.os == 'windows-11-arm' && 'ARM64' || 'AMD64' }}
+          HATCH_ZIG_TARGET: ${{ matrix.os == 'windows-11-arm' && 'aarch64-windows' || '' }}
+
       - name: Install
         env:
           HATCH_ZIG_TARGET: ${{ matrix.os == 'windows-11-arm' && 'aarch64-windows' || '' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,10 @@ jobs:
   release-windows:
     name: "release wheel (${{ matrix.archs }} on ${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    # ARM64 compiles x86-64 Zig under emulation. Hosted-runner variance has put
+    # the same wheel build between 8 and 18 minutes; leave room for repair and
+    # tests while the per-test timeout still catches an actual hang quickly.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -50,10 +50,11 @@ on supported POSIX platforms, Unix sockets and pipes. You get one from
 `create_connection`, a server's `connection_made`, or `connect_read_pipe` /
 `connect_write_pipe`.
 
-### `zuvloop.DatagramTransport`
+### `zuvloop._zuvloop.DatagramTransport`
 
 The native datagram transport, an `asyncio.DatagramTransport` subclass, returned
-by `create_datagram_endpoint`.
+by `create_datagram_endpoint`. It is an implementation type rather than part of
+zuvloop's small top-level API.
 
 ### `zuvloop.Handle` and `zuvloop.TimerHandle`
 

--- a/docs/usage/instrumentation.md
+++ b/docs/usage/instrumentation.md
@@ -1,7 +1,8 @@
 # Instrumentation
 
-zuvloop emits plain [OpenTelemetry](https://opentelemetry.io). Its only runtime
-dependency is `opentelemetry-api` — not the SDK, and nothing vendor-specific.
+zuvloop emits plain [OpenTelemetry](https://opentelemetry.io). Its instrumentation
+depends only on `opentelemetry-api` — not the SDK, and nothing vendor-specific.
+The package also uses `typing-extensions` for its shipped type declarations.
 
 Until an application installs a provider, OpenTelemetry hands back proxy
 instruments whose methods do nothing and slow-callback timing stays off.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,8 +113,17 @@ skip = "*-musllinux_i686 *t-*"
 # on Windows ARM64, for example, httptools must build with an older setuptools
 # range than zuvloop's own build environment.
 build-frontend = { name = "uv", args = ["--require-hashes", "--build-constraints", ".github/build-constraints.txt"] }
-test-requires = ["aiohttp", "anyio", "httptools", "hypothesis", "opentelemetry-sdk", "pytest", "uvicorn"]
-test-command = "pytest {project}/tests -q --import-mode=importlib"
+test-requires = [
+    "aiohttp",
+    "anyio",
+    "httptools",
+    "hypothesis",
+    "opentelemetry-sdk",
+    "pytest",
+    "pytest-timeout",
+    "uvicorn",
+]
+test-command = "pytest {project}/tests -q --import-mode=importlib --timeout=120 --timeout-method=thread"
 
 [tool.cibuildwheel.linux]
 # The Zig toolchain comes from PyPI, so the manylinux image needs nothing extra.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,10 @@ skip = "*-musllinux_i686 *t-*"
 # requirements. Setting UV_REQUIRE_HASHES globally also affects cibuildwheel's
 # own bootstrap tools (for example, delocate) before the project build starts.
 build-frontend = { name = "uv", args = ["--require-hashes"] }
-environment = { UV_BUILD_CONSTRAINT = "$(pwd)/.github/build-constraints.txt" }
+# Keep this relative to the package directory. `$(pwd)` is expanded by
+# cibuildwheel's POSIX-style environment parser and produces a `/c/...` path on
+# Windows, which native uv cannot resolve.
+environment = { UV_BUILD_CONSTRAINT = ".github/build-constraints.txt" }
 test-requires = ["aiohttp", "anyio", "httptools", "hypothesis", "opentelemetry-sdk", "pytest", "uvicorn"]
 test-command = "pytest {project}/tests -q --import-mode=importlib"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,14 +108,11 @@ filterwarnings = ["error"]
 # a GIL to save.
 build = "cp314-*"
 skip = "*-musllinux_i686 *t-*"
-# Let uv own the project build so hash checking applies only to the pinned build
-# requirements. Setting UV_REQUIRE_HASHES globally also affects cibuildwheel's
-# own bootstrap tools (for example, delocate) before the project build starts.
-build-frontend = { name = "uv", args = ["--require-hashes"] }
-# Keep this relative to the package directory. `$(pwd)` is expanded by
-# cibuildwheel's POSIX-style environment parser and produces a `/c/...` path on
-# Windows, which native uv cannot resolve.
-environment = { UV_BUILD_CONSTRAINT = ".github/build-constraints.txt" }
+# Pass hash and constraint enforcement directly to the project build. Global uv
+# environment variables also affect cibuildwheel's bootstrap and test tools;
+# on Windows ARM64, for example, httptools must build with an older setuptools
+# range than zuvloop's own build environment.
+build-frontend = { name = "uv", args = ["--require-hashes", "--build-constraints", ".github/build-constraints.txt"] }
 test-requires = ["aiohttp", "anyio", "httptools", "hypothesis", "opentelemetry-sdk", "pytest", "uvicorn"]
 test-command = "pytest {project}/tests -q --import-mode=importlib"
 


### PR DESCRIPTION
## Summary

- scope cibuildwheel's hash constraints to zuvloop's project build and exercise the release builder in Windows CI
- replace Dependabot-incompatible remote aiohttp requirements with a reviewed local snapshot, updating cryptography to 50.0.0
- correct the documented datagram implementation type and runtime dependency wording

## Context

The v0.0.7 publish run exposed the Windows path bug before PyPI upload: cibuildwheel expanded `$(pwd)` to `/c/...`, which native Windows `uv` cannot resolve. Both AMD64 and ARM64 wheel jobs failed in the same place; all non-Windows distributions built successfully. The first CI run then exposed a second ARM64-only issue: a global build constraint leaked into httptools' source build and made its setuptools range unsatisfiable. Passing the constraint directly to zuvloop's `uv build` fixes both failures without affecting cibuildwheel's bootstrap or test dependencies. The new aggregate-gated CI matrix uses the same pinned cibuildwheel action and architecture selection as the publish workflow, running independently from the normal Windows suite so the slow ARM64 builds do not consume its hang timeout.

Dependabot also could not update the aiohttp compatibility lock because it interpreted the remote `-r https://...` include as a repository-local path. The local snapshot is byte-for-byte equivalent to aiohttp's requirements at the pinned upstream commit after changing only cryptography 48.0.0 to 50.0.0, then regenerating all hashes.

## Validation

- `uv run ruff check`
- `uv run ruff format --check`
- `uv run mypy`
- `uv run python -m mypy.stubtest zuvloop --allowlist stubtest_allowlist.txt`
- `uv run pytest` (489 passed, 2 skipped)
- `./scripts/docs` (strict build)
- hash-locked aiohttp environment install with cryptography 50.0.0
- deterministic regeneration of `.github/aiohttp-compatibility-requirements.txt`
- cibuildwheel 4.2.0 Windows configuration parsing
