### PR TITLE
Preserve call-graph identity for completed slow tasks

### DIFF
--- a/.github/build-constraints.txt
+++ b/.github/build-constraints.txt
@@ -46,9 +46,9 @@ trove-classifiers==2026.6.1.19 \
     --hash=sha256:ab4c4ec93cc4a4e7815fa759906e05e6bb3f2fbd92ea0f897288c6a43efd15b3 \
     --hash=sha256:c5132b4b61a829d11cfbd2d72e97f20a45ed6edb95e45c5efdeb5e00836b2745
     # via hatchling
-vcs-versioning==2.2.4 \
-    --hash=sha256:48ffea8a6a175c37a718c7ee2e5f508d0e500c2cf3371791f7948bccb2b44628 \
-    --hash=sha256:ed718fdee42170e128a8add6f23f53aa64dc7d9ab2de87d3083a691df881a809
+vcs-versioning==2.3.0 \
+    --hash=sha256:1b8e76156e50961a29fa9a1bd25c38145a2df86bf47611e134ffbff7852bc801 \
+    --hash=sha256:eb7f5aa2ff5d0c9f8c108ec0bb9476e2ddbe708f08a5e41df4c7977062484cf7
     # via setuptools-scm
 ziglang==0.16.0 \
     --hash=sha256:089a16a4eb5a2f45151993342f8fabad24ff1a0723dc146642895c29208a3939 \

--- a/tests/test_instrumentation.py
+++ b/tests/test_instrumentation.py
@@ -119,6 +119,23 @@ async def test_slow_callbacks_inside_a_task_carry_the_call_graph(telemetry: Tele
     assert any(graph is not None and "slow-step" in str(graph) for graph in graphs)
 
 
+async def test_slow_callback_that_finishes_its_task_carries_the_call_graph(telemetry: Telemetry) -> None:
+    loop = running_loop()
+    loop.slow_callback_duration = 0.01
+
+    async def slow_and_finish() -> None:
+        time.sleep(0.05)
+
+    try:
+        await loop.create_task(slow_and_finish(), name="slow-final-step")
+    finally:
+        loop.slow_callback_duration = 0.1
+
+    spans = telemetry.spans("zuvloop.slow_callback")
+    graphs = [span.attributes.get("asyncio.call_graph") for span in spans if span.attributes]
+    assert any(graph is not None and "slow-final-step" in str(graph) for graph in graphs)
+
+
 async def test_the_call_graph_is_absent_outside_a_task() -> None:
     loop = running_loop()
     captured = loop.create_future()
@@ -670,15 +687,44 @@ async def test_metrics_on_a_closed_loop_are_zero() -> None:
     assert loop._metrics()["loop_count"] == 0
 
 
-async def test_completed_task_recovered_from_a_handle_has_no_call_graph() -> None:
-    task = asyncio.create_task(asyncio.sleep(0))
-    await task
+async def test_completed_task_recovered_from_a_handle_has_a_safe_call_graph() -> None:
+    async def completed_with_secret_result() -> str:
+        return "secret result"
+
+    task = asyncio.create_task(completed_with_secret_result(), name="completed-task")
+    assert await task == "secret result"
     callback = MethodType(lambda _task: None, task)
     handle = running_loop().call_soon(callback)
     try:
-        assert capture_call_graph(handle) is None
+        graph = capture_call_graph(handle)
     finally:
         handle.cancel()
+
+    assert graph is not None
+    assert "completed-task" in graph
+    assert "state=done" in graph
+    assert "completed_with_secret_result" in graph
+    assert __file__ in graph
+    assert "secret result" not in graph
+
+
+async def test_completed_task_call_graph_does_not_render_its_exception() -> None:
+    async def completed_with_secret_exception() -> None:
+        raise RuntimeError("secret exception")
+
+    task = asyncio.create_task(completed_with_secret_exception())
+    with pytest.raises(RuntimeError, match="secret exception"):
+        await task
+    callback = MethodType(lambda _task: None, task)
+    handle = running_loop().call_soon(callback)
+    try:
+        graph = capture_call_graph(handle)
+    finally:
+        handle.cancel()
+
+    assert graph is not None
+    assert "completed_with_secret_exception" in graph
+    assert "secret exception" not in graph
 
 
 async def test_the_stdlib_call_graph_apis_work_on_this_loop() -> None:

--- a/tests/test_instrumentation.py
+++ b/tests/test_instrumentation.py
@@ -704,7 +704,7 @@ async def test_completed_task_recovered_from_a_handle_has_a_safe_call_graph() ->
     assert "completed-task" in graph
     assert "state=done" in graph
     assert "completed_with_secret_result" in graph
-    assert __file__ in graph
+    assert repr(__file__) in graph
     assert "secret result" not in graph
 
 

--- a/zuvloop/_instrumentation.py
+++ b/zuvloop/_instrumentation.py
@@ -5,6 +5,7 @@ import functools
 import time
 import traceback
 from collections.abc import Mapping
+from types import CodeType
 
 from opentelemetry import metrics, trace
 from opentelemetry.metrics import NoOpMeterProvider
@@ -137,8 +138,21 @@ def capture_call_graph(handle: object = None) -> str | None:
     task = getattr(getattr(handle, "_callback", None), "__self__", None)
     if not isinstance(task, asyncio.Task):
         task = asyncio.current_task()
-    if task is None or task.done():
+    if task is None:
         return None
+    if task.done():
+        coroutine = task.get_coro()
+        qualname = getattr(coroutine, "__qualname__", type(coroutine).__qualname__)
+        code = getattr(coroutine, "cr_code", None)
+        location = (
+            f"  |   File {code.co_filename!r}, line {code.co_firstlineno}, in {qualname}()"
+            if isinstance(code, CodeType)
+            else f"  |   Coroutine {qualname}()"
+        )
+        return (
+            f"* Task(name={task.get_name()!r}, id={id(task):#x}, state=done)\n"
+            f"  + Call stack (task already finished):\n{location}"
+        )
     return asyncio.format_call_graph(task)
 
 


### PR DESCRIPTION
### Summary

`capture_call_graph()` currently returns `None` for a task that finishes during a slow callback because telemetry is emitted after the callback returns.

This change renders a fallback in the same broad shape as `asyncio.format_call_graph()`. It includes the task name, finished state, coroutine qualname, and source location. It deliberately does not render the task object, result, or exception, because those values may contain sensitive application data.

### Tests

- added an end-to-end slow callback test for a final task step
- added result and exception secrecy regressions
- `uv run coverage run -m pytest`
- `uv run coverage report` (100%)
- `uv run mypy`
- `uv run python -m mypy.stubtest zuvloop --allowlist stubtest_allowlist.txt`
- `uv run ruff check`
- `uv run ruff format --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves call-graph identity for tasks that finish during a slow callback. Previously `capture_call_graph()` returned None for a completed task; now it returns a safe, `asyncio.format_call_graph()`-shaped summary so `zuvloop.slow_callback` spans retain the task.

- Triggers only when the associated `asyncio.Task` is done; running tasks still use `asyncio.format_call_graph()`.
- Fallback includes task name and id, state=done, coroutine qualname, and file/line when available; renders file paths with repr(...) for portability.
- Omits the task object, result, and exception messages; tests cover secrecy and the slow-callback-finishes case.
- Updates build constraint to `vcs-versioning` 2.3.0; no public API changes and no migration required.

<sup>Written for commit 61658309705ceb417cc2ac4b69de60c451e9d411. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Completed tasks now expose a safe call-graph summary after finishing.
  - Slow callback instrumentation includes the task name in generated call graphs.
  - Call graphs include completion status and available source location while omitting secret return values and exception messages.
  - Active tasks continue to provide their existing call-graph details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->