### PR TITLE
Reject NULs in resolver inputs

### DIFF
--- a/.github/build-constraints.txt
+++ b/.github/build-constraints.txt
@@ -46,9 +46,9 @@ trove-classifiers==2026.6.1.19 \
     --hash=sha256:ab4c4ec93cc4a4e7815fa759906e05e6bb3f2fbd92ea0f897288c6a43efd15b3 \
     --hash=sha256:c5132b4b61a829d11cfbd2d72e97f20a45ed6edb95e45c5efdeb5e00836b2745
     # via hatchling
-vcs-versioning==2.3.0 \
-    --hash=sha256:1b8e76156e50961a29fa9a1bd25c38145a2df86bf47611e134ffbff7852bc801 \
-    --hash=sha256:eb7f5aa2ff5d0c9f8c108ec0bb9476e2ddbe708f08a5e41df4c7977062484cf7
+vcs-versioning==2.3.1 \
+    --hash=sha256:806635bd0ea653c96af98a70624be758d408a989f2cd0b390e63474d99f96b63 \
+    --hash=sha256:a11299394e101569a62ab061375260d08bc56cd33d685b7067d85312368f4457
     # via setuptools-scm
 ziglang==0.16.0 \
     --hash=sha256:089a16a4eb5a2f45151993342f8fabad24ff1a0723dc146642895c29208a3939 \

--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -33,6 +33,12 @@ async def test_getaddrinfo_resolves_localhost() -> None:
         assert sockaddr[1] == 80
 
 
+@pytest.mark.parametrize("host", ["127.0.0.1\0.allowed.example", b"127.0.0.1\0.allowed.example"])
+async def test_getaddrinfo_rejects_embedded_nuls(host: str | bytes) -> None:
+    with pytest.raises(ValueError, match="embedded null byte"):
+        await running_loop().getaddrinfo(host, 80)
+
+
 async def test_getaddrinfo_accepts_a_service_name() -> None:
     loop = running_loop()
     results = await loop.getaddrinfo("127.0.0.1", "http", family=socket.AF_INET, type=socket.SOCK_STREAM)

--- a/zig/dns.zig
+++ b/zig/dns.zig
@@ -140,9 +140,11 @@ fn copyZ(dst: []u8, value: *py.Object, what: [:0]const u8) py.Error!?[*:0]const 
         _ = c.PyErr_Format(py.exc_type_error, "%s must be str, bytes, int or None", what.ptr);
         return py.Error.Python;
     }
-    if (@as(usize, @intCast(len)) >= dst.len) return py.errValue("value too long");
-    @memcpy(dst[0..@intCast(len)], src[0..@intCast(len)]);
-    dst[@intCast(len)] = 0;
+    const value_len: usize = @intCast(len);
+    if (std.mem.indexOfScalar(u8, src[0..value_len], 0) != null) return py.errValue("embedded null byte");
+    if (value_len >= dst.len) return py.errValue("value too long");
+    @memcpy(dst[0..value_len], src[0..value_len]);
+    dst[value_len] = 0;
     return @ptrCast(dst.ptr);
 }
 


### PR DESCRIPTION
Reject embedded NUL bytes before resolver inputs become C strings, so validation and resolution cannot observe different hostnames. CPython 3.14 currently shares the truncation behavior, so this intentionally applies a stricter security boundary.

Tests: `.venv/bin/python -m pytest tests/test_dns.py -q`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.