### PR TITLE
Benchmark task and ready queue throughput

### DIFF
--- a/benchmarks/compare.py
+++ b/benchmarks/compare.py
@@ -219,6 +219,28 @@ def timers(loop: asyncio.AbstractEventLoop) -> Callable[[], None]:
     return _driver(loop, once)
 
 
+def loop_iterations(loop: asyncio.AbstractEventLoop) -> Callable[[], None]:
+    """One callback per turn, so the poll is included in every iteration."""
+
+    async def once() -> None:
+        for _ in range(1_000):
+            await asyncio.sleep(0)
+
+    return _driver(loop, once)
+
+
+def tasks(loop: asyncio.AbstractEventLoop) -> Callable[[], None]:
+    """Five thousand tasks that each suspend once before completing."""
+
+    async def tiny_task() -> None:
+        await asyncio.sleep(0)
+
+    async def once() -> None:
+        await asyncio.gather(*(tiny_task() for _ in range(5_000)))
+
+    return _driver(loop, once)
+
+
 def getaddrinfo(loop: asyncio.AbstractEventLoop) -> Callable[[], None]:
     """An address literal, which is what create_connection is handed most often."""
 
@@ -252,6 +274,8 @@ WORKLOADS: dict[str, Workload] = {
     "call_soon": call_soon,
     "call_soon_threadsafe": call_soon_threadsafe,
     "timers": timers,
+    "loop_iterations": loop_iterations,
+    "tasks": tasks,
     "getaddrinfo": getaddrinfo,
     "spawn": spawn,
 }

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -127,6 +127,18 @@ async def bench_sleep_zero(iterations: int = 30_000) -> float:
     return iterations / (time.perf_counter() - started)
 
 
+async def bench_tasks(total: int = 50_000, batch_size: int = 5_000) -> float:
+    """Task throughput in bounded batches, with one suspension per task."""
+
+    async def tiny_task() -> None:
+        await asyncio.sleep(0)
+
+    started = time.perf_counter()
+    for _ in range(total // batch_size):
+        await asyncio.gather(*(tiny_task() for _ in range(batch_size)))
+    return total / (time.perf_counter() - started)
+
+
 async def bench_echo(payload_size: int = 1024, roundtrips: int = 50_000) -> float:
     """Protocol round trips over a loopback TCP connection."""
     loop = asyncio.get_running_loop()
@@ -255,6 +267,7 @@ BENCHMARKS: dict[str, tuple[Benchmark, str]] = {
     "call_soon_threadsafe": (bench_call_soon_threadsafe, "callbacks/s"),
     "timers": (bench_timers, "timers/s"),
     "sleep_zero": (bench_sleep_zero, "iterations/s"),
+    "tasks": (bench_tasks, "tasks/s"),
     "echo_1kb": (bench_echo, "roundtrips/s"),
     "stream": (bench_stream, "bytes/s"),
     "getaddrinfo": (bench_getaddrinfo, "lookups/s"),

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -133,10 +133,16 @@ async def bench_tasks(total: int = 50_000, batch_size: int = 5_000) -> float:
     async def tiny_task() -> None:
         await asyncio.sleep(0)
 
+    if total < 0 or batch_size <= 0:
+        raise ValueError("total must be non-negative and batch_size must be positive")
+
     started = time.perf_counter()
-    for _ in range(total // batch_size):
-        await asyncio.gather(*(tiny_task() for _ in range(batch_size)))
-    return total / (time.perf_counter() - started)
+    completed = 0
+    while completed < total:
+        current_batch = min(batch_size, total - completed)
+        await asyncio.gather(*(tiny_task() for _ in range(current_batch)))
+        completed += current_batch
+    return completed / (time.perf_counter() - started)
 
 
 async def bench_echo(payload_size: int = 1024, roundtrips: int = 50_000) -> float:

--- a/benchmarks/test_benchmarks.py
+++ b/benchmarks/test_benchmarks.py
@@ -210,6 +210,19 @@ def test_loop_iterations(benchmark: BenchmarkFixture, loop: asyncio.AbstractEven
     benchmark(drive(loop, work))
 
 
+@pytest.mark.benchmark
+def test_tasks(benchmark: BenchmarkFixture, loop: asyncio.AbstractEventLoop) -> None:
+    """Create, schedule and finish a batch of tasks that each yield once."""
+
+    async def tiny_task() -> None:
+        await asyncio.sleep(0)
+
+    async def work() -> None:
+        await asyncio.gather(*(tiny_task() for _ in range(5_000)))
+
+    benchmark(drive(loop, work))
+
+
 # ---------------------------------------------------------------------------
 # networking
 


### PR DESCRIPTION
## Summary

- Add a batched task benchmark matching rsloop's workload.
- Expose task and ready-queue workloads in the comparison and throughput harnesses.

## Verification

- `ruff check benchmarks`
- `mypy benchmarks`
- Targeted CodSpeed benchmark run

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds batched task benchmarks to the comparison and throughput harnesses so task and ready-queue performance is measured alongside existing workloads, matching the workload in `rsloop`; batches now run to completion when the total isn't a multiple of the batch size.

<sup>Written for commit 4e40ede4f725fcbf82098c1fb357c1321bcf744a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

