### PR TITLE
Optimize call_soon_threadsafe scheduling

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -126,6 +126,7 @@ pub fn build(b: *std.Build) void {
         .pic = true,
     });
     mod.addIncludePath(.{ .cwd_relative = python_include });
+    mod.addIncludePath(b.path("zig"));
     mod.addIncludePath(b.path("vendor/libuv/include"));
     mod.addIncludePath(b.path("vendor/libuv/src"));
 

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -321,6 +321,22 @@ def test_threadsafe_inbox_does_not_retain_an_abandoned_loop() -> None:
     assert handle_ref() is None
 
 
+def test_close_tracks_a_retained_threadsafe_handle_cycle() -> None:
+    loop = zuvloop.new_event_loop()
+    handles: list[asyncio.Handle] = []
+    handle = loop.call_soon_threadsafe(handles.clear)
+    handles.append(handle)
+    loop_ref = weakref.ref(loop)
+    handle_ref = weakref.ref(handle)
+    loop.close()
+
+    del handle, handles, loop
+    gc.collect()
+
+    assert loop_ref() is None
+    assert handle_ref() is None
+
+
 def test_asyncio_run_accepts_the_loop_factory() -> None:
     async def main() -> str:
         return type(running_loop()).__name__

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -337,6 +337,39 @@ def test_close_tracks_a_retained_threadsafe_handle_cycle() -> None:
     assert handle_ref() is None
 
 
+def test_retained_threadsafe_handle_cycle_does_not_retain_an_abandoned_loop() -> None:
+    loop = zuvloop.new_event_loop()
+    handles: list[asyncio.Handle] = []
+    handle = loop.call_soon_threadsafe(handles.clear)
+    handles.append(handle)
+    loop_ref = weakref.ref(loop)
+    handle_ref = weakref.ref(handle)
+
+    with pytest.warns(ResourceWarning, match="unclosed event loop"):
+        del handle, handles, loop
+        gc.collect()
+
+    assert loop_ref() is None
+    assert handle_ref() is None
+
+
+def test_retained_threadsafe_handle_keeps_its_loop_reachable() -> None:
+    loop = zuvloop.new_event_loop()
+    handles: list[asyncio.Handle] = []
+    handle = loop.call_soon_threadsafe(handles.clear)
+    handles.append(handle)
+    loop_ref = weakref.ref(loop)
+
+    del handles, loop
+    gc.collect()
+
+    retained_loop = loop_ref()
+    assert retained_loop is not None
+    retained_loop.close()
+    del handle, retained_loop
+    gc.collect()
+
+
 def test_asyncio_run_accepts_the_loop_factory() -> None:
     async def main() -> str:
         return type(running_loop()).__name__

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -276,6 +276,58 @@ async def test_call_soon_threadsafe_from_another_thread() -> None:
     assert await done == "from thread"
 
 
+def test_call_soon_threadsafe_captures_the_worker_context() -> None:
+    loop = zuvloop.new_event_loop()
+    variable: contextvars.ContextVar[str] = contextvars.ContextVar("variable", default="default")
+    seen: list[str] = []
+
+    def worker() -> None:
+        variable.set("scheduled")
+        loop.call_soon_threadsafe(lambda: seen.append(variable.get()))
+        variable.set("changed later")
+        loop.call_soon_threadsafe(loop.stop)
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+    thread.join()
+    try:
+        loop.run_forever()
+    finally:
+        loop.close()
+    assert seen == ["scheduled"]
+
+
+def test_call_soon_threadsafe_keeps_empty_contexts_independent() -> None:
+    loop = zuvloop.new_event_loop()
+    variable: contextvars.ContextVar[str] = contextvars.ContextVar("variable", default="default")
+    seen: list[str] = []
+
+    loop.call_soon_threadsafe(variable.set, "first callback")
+    loop.call_soon_threadsafe(lambda: seen.append(variable.get()))
+    loop.call_soon_threadsafe(loop.stop)
+    try:
+        loop.run_forever()
+    finally:
+        loop.close()
+    assert seen == ["default"]
+
+
+def test_call_soon_threadsafe_exposes_its_context_before_running() -> None:
+    loop = zuvloop.new_event_loop()
+    variable: contextvars.ContextVar[str] = contextvars.ContextVar("variable", default="default")
+    seen: list[str] = []
+    handle = loop.call_soon_threadsafe(lambda: seen.append(variable.get()))
+    context = handle.get_context()
+    context.run(variable.set, "modified")
+    loop.call_soon_threadsafe(loop.stop)
+    try:
+        loop.run_forever()
+    finally:
+        loop.close()
+    assert handle.get_context() is context
+    assert seen == ["modified"]
+
+
 async def test_call_soon_threadsafe_validates_its_arguments() -> None:
     loop = running_loop()
     with pytest.raises(TypeError, match="requires a callback"):

--- a/zig/c.zig
+++ b/zig/c.zig
@@ -1,4 +1,5 @@
 pub const c = @cImport({
     @cDefine("PY_SSIZE_T_CLEAN", {});
     @cInclude("Python.h");
+    @cInclude("context_shim.h");
 });

--- a/zig/context_shim.h
+++ b/zig/context_shim.h
@@ -1,0 +1,10 @@
+#ifndef ZUVLOOP_CONTEXT_SHIM_H
+#define ZUVLOOP_CONTEXT_SHIM_H
+
+#include <stddef.h>
+
+enum {
+    ZUVLOOP_PYTHREADSTATE_CONTEXT_OFFSET = offsetof(PyThreadState, context),
+};
+
+#endif

--- a/zig/loop.zig
+++ b/zig/loop.zig
@@ -24,6 +24,7 @@ const alloc = std.heap.c_allocator;
 
 /// Timers below this many cancelled entries are never compacted.
 const min_cancelled_timers = 100;
+const context_pool_capacity = 16;
 
 pub const State = struct {
     uvloop: *uv.Loop,
@@ -38,6 +39,8 @@ pub const State = struct {
     timers: collections.Timers = .empty,
     pollers: pollermod.Map = .empty,
     scratch: ?[*]u8 = null,
+    empty_contexts: [context_pool_capacity]?*py.Object = .{null} ** context_pool_capacity,
+    empty_contexts_len: usize = 0,
     dns_requests: ?*anyopaque = null,
     transport_head: ?*transportmod.Transport = null,
     flush_head: ?*transportmod.Transport = null,
@@ -53,6 +56,7 @@ pub const State = struct {
     debug: bool = false,
     slow_callback_monitoring: bool = false,
     idle_active: bool = false,
+    waker_pending: bool = false,
     timer_active: bool = false,
     sampler_active: bool = false,
     flusher_active: bool = false,
@@ -168,6 +172,7 @@ fn onWake(waker: ?*uv.Async) callconv(.c) void {
     const st = self.state();
     st.gilEnter();
     defer st.gilExit();
+    st.waker_pending = false;
     startIdle(st);
 }
 
@@ -263,6 +268,38 @@ pub inline fn startIdle(st: *State) void {
     if (!st.idle_active and st.ready.len != 0) {
         _ = uv.uv_idle_start(st.idle, onIdle);
         st.idle_active = true;
+    }
+}
+
+pub fn takeEmptyContext(loop_obj: *py.Object) ?*py.Object {
+    const st = asLoop(loop_obj).state();
+    if (st.empty_contexts_len == 0) return null;
+    st.empty_contexts_len -= 1;
+    const context = st.empty_contexts[st.empty_contexts_len];
+    st.empty_contexts[st.empty_contexts_len] = null;
+    return context;
+}
+
+pub fn recycleEmptyContext(loop_obj: *py.Object, context: *py.Object) bool {
+    const st = asLoop(loop_obj).state();
+    if (st.closed or st.empty_contexts_len == context_pool_capacity) return false;
+    st.empty_contexts[st.empty_contexts_len] = context;
+    st.empty_contexts_len += 1;
+    return true;
+}
+
+fn clearEmptyContexts(st: *State) void {
+    while (st.empty_contexts_len > 0) {
+        st.empty_contexts_len -= 1;
+        py.clear(&st.empty_contexts[st.empty_contexts_len]);
+    }
+}
+
+fn trackRetainedThreadSafeHandles(st: *State) void {
+    var i: usize = 0;
+    while (i < st.ready.len) : (i += 1) {
+        const handle = st.ready.items[(st.ready.head + i) & (st.ready.items.len - 1)].?;
+        if (tshandle.owns(handle)) tshandle.trackIfRetained(handle);
     }
 }
 
@@ -498,9 +535,12 @@ fn callSoonThreadsafe(self_obj: *py.Object, args: []const ?*py.Object, nargs: us
         py.decref(h);
         return py.errNoMemory();
     };
-    // The only libuv call legal from a foreign thread; `uv_idle_start` is not, so
-    // the idle handle is armed by the waker on the loop thread.
-    _ = uv.uv_async_send(st.waker);
+    // libuv clears its pending bit before `onWake` acquires the GIL. Keep one at
+    // this layer so a producer cannot issue another kernel wake in that window.
+    if (!st.idle_active and !st.waker_pending) {
+        st.waker_pending = true;
+        _ = uv.uv_async_send(st.waker);
+    }
     return h;
 }
 
@@ -713,8 +753,10 @@ fn closeLoop(self_obj: *py.Object) py.Error!*py.Object {
     if (st.closed) return py.noneRef();
     st.closed = true;
 
+    trackRetainedThreadSafeHandles(st);
     st.ready.deinit();
     st.timers.deinit();
+    clearEmptyContexts(st);
     dropFlushList(st);
     py.clear(&st.fatal);
     py.clear(&st.metrics_cb);
@@ -923,8 +965,10 @@ fn dealloc(obj: ?*py.Object) callconv(.c) void {
         const needs_close = !st.closed;
         st.closed = true;
         if (needs_close) {
+            trackRetainedThreadSafeHandles(st);
             st.ready.deinit();
             st.timers.deinit();
+            clearEmptyContexts(st);
         }
         // The flush list owns one Python reference per transport regardless of
         // how the loop reached deallocation, including partially completed
@@ -952,7 +996,11 @@ fn traverse(obj: ?*py.Object, visitproc: c.visitproc, arg: ?*anyopaque) callconv
         if (r != 0) return r;
         var i: usize = 0;
         while (i < st.ready.len) : (i += 1) {
-            r = py.visit(st.ready.items[(st.ready.head + i) & (st.ready.items.len - 1)], visitproc, arg);
+            const handle = st.ready.items[(st.ready.head + i) & (st.ready.items.len - 1)].?;
+            r = if (tshandle.owns(handle))
+                tshandle.traverseQueued(handle, visitproc, arg)
+            else
+                py.visit(handle, visitproc, arg);
             if (r != 0) return r;
         }
         i = 0;

--- a/zig/loop.zig
+++ b/zig/loop.zig
@@ -41,6 +41,7 @@ pub const State = struct {
     scratch: ?[*]u8 = null,
     empty_contexts: [context_pool_capacity]?*py.Object = .{null} ** context_pool_capacity,
     empty_contexts_len: usize = 0,
+    threadsafe_candidate: ?*py.Object = null,
     dns_requests: ?*anyopaque = null,
     transport_head: ?*transportmod.Transport = null,
     flush_head: ?*transportmod.Transport = null,
@@ -295,12 +296,11 @@ fn clearEmptyContexts(st: *State) void {
     }
 }
 
-fn trackRetainedThreadSafeHandles(st: *State) void {
-    var i: usize = 0;
-    while (i < st.ready.len) : (i += 1) {
-        const handle = st.ready.items[(st.ready.head + i) & (st.ready.items.len - 1)].?;
-        if (tshandle.owns(handle)) tshandle.trackIfRetained(handle);
-    }
+fn clearThreadsafeCandidate(st: *State, untrack_queue_only: bool) void {
+    const candidate = st.threadsafe_candidate orelse return;
+    st.threadsafe_candidate = null;
+    if (untrack_queue_only) tshandle.untrackIfQueueOnly(candidate);
+    py.decref(candidate);
 }
 
 /// The ready queue holds both handle types; only the type says which protocol
@@ -325,6 +325,7 @@ fn runReady(self: *LoopObject) void {
     st.callbacks_run += remaining;
     while (remaining != 0) : (remaining -= 1) {
         const obj = st.ready.pop() orelse break;
+        if (st.threadsafe_candidate == obj) clearThreadsafeCandidate(st, true);
         if ((st.debug or st.slow_callback_monitoring) and st.slow_callback_duration < std.math.inf(f64)) {
             const started = uv.uv_hrtime();
             runOne(obj);
@@ -525,6 +526,7 @@ fn callSoonThreadsafe(self_obj: *py.Object, args: []const ?*py.Object, nargs: us
     const st = self.state();
     try checkClosed(st);
     const p = try parseCall(args, nargs, kwnames, 1);
+    clearThreadsafeCandidate(st, true);
     const h = try tshandle.create(self_obj, args[0].?, p.positional, p.context);
     py.incref(h);
     // One FIFO for both schedulers, so a `call_soon` issued after a
@@ -535,6 +537,9 @@ fn callSoonThreadsafe(self_obj: *py.Object, args: []const ?*py.Object, nargs: us
         py.decref(h);
         return py.errNoMemory();
     };
+    // Keep the return value tracked until a later call proves only the queue retained it.
+    py.incref(h);
+    st.threadsafe_candidate = h;
     // libuv clears its pending bit before `onWake` acquires the GIL. Keep one at
     // this layer so a producer cannot issue another kernel wake in that window.
     if (!st.idle_active and !st.waker_pending) {
@@ -753,7 +758,7 @@ fn closeLoop(self_obj: *py.Object) py.Error!*py.Object {
     if (st.closed) return py.noneRef();
     st.closed = true;
 
-    trackRetainedThreadSafeHandles(st);
+    clearThreadsafeCandidate(st, false);
     st.ready.deinit();
     st.timers.deinit();
     clearEmptyContexts(st);
@@ -965,7 +970,7 @@ fn dealloc(obj: ?*py.Object) callconv(.c) void {
         const needs_close = !st.closed;
         st.closed = true;
         if (needs_close) {
-            trackRetainedThreadSafeHandles(st);
+            clearThreadsafeCandidate(st, false);
             st.ready.deinit();
             st.timers.deinit();
             clearEmptyContexts(st);
@@ -993,6 +998,8 @@ fn traverse(obj: ?*py.Object, visitproc: c.visitproc, arg: ?*anyopaque) callconv
         var r = py.visit(st.fatal, visitproc, arg);
         if (r != 0) return r;
         r = py.visit(st.metrics_cb, visitproc, arg);
+        if (r != 0) return r;
+        r = py.visit(st.threadsafe_candidate, visitproc, arg);
         if (r != 0) return r;
         var i: usize = 0;
         while (i < st.ready.len) : (i += 1) {

--- a/zig/tshandle.zig
+++ b/zig/tshandle.zig
@@ -72,8 +72,9 @@ pub inline fn owns(obj: *py.Object) bool {
     return py.typeOf(obj) == ts_type.?;
 }
 
-pub fn trackIfRetained(obj: *py.Object) void {
-    if (c.Py_REFCNT(obj) > 1 and c.PyObject_GC_IsTracked(obj) == 0) c.PyObject_GC_Track(obj);
+/// Untracks a handle owned only by the ready queue and candidate slot.
+pub fn untrackIfQueueOnly(obj: *py.Object) void {
+    if (c.Py_REFCNT(obj) == 2 and c.PyObject_GC_IsTracked(obj) != 0) c.PyObject_GC_UnTrack(obj);
 }
 
 pub fn create(
@@ -128,14 +129,13 @@ pub fn create(
         }
     }
 
+    c.PyObject_GC_Track(obj);
     return obj;
 }
 
 /// Runs the callback unless a cancellation already won the state word, then
 /// releases any thread blocked in `cancel` or `cancelled`.
 pub fn run(obj: *py.Object) void {
-    trackIfRetained(obj);
-    defer trackIfRetained(obj);
     const self = payload(obj);
     if (@cmpxchgStrong(u32, &self.run_state, PENDING, RUNNING, .acq_rel, .acquire) != null) return;
     const previous_running = running_payload;
@@ -210,7 +210,6 @@ fn clearArgs(self: *Payload) void {
 }
 
 fn cancel(self_obj: *py.Object) py.Error!*py.Object {
-    trackIfRetained(self_obj);
     const self = payload(self_obj);
     while (true) {
         const s = @atomicLoad(u32, &self.run_state, .acquire);
@@ -230,7 +229,6 @@ fn cancel(self_obj: *py.Object) py.Error!*py.Object {
 }
 
 fn cancelled(self_obj: *py.Object) py.Error!*py.Object {
-    trackIfRetained(self_obj);
     const self = payload(self_obj);
     if (mustWait(self)) awaitCompletion(self);
     return py.boolRef(self.flags & cancelled_flag != 0);
@@ -242,7 +240,6 @@ fn runMethod(self_obj: *py.Object) py.Error!*py.Object {
 }
 
 fn repr(obj: ?*py.Object) callconv(.c) ?*py.Object {
-    trackIfRetained(obj.?);
     const self = payload(obj.?);
     const name = py.typeOf(obj.?).tp_name;
     if (self.flags & cancelled_flag != 0) return c.PyUnicode_FromFormat("<%s cancelled>", name);
@@ -297,9 +294,9 @@ fn visitReferences(obj: *py.Object, visitproc: c.visitproc, arg: ?*anyopaque) c_
     return py.visit(@ptrCast(py.typeOf(obj)), visitproc, arg);
 }
 
+/// Visits queued references transparently when the handle is untracked.
 pub fn traverseQueued(obj: *py.Object, visitproc: c.visitproc, arg: ?*anyopaque) c_int {
     if (c.PyObject_GC_IsTracked(obj) != 0) return py.visit(obj, visitproc, arg);
-    if (c.Py_REFCNT(obj) != 1) return 0;
     return visitReferences(obj, visitproc, arg);
 }
 
@@ -341,7 +338,6 @@ fn getLoop(self_obj: ?*py.Object, _: ?*anyopaque) callconv(.c) ?*py.Object {
 }
 
 fn getContext(self_obj: ?*py.Object, _: ?*anyopaque) callconv(.c) ?*py.Object {
-    trackIfRetained(self_obj.?);
     const context = materializeContext(payload(self_obj.?)) catch return null;
     return py.newref(context);
 }

--- a/zig/tshandle.zig
+++ b/zig/tshandle.zig
@@ -4,22 +4,24 @@
 //! holds with none of its costs: `isinstance` agrees, and `cancel()` or
 //! `cancelled()` from a foreign thread still blocks while the callback runs,
 //! but through an atomic state machine and a futex instead of a per-handle
-//! `threading.RLock`. The base class's slots are never written; every one is
-//! shadowed by a read-only descriptor over the native payload appended after
-//! the base layout.
+//! `threading.RLock`. The base class's slots hold the native payload and are
+//! shadowed by read-only descriptors.
 
 const std = @import("std");
 const py = @import("py.zig");
 const c = py.c;
 const handlemod = @import("handle.zig");
+const loopmod = @import("loop.zig");
 
-const inline_args = 3;
+const inline_args = 1;
 const arg_alloc = std.heap.c_allocator;
 
 const PENDING: u32 = 0;
 const RUNNING: u32 = 1;
 /// Ran, or cancelled before it could run; either way it never will again.
 const DONE: u32 = 2;
+const cancelled_flag: u32 = 1 << 0;
+const captured_context_flag: u32 = 1 << 1;
 
 /// One blocked `cancel` or `cancelled` call, parked on a lock it acquired
 /// twice; the loop thread releases it when the callback finishes. Lives on the
@@ -42,8 +44,7 @@ const Payload = extern struct {
     waiters: ?*Waiter,
     nargs: c.Py_ssize_t,
     run_state: u32,
-    cancelled_flag: u32,
-    runner: c_ulong,
+    flags: u32,
     args: [inline_args]?*py.Object,
 
     pub inline fn argv(self: *Payload) [*]?*py.Object {
@@ -52,7 +53,16 @@ const Payload = extern struct {
 };
 
 pub var ts_type: ?*c.PyTypeObject = null;
-var payload_offset: usize = 0;
+const payload_offset = @sizeOf(c.PyObject);
+threadlocal var running_payload: ?*Payload = null;
+
+const ContextObject = extern struct {
+    ob_base: c.PyObject,
+    previous: ?*ContextObject,
+    variables: ?*py.Object,
+    weakrefs: ?*py.Object,
+    entered: c_int,
+};
 
 inline fn payload(obj: *py.Object) *Payload {
     return @ptrFromInt(@intFromPtr(obj) + payload_offset);
@@ -62,14 +72,19 @@ pub inline fn owns(obj: *py.Object) bool {
     return py.typeOf(obj) == ts_type.?;
 }
 
+pub fn trackIfRetained(obj: *py.Object) void {
+    if (c.Py_REFCNT(obj) > 1 and c.PyObject_GC_IsTracked(obj) == 0) c.PyObject_GC_Track(obj);
+}
+
 pub fn create(
     loop: *py.Object,
     callback: *py.Object,
     args: []const ?*py.Object,
     context: ?*py.Object,
 ) py.Error!*py.Object {
-    const obj = c.PyType_GenericAlloc(ts_type.?, 0) orelse return py.Error.Python;
+    const obj = c._PyObject_GC_New(ts_type.?) orelse return py.Error.Python;
     const self = payload(obj);
+    self.* = std.mem.zeroes(Payload);
 
     if (args.len > inline_args) {
         const buf = arg_alloc.alloc(?*py.Object, args.len) catch {
@@ -94,10 +109,23 @@ pub fn create(
         py.incref(ctx);
         self.context = ctx;
     } else {
-        self.context = c.PyContext_CopyCurrent() orelse {
+        self.flags |= captured_context_flag;
+        const thread_state = c.PyThreadState_Get();
+        const current_slot: *?*py.Object = @ptrFromInt(
+            @intFromPtr(thread_state) + c.ZUVLOOP_PYTHREADSTATE_CONTEXT_OFFSET,
+        );
+        const current = current_slot.*;
+        const context_size = if (current) |current_context| c.PyObject_Size(current_context) else 0;
+        if (context_size < 0) {
             py.decref(obj);
             return py.Error.Python;
-        };
+        }
+        if (context_size != 0) {
+            self.context = c.PyContext_CopyCurrent() orelse {
+                py.decref(obj);
+                return py.Error.Python;
+            };
+        }
     }
 
     return obj;
@@ -106,22 +134,35 @@ pub fn create(
 /// Runs the callback unless a cancellation already won the state word, then
 /// releases any thread blocked in `cancel` or `cancelled`.
 pub fn run(obj: *py.Object) void {
+    trackIfRetained(obj);
+    defer trackIfRetained(obj);
     const self = payload(obj);
     if (@cmpxchgStrong(u32, &self.run_state, PENDING, RUNNING, .acq_rel, .acquire) != null) return;
-    // Only the winner may claim the run: `_run` is a Python method, and a
-    // losing caller writing here would misdirect the waits keyed on it. A
-    // reader that sees RUNNING before this write compares against zero, which
-    // is never a thread id, and waits - the conservative side of the race.
-    self.runner = c.PyThread_get_thread_ident();
-    const callback = self.callback.?;
-    handlemod.invoke(obj, self.loop, callback, self.argv(), self.nargs, self.context.?);
-    @atomicStore(u32, &self.run_state, DONE, .release);
-    var node = self.waiters;
-    self.waiters = null;
-    while (node) |w| {
-        node = w.next;
-        c.PyThread_release_lock(w.lock);
+    const previous_running = running_payload;
+    running_payload = self;
+    defer running_payload = previous_running;
+    defer {
+        @atomicStore(u32, &self.run_state, DONE, .release);
+        var node = self.waiters;
+        self.waiters = null;
+        while (node) |w| {
+            node = w.next;
+            c.PyThread_release_lock(w.lock);
+        }
     }
+    const callback = self.callback.?;
+    const context = materializeContext(self) catch {
+        loopmod.callbackFailed(self.loop, obj);
+        return;
+    };
+    handlemod.invoke(obj, self.loop, callback, self.argv(), self.nargs, context);
+}
+
+fn materializeContext(self: *Payload) py.Error!*py.Object {
+    if (self.context) |context| return context;
+    const context = loopmod.takeEmptyContext(self.loop.?) orelse c.PyContext_New() orelse return py.Error.Python;
+    self.context = context;
+    return context;
 }
 
 /// Parks until the running callback finishes. The GIL is released for the
@@ -153,7 +194,7 @@ fn awaitCompletion(self: *Payload) void {
 /// reentrant `cancel` a callback may issue on its own handle.
 fn mustWait(self: *Payload) bool {
     if (@atomicLoad(u32, &self.run_state, .acquire) != RUNNING) return false;
-    return self.runner != c.PyThread_get_thread_ident();
+    return running_payload != self;
 }
 
 fn clearArgs(self: *Payload) void {
@@ -169,6 +210,7 @@ fn clearArgs(self: *Payload) void {
 }
 
 fn cancel(self_obj: *py.Object) py.Error!*py.Object {
+    trackIfRetained(self_obj);
     const self = payload(self_obj);
     while (true) {
         const s = @atomicLoad(u32, &self.run_state, .acquire);
@@ -176,11 +218,11 @@ fn cancel(self_obj: *py.Object) py.Error!*py.Object {
             if (@cmpxchgStrong(u32, &self.run_state, PENDING, DONE, .acq_rel, .acquire) == null) break;
             continue;
         }
-        if (s != DONE and self.runner != c.PyThread_get_thread_ident()) awaitCompletion(self);
+        if (s != DONE and running_payload != self) awaitCompletion(self);
         break;
     }
-    if (self.cancelled_flag == 0) {
-        self.cancelled_flag = 1;
+    if (self.flags & cancelled_flag == 0) {
+        self.flags |= cancelled_flag;
         py.clear(&self.callback);
         clearArgs(self);
     }
@@ -188,9 +230,10 @@ fn cancel(self_obj: *py.Object) py.Error!*py.Object {
 }
 
 fn cancelled(self_obj: *py.Object) py.Error!*py.Object {
+    trackIfRetained(self_obj);
     const self = payload(self_obj);
     if (mustWait(self)) awaitCompletion(self);
-    return py.boolRef(self.cancelled_flag != 0);
+    return py.boolRef(self.flags & cancelled_flag != 0);
 }
 
 fn runMethod(self_obj: *py.Object) py.Error!*py.Object {
@@ -199,9 +242,10 @@ fn runMethod(self_obj: *py.Object) py.Error!*py.Object {
 }
 
 fn repr(obj: ?*py.Object) callconv(.c) ?*py.Object {
+    trackIfRetained(obj.?);
     const self = payload(obj.?);
     const name = py.typeOf(obj.?).tp_name;
-    if (self.cancelled_flag != 0) return c.PyUnicode_FromFormat("<%s cancelled>", name);
+    if (self.flags & cancelled_flag != 0) return c.PyUnicode_FromFormat("<%s cancelled>", name);
     return c.PyUnicode_FromFormat("<%s %R>", name, self.callback orelse py.none());
 }
 
@@ -211,15 +255,32 @@ fn dealloc(obj: ?*py.Object) callconv(.c) void {
     c.PyObject_GC_UnTrack(obj);
     c.PyObject_ClearWeakRefs(obj);
     clearArgs(self);
-    py.clear(&self.loop);
     py.clear(&self.callback);
-    py.clear(&self.context);
+    releaseContext(self);
+    py.clear(&self.loop);
     tp.tp_free.?(obj);
     py.decref(tp);
 }
 
-fn traverse(obj: ?*py.Object, visitproc: c.visitproc, arg: ?*anyopaque) callconv(.c) c_int {
-    const self = payload(obj.?);
+fn releaseContext(self: *Payload) void {
+    const context = self.context orelse return;
+    self.context = null;
+    if (self.flags & captured_context_flag != 0 and c.Py_REFCNT(context) == 1) {
+        const context_obj: *ContextObject = @ptrCast(@alignCast(context));
+        const size = c.PyObject_Size(context);
+        if (size == 0 and context_obj.weakrefs == null and context_obj.entered == 0) {
+            if (self.loop) |loop| {
+                if (loopmod.recycleEmptyContext(loop, context)) return;
+            }
+        } else if (size < 0) {
+            c.PyErr_Clear();
+        }
+    }
+    py.decref(context);
+}
+
+fn visitReferences(obj: *py.Object, visitproc: c.visitproc, arg: ?*anyopaque) c_int {
+    const self = payload(obj);
     var r = py.visit(self.loop, visitproc, arg);
     if (r != 0) return r;
     r = py.visit(self.callback, visitproc, arg);
@@ -233,7 +294,17 @@ fn traverse(obj: ?*py.Object, visitproc: c.visitproc, arg: ?*anyopaque) callconv
         r = py.visit(items[i], visitproc, arg);
         if (r != 0) return r;
     }
-    return py.visit(@ptrCast(py.typeOf(obj.?)), visitproc, arg);
+    return py.visit(@ptrCast(py.typeOf(obj)), visitproc, arg);
+}
+
+pub fn traverseQueued(obj: *py.Object, visitproc: c.visitproc, arg: ?*anyopaque) c_int {
+    if (c.PyObject_GC_IsTracked(obj) != 0) return py.visit(obj, visitproc, arg);
+    if (c.Py_REFCNT(obj) != 1) return 0;
+    return visitReferences(obj, visitproc, arg);
+}
+
+fn traverse(obj: ?*py.Object, visitproc: c.visitproc, arg: ?*anyopaque) callconv(.c) c_int {
+    return visitReferences(obj.?, visitproc, arg);
 }
 
 fn clear_(obj: ?*py.Object) callconv(.c) c_int {
@@ -262,7 +333,7 @@ fn getArgs(self_obj: ?*py.Object, _: ?*anyopaque) callconv(.c) ?*py.Object {
 }
 
 fn getCancelledSlot(self_obj: ?*py.Object, _: ?*anyopaque) callconv(.c) ?*py.Object {
-    return py.boolRef(payload(self_obj.?).cancelled_flag != 0);
+    return py.boolRef(payload(self_obj.?).flags & cancelled_flag != 0);
 }
 
 fn getLoop(self_obj: ?*py.Object, _: ?*anyopaque) callconv(.c) ?*py.Object {
@@ -270,15 +341,17 @@ fn getLoop(self_obj: ?*py.Object, _: ?*anyopaque) callconv(.c) ?*py.Object {
 }
 
 fn getContext(self_obj: ?*py.Object, _: ?*anyopaque) callconv(.c) ?*py.Object {
-    return py.newref(payload(self_obj.?).context orelse py.none());
+    trackIfRetained(self_obj.?);
+    const context = materializeContext(payload(self_obj.?)) catch return null;
+    return py.newref(context);
 }
 
 fn getNone(_: ?*py.Object, _: ?*anyopaque) callconv(.c) ?*py.Object {
     return py.newref(py.none());
 }
 
-// Every base slot is shadowed read-only, so their storage stays empty and the
-// payload is the single source of truth for traverse, clear and dealloc.
+// Every base slot is shadowed read-only, so the payload is the single source of
+// truth for traverse, clear and dealloc.
 var getsets = [_]c.PyGetSetDef{
     .{ .name = "_callback", .get = getCallback, .set = null, .doc = "The scheduled callable.", .closure = null },
     .{ .name = "_args", .get = getArgs, .set = null, .doc = "Arguments the callable receives.", .closure = null },
@@ -326,8 +399,9 @@ pub fn register(module: *py.Object) py.Error!void {
     const base = py.importFrom("asyncio.events", "_ThreadSafeHandle") orelse return py.Error.Python;
     defer py.decref(base);
     const base_tp: *c.PyTypeObject = @ptrCast(base);
-    payload_offset = std.mem.alignForward(usize, @intCast(base_tp.tp_basicsize), @alignOf(Payload));
-    spec.basicsize = @intCast(payload_offset + @sizeOf(Payload));
+    if (base_tp.tp_basicsize < payload_offset + @sizeOf(Payload)) {
+        return py.errRuntime("asyncio.events._ThreadSafeHandle has an incompatible layout");
+    }
     ts_type = @ptrCast(c.PyType_FromModuleAndSpec(module, &spec, base) orelse return py.Error.Python);
     if (c.PyModule_AddObjectRef(module, "ThreadSafeHandle", @ptrCast(ts_type)) < 0) return py.Error.Python;
 }


### PR DESCRIPTION
## Summary

- Coalesce cross-thread wakeups while the ready queue is active.
- Compact thread-safe handles and lazily materialize reusable empty contexts.
- Preserve ContextVar capture, cancellation, retained-handle, and GC behavior.

## Benchmark

The existing `call_soon_threadsafe` benchmark improves from approximately 5.85 million to 12.29 million callbacks per second on macOS ARM64, a 2.1x increase.

## Verification

- 509 tests passed, 2 skipped
- 100% coverage
- Ruff, mypy, stubtest, and Zig formatting passed

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimizes `call_soon_threadsafe` by coalescing cross-thread wakeups, reusing empty contexts, and untracking queue-only handles from GC so a user-retained handle can't keep an abandoned loop alive. Throughput increases about 2.1x on macOS ARM64.

- One `uv_async_send` covers bursts of callbacks: the waker arms only while the idle handle is inactive and no wake is pending.
- Empty contexts are pooled per loop and lazily materialized, skipping `PyContext_CopyCurrent` when no variables are set.
- Reentrant cancellation is detected via a thread-local running payload instead of a thread id.
- Added tests for ContextVar capture, independent empty contexts, context exposure before running, and retained-handle cycles.

<sup>Written for commit 2ade8a9048863b8207d66e6d1f805c9efd925026. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

