### PR TITLE
Surface process exit scheduling failures

### DIFF
--- a/.github/build-constraints.txt
+++ b/.github/build-constraints.txt
@@ -46,9 +46,9 @@ trove-classifiers==2026.6.1.19 \
     --hash=sha256:ab4c4ec93cc4a4e7815fa759906e05e6bb3f2fbd92ea0f897288c6a43efd15b3 \
     --hash=sha256:c5132b4b61a829d11cfbd2d72e97f20a45ed6edb95e45c5efdeb5e00836b2745
     # via hatchling
-vcs-versioning==2.3.0 \
-    --hash=sha256:1b8e76156e50961a29fa9a1bd25c38145a2df86bf47611e134ffbff7852bc801 \
-    --hash=sha256:eb7f5aa2ff5d0c9f8c108ec0bb9476e2ddbe708f08a5e41df4c7977062484cf7
+vcs-versioning==2.3.1 \
+    --hash=sha256:806635bd0ea653c96af98a70624be758d408a989f2cd0b390e63474d99f96b63 \
+    --hash=sha256:a11299394e101569a62ab061375260d08bc56cd33d685b7067d85312368f4457
     # via setuptools-scm
 ziglang==0.16.0 \
     --hash=sha256:089a16a4eb5a2f45151993342f8fabad24ff1a0723dc146642895c29208a3939 \

--- a/zig/process.zig
+++ b/zig/process.zig
@@ -138,19 +138,26 @@ fn onExit(handle: ?*uv.Process, status: i64, signal: c_int) callconv(.c) void {
     self.flags |= EXITED;
 
     if (self.on_exit) |callback| {
+        const loop = loopmod.asLoop(self.loop.?);
         const code = py.int(@as(c.Py_ssize_t, self.returncode)) orelse {
-            c.PyErr_Clear();
+            loopmod.captureFatal(loop);
             closeHandle(self);
             return;
         };
         defer py.decref(code);
         var argv = [_]?*py.Object{code};
         const h = handlemod.create(handlemod.handle_type.?, self.loop.?, callback, argv[0..1], self.context) catch {
-            c.PyErr_Clear();
+            loopmod.captureFatal(loop);
             closeHandle(self);
             return;
         };
-        st.ready.push(@ptrCast(h)) catch py.decref(h);
+        st.ready.push(@ptrCast(h)) catch {
+            py.decref(h);
+            py.errNoMemory() catch {};
+            loopmod.captureFatal(loop);
+            closeHandle(self);
+            return;
+        };
         loopmod.startIdle(st);
     }
     closeHandle(self);


### PR DESCRIPTION
Stop the loop with the active exception when a one-shot process exit notification cannot be created or queued. `wait()` and `communicate()` can no longer remain pending forever without any visible failure after the child was reaped.

Tests: `.venv/bin/python -m pytest tests/test_subprocess.py -q`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.