### PR TITLE
Support Python 3.15 builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest, windows-11-arm]
         python-version: ["3.14"]
+        include:
+          - os: macos-latest
+            python-version: "3.15"
+          - os: macos-latest
+            python-version: "3.15t"
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -57,9 +57,13 @@ jobs:
           uv run --no-sync python scripts/conformance.py
 
   free-threaded:
-    name: CPython 3.14 free-threaded
+    name: CPython ${{ matrix.python-version }} free-threaded
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.14t", "3.15t"]
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -73,11 +77,13 @@ jobs:
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
-          python-version: 3.14t
+          python-version: ${{ matrix.python-version }}
           version: 0.12.3
 
       - name: Install
-        run: uv sync --locked --python 3.14t --group dev --group bench
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
+        run: uv sync --locked --python "$PYTHON_VERSION" --group dev --group bench
 
       - name: Test with the GIL disabled
         run: |

--- a/README.md
+++ b/README.md
@@ -156,8 +156,8 @@ pinned upstream suites from aiohttp, uvicorn, AnyIO, websockets, aioquic, Tornad
 zuvloop swapped underneath. The third runs the native sanitizer build and a 500-cycle
 resource-ownership soak.
 
-The weekly compatibility run also tests CPython 3.14.0, the newest 3.14 patch and the 3.15
-prerelease, then exercises gRPC AsyncIO, asyncpg, Psycopg and redis-py against real local services.
+The compatibility run also tests CPython 3.14.0, the newest 3.14 patch, and standard and free-threaded
+3.15 builds, then exercises gRPC AsyncIO, asyncpg, Psycopg and redis-py against real local services.
 The immutable commits and exact commands in `.github/workflows/compatibility.yml` are the source
 of truth.
 

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -12,9 +12,10 @@ Compatibility is checked at four levels:
   inspect CPython's private server attributes.
 - Every pull request builds with native safety checks and the C sanitizer, then
   repeats the loop lifecycle and resource-ownership scenario 500 times.
-- A weekly job builds and tests the declared floor (CPython 3.14.0), the newest
-  CPython 3.14 patch and CPython 3.15 prereleases, and adds service-backed smoke
-  tests for gRPC AsyncIO, asyncpg, Psycopg and redis-py.
+- The compatibility job builds and tests the declared floor (CPython 3.14.0),
+  the newest CPython 3.14 patch, and standard and free-threaded CPython 3.15.
+  It also adds service-backed smoke tests for gRPC AsyncIO, asyncpg, Psycopg
+  and redis-py.
 
 The pinned commits and exact commands live in
 `.github/workflows/compatibility.yml`. Pinning makes a new upstream release an
@@ -83,10 +84,9 @@ string as an unspecified host; zuvloop raises `OSError`. This is the whole of it
 
 ## Interpreter and platform policy
 
-Standard and free-threaded CPython 3.14 and later are supported on Linux, macOS
-and Windows. The minimum 3.14.0 release, a free-threaded 3.14 build and the next
-CPython prerelease are continuously exercised rather than inferred from the
-newest local interpreter.
+Standard and free-threaded CPython 3.14 and 3.15 are supported on Linux, macOS
+and Windows. The minimum 3.14.0 release and both variants of 3.15 are
+continuously exercised rather than inferred from the newest local interpreter.
 
 Linux glibc, Linux musl and macOS execute the full in-repository suite. Windows
 builds run the portable suite natively; tests that require

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Zig",
     "Typing :: Typed",
 ]
@@ -102,9 +103,9 @@ xfail_strict = true
 filterwarnings = ["error"]
 
 [tool.cibuildwheel]
-# Build both standard and free-threaded CPython 3.14 wheels. The same suite runs
-# against each interpreter before a wheel is published.
-build = "cp314-* cp314t-*"
+# Build standard and free-threaded CPython 3.14 and 3.15 wheels. The same suite
+# runs against each interpreter before a wheel is published.
+build = "cp314-* cp314t-* cp315-* cp315t-*"
 skip = "*-musllinux_i686"
 # Pass hash and constraint enforcement directly to the project build. Global uv
 # environment variables also affect cibuildwheel's bootstrap and test tools;

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -404,11 +404,12 @@ def test_worker_thread_finalization_restores_signal_state_on_main_thread() -> No
         gc.collect()
 
     try:
-        with pytest.warns(ResourceWarning, match="unclosed event loop"):
+        with pytest.warns(ResourceWarning, match="unclosed event loop") as caught:
             thread = threading.Thread(target=finalize)
             thread.start()
             thread.join()
 
+        caught.clear()
         gc.collect()
         assert loop_ref() is None
         assert signal.set_wakeup_fd(-1) == -1

--- a/zig/module.zig
+++ b/zig/module.zig
@@ -47,5 +47,5 @@ var moddef = c.PyModuleDef{
 };
 
 export fn PyInit__zuvloop() ?*py.Object {
-    return c.PyModuleDef_Init(&moddef);
+    return c.zuvloop_PyModuleDef_Init(&moddef);
 }

--- a/zig/python_shim.c
+++ b/zig/python_shim.c
@@ -21,6 +21,14 @@ void zuvloop_critical_section_end(zuvloop_critical_section *section) {
 #endif
 }
 
+PyObject *zuvloop_PyModuleDef_Init(PyModuleDef *definition) {
+    if (Py_TYPE((PyObject *)&definition->m_base) == NULL) {
+        PyModuleDef_Base initial = PyModuleDef_HEAD_INIT;
+        definition->m_base = initial;
+    }
+    return PyModuleDef_Init(definition);
+}
+
 void zuvloop_Py_INCREF(PyObject *object) {
     Py_INCREF(object);
 }

--- a/zig/python_shim.h
+++ b/zig/python_shim.h
@@ -10,6 +10,11 @@ static inline unsigned long long zuvloop_read_x18(void) {
 }
 #define __getReg(reg) zuvloop_read_x18()
 #endif
+
+#if defined(__GNUC__) || defined(__clang__)
+// Zig rejects C11 alignments below the type's natural alignment; this equivalent form never reduces it.
+#define _Py_ALIGNED_DEF(N, T) __attribute__((aligned(N))) T
+#endif
 #include <Python.h>
 
 typedef struct {
@@ -18,6 +23,7 @@ typedef struct {
 
 void zuvloop_critical_section_begin(zuvloop_critical_section *section);
 void zuvloop_critical_section_end(zuvloop_critical_section *section);
+PyObject *zuvloop_PyModuleDef_Init(PyModuleDef *definition);
 void zuvloop_Py_INCREF(PyObject *object);
 void zuvloop_Py_DECREF(PyObject *object);
 int zuvloop_PyBytes_Check(PyObject *object);


### PR DESCRIPTION
## Summary

- Publish standard and free-threaded CPython 3.15 wheels.
- Handle CPython 3.15 object alignment and static module initialization in the native shim.
- Exercise 3.15 and 3.15t across compatibility and platform CI.

## Testing

- 514 tests passed on CPython 3.14, 3.14t, 3.15rc1, and 3.15rc1t.
- CPython conformance passed on all four interpreters.
- Coverage remains at 100%.
- Clean `cp315` and `cp315t` wheel smoke tests passed.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds standard and free-threaded CPython 3.15 wheel builds, extending CI compatibility runs and updating the native shim for 3.15's module initialization and alignment requirements.

**Compatibility updates**
- CI now builds and tests `3.15` and `3.15t` on macOS in addition to the existing 3.14 matrix.
- The free-threaded compatibility job now runs both `3.14t` and `3.15t`.
- `pyproject.toml` adds `cp315-*` and `cp315t-*` to the wheel build targets and declares the 3.15 classifier.
- README and compatibility docs now list 3.15 support.
- The Zig shim defines a `zuvloop_PyModuleDef_Init` wrapper to handle uninitialized module definitions, and redefines `_Py_ALIGNED_DEF` with a GCC/clang form that never reduce alignment.
- `tests/test_signals.py` clears captured warnings before re-collecting to avoid a spurious ResourceWarning on 3.15.

<sup>Written for commit 245d90d3ca5a1df5d5c515b7fc7836e6ebaefa41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

