### PR TITLE
Reject NULs in UNIX datagram paths

### DIFF
--- a/.github/build-constraints.txt
+++ b/.github/build-constraints.txt
@@ -46,9 +46,9 @@ trove-classifiers==2026.6.1.19 \
     --hash=sha256:ab4c4ec93cc4a4e7815fa759906e05e6bb3f2fbd92ea0f897288c6a43efd15b3 \
     --hash=sha256:c5132b4b61a829d11cfbd2d72e97f20a45ed6edb95e45c5efdeb5e00836b2745
     # via hatchling
-vcs-versioning==2.3.0 \
-    --hash=sha256:1b8e76156e50961a29fa9a1bd25c38145a2df86bf47611e134ffbff7852bc801 \
-    --hash=sha256:eb7f5aa2ff5d0c9f8c108ec0bb9476e2ddbe708f08a5e41df4c7977062484cf7
+vcs-versioning==2.3.1 \
+    --hash=sha256:806635bd0ea653c96af98a70624be758d408a989f2cd0b390e63474d99f96b63 \
+    --hash=sha256:a11299394e101569a62ab061375260d08bc56cd33d685b7067d85312368f4457
     # via setuptools-scm
 ziglang==0.16.0 \
     --hash=sha256:089a16a4eb5a2f45151993342f8fabad24ff1a0723dc146642895c29208a3939 \

--- a/tests/test_datagram.py
+++ b/tests/test_datagram.py
@@ -621,6 +621,19 @@ async def test_unix_datagram_endpoints_round_trip() -> None:
             server.close()
 
 
+@requires_unix_sockets
+async def test_unix_datagram_destinations_reject_embedded_nuls() -> None:
+    loop = running_loop()
+    with unix_socket_dir() as directory:
+        client_path = str(directory / "client")
+        client, _ = await loop.create_datagram_endpoint(Collector, local_addr=client_path, family=socket.AF_UNIX)
+        try:
+            with pytest.raises(ValueError, match="embedded null byte"):
+                client.sendto(b"unix", f"{directory}/target\0ignored")
+        finally:
+            client.close()
+
+
 @pytest.mark.skipif(sys.platform != "linux", reason="abstract AF_UNIX names are a Linux feature")
 async def test_abstract_unix_datagram_sender_address_is_preserved() -> None:  # pragma: no cover - Linux CI
     loop = running_loop()

--- a/zig/addr.zig
+++ b/zig/addr.zig
@@ -48,9 +48,13 @@ pub fn fromPython(family: c_int, address: *py.Object, out: *Storage) py.Error!c_
         }
         const un: *posix.sockaddr.un = @ptrCast(out);
         if (len >= un.path.len) return py.errValue("AF_UNIX path too long");
+        const path_len: usize = @intCast(len);
+        if (path_len != 0 and path[0] != 0 and std.mem.indexOfScalar(u8, path[0..path_len], 0) != null) {
+            return py.errValue("embedded null byte");
+        }
         un.family = @intCast(AF_UNIX);
-        @memcpy(un.path[0..@intCast(len)], path[0..@intCast(len)]);
-        return @intCast(UN_BASE + @as(usize, @intCast(len)));
+        @memcpy(un.path[0..path_len], path[0..path_len]);
+        return @intCast(UN_BASE + path_len);
     }
 
     if (c.PyTuple_Check(address) == 0) return py.errType("address must be a tuple");


### PR DESCRIPTION
Reject embedded NUL bytes in pathname `AF_UNIX` destinations before they reach the kernel. Leading-NUL abstract names remain valid and retain their exact length from the existing address-length patch.

Tests: `.venv/bin/python -m pytest tests/test_datagram.py -q`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.