### PR TITLE
Recheck loop state before adopting datagrams

### DIFF
--- a/.github/build-constraints.txt
+++ b/.github/build-constraints.txt
@@ -46,9 +46,9 @@ trove-classifiers==2026.6.1.19 \
     --hash=sha256:ab4c4ec93cc4a4e7815fa759906e05e6bb3f2fbd92ea0f897288c6a43efd15b3 \
     --hash=sha256:c5132b4b61a829d11cfbd2d72e97f20a45ed6edb95e45c5efdeb5e00836b2745
     # via hatchling
-vcs-versioning==2.3.0 \
-    --hash=sha256:1b8e76156e50961a29fa9a1bd25c38145a2df86bf47611e134ffbff7852bc801 \
-    --hash=sha256:eb7f5aa2ff5d0c9f8c108ec0bb9476e2ddbe708f08a5e41df4c7977062484cf7
+vcs-versioning==2.3.1 \
+    --hash=sha256:806635bd0ea653c96af98a70624be758d408a989f2cd0b390e63474d99f96b63 \
+    --hash=sha256:a11299394e101569a62ab061375260d08bc56cd33d685b7067d85312368f4457
     # via setuptools-scm
 ziglang==0.16.0 \
     --hash=sha256:089a16a4eb5a2f45151993342f8fabad24ff1a0723dc146642895c29208a3939 \

--- a/tests/test_datagram.py
+++ b/tests/test_datagram.py
@@ -14,7 +14,7 @@ from typing import NoReturn
 import pytest
 
 from tests.conftest import running_loop
-from zuvloop import _connect, _zuvloop
+from zuvloop import _connect, _zuvloop, new_event_loop
 
 pytestmark = pytest.mark.anyio
 requires_unix_sockets = pytest.mark.skipif(sys.platform == "win32", reason="Windows has no Unix sockets")
@@ -103,6 +103,22 @@ async def test_datagram_round_trip() -> None:
     finally:
         client.close()
         server.close()
+
+
+def test_datagram_adoption_rechecks_the_loop_after_protocol_binding() -> None:
+    loop = new_event_loop()
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+    class ClosingProtocol(asyncio.DatagramProtocol):
+        def __getattribute__(self, name: str) -> object:
+            if name == "connection_lost":
+                loop.close()
+            return super().__getattribute__(name)
+
+    call = loop.create_datagram_endpoint(ClosingProtocol, sock=sock)
+    with pytest.raises(RuntimeError, match="Event loop is closed"):
+        call.send(None)
+    assert sock.fileno() == -1
 
 
 async def test_a_connected_endpoint_needs_no_address() -> None:

--- a/zig/datagram.zig
+++ b/zig/datagram.zig
@@ -615,6 +615,7 @@ pub fn makeDatagram(self_obj: *py.Object, args: []const ?*py.Object) py.Error!*p
 
     bindProtocol(self, args[3].?);
     st.ready.ensureUnusedCapacity(1) catch return py.errNoMemory();
+    try loopmod.checkClosed(st);
 
     try py.errUvIfNeg(uv.uv_udp_init_ex(st.uvloop, self.udp(), 0));
     self.flags |= OPEN;


### PR DESCRIPTION
Recheck the loop after binding protocol callbacks so `uv_udp_init_ex` never receives a closed libuv loop. The regression drives `create_datagram_endpoint()` with an adopted socket and closes the loop from protocol attribute lookup.

Tests: `.venv/bin/python -m pytest tests/test_datagram.py -q`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.