### PR TITLE
Defer read state changes during buffer allocation

### DIFF
--- a/.github/build-constraints.txt
+++ b/.github/build-constraints.txt
@@ -46,9 +46,9 @@ trove-classifiers==2026.6.1.19 \
     --hash=sha256:ab4c4ec93cc4a4e7815fa759906e05e6bb3f2fbd92ea0f897288c6a43efd15b3 \
     --hash=sha256:c5132b4b61a829d11cfbd2d72e97f20a45ed6edb95e45c5efdeb5e00836b2745
     # via hatchling
-vcs-versioning==2.3.0 \
-    --hash=sha256:1b8e76156e50961a29fa9a1bd25c38145a2df86bf47611e134ffbff7852bc801 \
-    --hash=sha256:eb7f5aa2ff5d0c9f8c108ec0bb9476e2ddbe708f08a5e41df4c7977062484cf7
+vcs-versioning==2.3.1 \
+    --hash=sha256:806635bd0ea653c96af98a70624be758d408a989f2cd0b390e63474d99f96b63 \
+    --hash=sha256:a11299394e101569a62ab061375260d08bc56cd33d685b7067d85312368f4457
     # via setuptools-scm
 ziglang==0.16.0 \
     --hash=sha256:089a16a4eb5a2f45151993342f8fabad24ff1a0723dc146642895c29208a3939 \

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -12,7 +12,7 @@ import tempfile
 from asyncio import constants, trsock
 from collections.abc import Callable, Iterator, Sequence
 from pathlib import Path
-from typing import NoReturn
+from typing import Literal, NoReturn
 
 import pytest
 
@@ -760,6 +760,56 @@ async def test_buffered_protocol_reads_into_its_own_buffer() -> None:
         assert await done == b"hello"
         transport.close()
         await asyncio.sleep(0.05)
+
+
+@pytest.mark.parametrize("action", ["pause", "close", "abort"])
+async def test_buffered_protocol_can_change_read_state_from_get_buffer(
+    action: Literal["pause", "close", "abort"],
+) -> None:
+    loop = running_loop()
+
+    class ReentrantBuffered(asyncio.BufferedProtocol):
+        def __init__(self) -> None:
+            self.transport: asyncio.Transport | None = None
+            self.buffer = bytearray(4096)
+            self.acted: asyncio.Future[None] = loop.create_future()
+            self.received: asyncio.Future[bytes] = loop.create_future()
+            self.lost: asyncio.Future[BaseException | None] = loop.create_future()
+
+        def connection_made(self, transport: asyncio.BaseTransport) -> None:
+            self.transport = transport  # type: ignore[assignment]
+
+        def get_buffer(self, sizehint: int) -> bytearray:
+            assert self.transport is not None
+            if not self.acted.done():
+                if action == "pause":
+                    self.transport.pause_reading()
+                elif action == "close":
+                    self.transport.close()
+                else:
+                    self.transport.abort()
+                self.acted.set_result(None)
+            return self.buffer
+
+        def buffer_updated(self, nbytes: int) -> None:
+            self.received.set_result(bytes(self.buffer[:nbytes]))
+
+        def connection_lost(self, exc: BaseException | None) -> None:
+            self.lost.set_result(exc)
+
+    server, port, _ = await start_echo()
+    async with server:
+        transport, protocol = await loop.create_connection(ReentrantBuffered, "127.0.0.1", port)
+        transport.write(b"hello")
+        await asyncio.wait_for(protocol.acted, 2)
+        if action == "pause":
+            assert transport.is_reading() is False
+            transport.resume_reading()
+            assert await asyncio.wait_for(protocol.received, 2) == b"hello"
+            transport.close()
+        else:
+            await asyncio.wait_for(protocol.lost, 2)
+            assert transport.is_closing() is True
 
 
 async def test_connection_refused_is_reported(closed_port: int) -> None:

--- a/zig/transport.zig
+++ b/zig/transport.zig
@@ -32,6 +32,8 @@ const PIPE_OWNED: u32 = 1 << 9;
 /// CLOSING, and `repr` has to tell the two apart: asyncio still calls a transport
 /// "open" after `loop.close()`, because that never delivers `connection_lost`.
 const CLOSE_REQUESTED: u32 = 1 << 10;
+const ALLOCATING_READ_BUFFER: u32 = 1 << 11;
+const READ_STATE_PENDING: u32 = 1 << 12;
 
 pub const KIND_TCP: c_int = 0;
 pub const KIND_PIPE: c_int = 1;
@@ -328,6 +330,7 @@ fn onAlloc(handle: ?*uv.Handle, suggested: usize, buf: *uv.Buf) callconv(.c) voi
     defer st.gilExit();
 
     if (self.flags & BUFFERED != 0) {
+        self.flags |= ALLOCATING_READ_BUFFER;
         const size = py.int(@as(c.Py_ssize_t, 65536)) orelse {
             c.PyErr_Clear();
             buf.* = .{ .base = @ptrFromInt(@alignOf(u8)), .len = 0 };
@@ -348,6 +351,10 @@ fn onAlloc(handle: ?*uv.Handle, suggested: usize, buf: *uv.Buf) callconv(.c) voi
         if (target) |t| {
             defer py.decref(t);
             if (c.PyObject_GetBuffer(t, &self.view, c.PyBUF_WRITABLE) == 0) {
+                if (self.flags & READ_STATE_PENDING != 0) {
+                    buf.* = .{ .base = @ptrFromInt(@alignOf(u8)), .len = 0 };
+                    return;
+                }
                 // A short read is always allowed, so a buffer wider than the
                 // platform's vector element is simply not filled past it.
                 const avail = @min(@as(usize, @intCast(self.view.len)), uv.Buf.max_len);
@@ -385,8 +392,20 @@ fn onRead(stream: ?*uv.Stream, nread: isize, buf: *const uv.Buf) callconv(.c) vo
     st.gilEnter();
     defer st.gilExit();
 
+    const allocated_with_python = self.flags & ALLOCATING_READ_BUFFER != 0;
+    self.flags &= ~ALLOCATING_READ_BUFFER;
     const buffered = self.flags & BUFFERED != 0;
     if (buffered and self.view.obj != null) c.PyBuffer_Release(&self.view);
+    if (allocated_with_python and self.flags & READ_STATE_PENDING != 0) {
+        self.flags &= ~READ_STATE_PENDING;
+        py.clear(&self.read_bytes);
+        if (self.flags & READING != 0) {
+            _ = uv.uv_read_stop(self.stream());
+            self.flags &= ~READING;
+        }
+        if (self.flags & CLOSING != 0 and self.write_buffer_size == 0) shutdownAndClose(self);
+        return;
+    }
 
     // A write pipe reads only to learn that the peer went away; asyncio arms the
     // descriptor for the same reason and never delivers what arrives on it.
@@ -808,6 +827,10 @@ fn closeTransport(self: *Transport) void {
     if (self.flags & CLOSING != 0) return;
     flushPending(self);
     self.flags |= CLOSING;
+    if (self.flags & ALLOCATING_READ_BUFFER != 0) {
+        self.flags |= READ_STATE_PENDING;
+        return;
+    }
     if (self.flags & READING != 0) {
         _ = uv.uv_read_stop(self.stream());
         self.flags &= ~READING;
@@ -826,6 +849,10 @@ fn forceClose(self: *Transport, exc: ?*py.Object) void {
     }
     self.flags |= CLOSING;
     self.write_buffer_size = 0;
+    if (self.flags & ALLOCATING_READ_BUFFER != 0) {
+        self.flags |= READ_STATE_PENDING;
+        return;
+    }
     shutdownAndClose(self);
 }
 
@@ -900,6 +927,10 @@ fn isReading(self_obj: *py.Object) py.Error!*py.Object {
 fn pauseReading(self_obj: *py.Object) py.Error!*py.Object {
     const self = asTransport(self_obj);
     if (self.flags & READING != 0) {
+        if (self.flags & ALLOCATING_READ_BUFFER != 0) {
+            self.flags |= READ_STATE_PENDING;
+            return py.noneRef();
+        }
         try py.errUvIfNeg(uv.uv_read_stop(self.stream()));
         self.flags &= ~READING;
     }


### PR DESCRIPTION
Defer `pause_reading()`, `close()`, and `abort()` side effects requested from `BufferedProtocol.get_buffer()` until libuv reaches the matching read callback. This keeps libuv's read callback installed for the full alloc/read sequence and avoids a NULL callback dereference.

Tests: `.venv/bin/python -m pytest tests/test_network.py -q`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.