### PR TITLE
Close streams when received data cannot be delivered

### DIFF
--- a/.github/build-constraints.txt
+++ b/.github/build-constraints.txt
@@ -46,9 +46,9 @@ trove-classifiers==2026.6.1.19 \
     --hash=sha256:ab4c4ec93cc4a4e7815fa759906e05e6bb3f2fbd92ea0f897288c6a43efd15b3 \
     --hash=sha256:c5132b4b61a829d11cfbd2d72e97f20a45ed6edb95e45c5efdeb5e00836b2745
     # via hatchling
-vcs-versioning==2.3.0 \
-    --hash=sha256:1b8e76156e50961a29fa9a1bd25c38145a2df86bf47611e134ffbff7852bc801 \
-    --hash=sha256:eb7f5aa2ff5d0c9f8c108ec0bb9476e2ddbe708f08a5e41df4c7977062484cf7
+vcs-versioning==2.3.1 \
+    --hash=sha256:806635bd0ea653c96af98a70624be758d408a989f2cd0b390e63474d99f96b63 \
+    --hash=sha256:a11299394e101569a62ab061375260d08bc56cd33d685b7067d85312368f4457
     # via setuptools-scm
 ziglang==0.16.0 \
     --hash=sha256:089a16a4eb5a2f45151993342f8fabad24ff1a0723dc146642895c29208a3939 \

--- a/zig/transport.zig
+++ b/zig/transport.zig
@@ -404,7 +404,7 @@ fn onRead(stream: ?*uv.Stream, nread: isize, buf: *const uv.Buf) callconv(.c) vo
     if (nread > 0) {
         if (buffered) {
             const n = py.int(@as(c.Py_ssize_t, @intCast(nread))) orelse {
-                c.PyErr_Clear();
+                forceClose(self, c.PyErr_GetRaisedException());
                 return;
             };
             defer py.decref(n);
@@ -417,13 +417,13 @@ fn onRead(stream: ?*uv.Stream, nread: isize, buf: *const uv.Buf) callconv(.c) vo
                 self.read_bytes = null;
                 var resized = owned;
                 if (c._PyBytes_Resize(@ptrCast(&resized), @intCast(nread)) < 0) {
-                    c.PyErr_Clear();
+                    forceClose(self, c.PyErr_GetRaisedException());
                     return;
                 }
                 break :blk resized;
             }
             break :blk py.bytes(buf.base[0..@intCast(nread)]) orelse {
-                c.PyErr_Clear();
+                forceClose(self, c.PyErr_GetRaisedException());
                 return;
             };
         };


### PR DESCRIPTION
Force-close a stream with the active allocation exception when received bytes cannot be converted for `data_received()` or `buffer_updated()`. The application now observes a broken connection instead of a silently corrupted byte stream.

Tests: `.venv/bin/python -m pytest tests/test_network.py -q`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.