### PR TITLE
Recheck loop state before DNS submission

### DIFF
--- a/.github/build-constraints.txt
+++ b/.github/build-constraints.txt
@@ -46,9 +46,9 @@ trove-classifiers==2026.6.1.19 \
     --hash=sha256:ab4c4ec93cc4a4e7815fa759906e05e6bb3f2fbd92ea0f897288c6a43efd15b3 \
     --hash=sha256:c5132b4b61a829d11cfbd2d72e97f20a45ed6edb95e45c5efdeb5e00836b2745
     # via hatchling
-vcs-versioning==2.3.0 \
-    --hash=sha256:1b8e76156e50961a29fa9a1bd25c38145a2df86bf47611e134ffbff7852bc801 \
-    --hash=sha256:eb7f5aa2ff5d0c9f8c108ec0bb9476e2ddbe708f08a5e41df4c7977062484cf7
+vcs-versioning==2.3.1 \
+    --hash=sha256:806635bd0ea653c96af98a70624be758d408a989f2cd0b390e63474d99f96b63 \
+    --hash=sha256:a11299394e101569a62ab061375260d08bc56cd33d685b7067d85312368f4457
     # via setuptools-scm
 ziglang==0.16.0 \
     --hash=sha256:089a16a4eb5a2f45151993342f8fabad24ff1a0723dc146642895c29208a3939 \

--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -7,6 +7,7 @@ from collections.abc import Sequence
 import pytest
 
 from tests.conftest import running_loop
+from zuvloop import new_event_loop
 
 pytestmark = pytest.mark.anyio
 
@@ -114,6 +115,19 @@ async def test_getaddrinfo_without_a_host_or_a_port_reports_no_name() -> None:
     with pytest.raises(socket.gaierror) as stdlib:
         socket.getaddrinfo(None, None)
     assert caught.value.args == stdlib.value.args
+
+
+def test_getaddrinfo_rechecks_the_loop_after_argument_conversion() -> None:
+    loop = new_event_loop()
+
+    class ClosingFamily:
+        def __index__(self) -> int:
+            loop.close()
+            return int(socket.AF_UNSPEC)
+
+    call = loop.getaddrinfo("localhost", 80, family=ClosingFamily())  # type: ignore[arg-type]
+    with pytest.raises(RuntimeError, match="Event loop is closed"):
+        call.send(None)
 
 
 @pytest.mark.parametrize(

--- a/zig/dns.zig
+++ b/zig/dns.zig
@@ -457,6 +457,7 @@ pub fn getaddrinfo(self_obj: *py.Object, args: []const ?*py.Object) py.Error!*py
     hints.socktype = try py.asCInt(args[3].?);
     hints.protocol = try py.asCInt(args[4].?);
     hints.flags = @bitCast(@as(u32, @bitCast(try py.asCInt(args[5].?))));
+    try loopmod.checkClosed(loop.state());
 
     // libuv refuses this pair outright, before any resolver sees it, and reports
     // it as EINVAL. The resolver the standard library reaches would have answered
@@ -496,6 +497,7 @@ pub fn getaddrinfo(self_obj: *py.Object, args: []const ?*py.Object) py.Error!*py
 
     const req = try allocRequest(loop, .getaddrinfo);
     errdefer freeRequest(req, .getaddrinfo);
+    try loopmod.checkClosed(loop.state());
     req.hints = hints;
     @memcpy(req.host[0..host_buf.len], &host_buf);
     @memcpy(req.service[0..service_buf.len], &service_buf);


### PR DESCRIPTION
Recheck the loop after Python argument conversion and future creation so `uv_getaddrinfo` never receives a closed libuv loop. Add a public-API regression test that closes the loop from `family.__index__`.

Tests: `.venv/bin/python -m pytest tests/test_dns.py -q`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.