### PR TITLE
Reject invalid STARTTLS contexts

### DIFF
--- a/.github/build-constraints.txt
+++ b/.github/build-constraints.txt
@@ -46,9 +46,9 @@ trove-classifiers==2026.6.1.19 \
     --hash=sha256:ab4c4ec93cc4a4e7815fa759906e05e6bb3f2fbd92ea0f897288c6a43efd15b3 \
     --hash=sha256:c5132b4b61a829d11cfbd2d72e97f20a45ed6edb95e45c5efdeb5e00836b2745
     # via hatchling
-vcs-versioning==2.3.0 \
-    --hash=sha256:1b8e76156e50961a29fa9a1bd25c38145a2df86bf47611e134ffbff7852bc801 \
-    --hash=sha256:eb7f5aa2ff5d0c9f8c108ec0bb9476e2ddbe708f08a5e41df4c7977062484cf7
+vcs-versioning==2.3.1 \
+    --hash=sha256:806635bd0ea653c96af98a70624be758d408a989f2cd0b390e63474d99f96b63 \
+    --hash=sha256:a11299394e101569a62ab061375260d08bc56cd33d685b7067d85312368f4457
     # via setuptools-scm
 ziglang==0.16.0 \
     --hash=sha256:089a16a4eb5a2f45151993342f8fabad24ff1a0723dc146642895c29208a3939 \

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -276,3 +276,8 @@ async def test_start_tls_closes_the_transport_when_the_handshake_fails(client_co
 async def test_start_tls_rejects_a_write_only_transport(client_context: ssl.SSLContext) -> None:
     with pytest.raises(TypeError, match="both reading and writing"):
         await running_loop().start_tls(asyncio.WriteTransport(), asyncio.Protocol(), client_context)
+
+
+async def test_start_tls_rejects_an_invalid_ssl_context() -> None:
+    with pytest.raises(TypeError, match="expected to be an instance of ssl.SSLContext"):
+        await running_loop().start_tls(asyncio.Transport(), asyncio.Protocol(), None)  # type: ignore[arg-type]

--- a/zuvloop/_connect.py
+++ b/zuvloop/_connect.py
@@ -546,6 +546,8 @@ class ConnectionOperations(SendfileOperations):
         ssl_handshake_timeout: float | None = None,
         ssl_shutdown_timeout: float | None = None,
     ) -> asyncio.Transport:
+        if not isinstance(sslcontext, ssl_module.SSLContext):
+            raise TypeError(f"sslcontext is expected to be an instance of ssl.SSLContext, got {sslcontext!r}")
         if not isinstance(transport, asyncio.Transport):
             raise TypeError("transport must support both reading and writing")
         waiter = self.create_future()


### PR DESCRIPTION
Match `asyncio` by requiring an `ssl.SSLContext` before constructing `SSLProtocol`. This prevents the stdlib fallback from creating a client context without hostname verification when `None` is passed.

Tests: `.venv/bin/python -m pytest tests/test_tls.py -q`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.