### PR TITLE
Benchmark ready chains with idle connections

### DIFF
--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -145,6 +145,38 @@ async def bench_tasks(total: int = 50_000, batch_size: int = 5_000) -> float:
     return completed / (time.perf_counter() - started)
 
 
+async def bench_ready_with_io(connection_count: int = 250, iterations: int = 20_000) -> float:
+    """Ready-chain throughput while idle stream handles keep I/O active."""
+    loop = asyncio.get_running_loop()
+    accepted: list[asyncio.BaseTransport] = []
+
+    class Hold(asyncio.Protocol):
+        def connection_made(self, transport: asyncio.BaseTransport) -> None:
+            accepted.append(transport)
+
+    server = await loop.create_server(Hold, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    pairs = await asyncio.gather(
+        *(loop.create_connection(asyncio.Protocol, "127.0.0.1", port) for _ in range(connection_count))
+    )
+    clients = [transport for transport, _protocol in pairs]
+    while len(accepted) < connection_count:
+        await asyncio.sleep(0)
+
+    started = time.perf_counter()
+    for _ in range(iterations):
+        await asyncio.sleep(0)
+    elapsed = time.perf_counter() - started
+
+    for transport in clients + accepted:
+        transport.close()
+    server.close()
+    await server.wait_closed()
+    for _ in range(3):
+        await asyncio.sleep(0)
+    return iterations / elapsed
+
+
 async def bench_echo(payload_size: int = 1024, roundtrips: int = 50_000) -> float:
     """Protocol round trips over a loopback TCP connection."""
     loop = asyncio.get_running_loop()
@@ -274,6 +306,7 @@ BENCHMARKS: dict[str, tuple[Benchmark, str]] = {
     "timers": (bench_timers, "timers/s"),
     "sleep_zero": (bench_sleep_zero, "iterations/s"),
     "tasks": (bench_tasks, "tasks/s"),
+    "ready_with_io": (bench_ready_with_io, "iterations/s"),
     "echo_1kb": (bench_echo, "roundtrips/s"),
     "stream": (bench_stream, "bytes/s"),
     "getaddrinfo": (bench_getaddrinfo, "lookups/s"),

--- a/benchmarks/test_benchmarks.py
+++ b/benchmarks/test_benchmarks.py
@@ -223,6 +223,41 @@ def test_tasks(benchmark: BenchmarkFixture, loop: asyncio.AbstractEventLoop) -> 
     benchmark(drive(loop, work))
 
 
+@pytest.mark.benchmark
+def test_ready_chain_with_idle_connections(benchmark: BenchmarkFixture, loop: asyncio.AbstractEventLoop) -> None:
+    """One ready callback per turn while idle stream handles remain active."""
+    connection_count = 250
+    accepted: list[asyncio.BaseTransport] = []
+
+    class Hold(asyncio.Protocol):
+        def connection_made(self, transport: asyncio.BaseTransport) -> None:
+            accepted.append(transport)
+
+    async def setup() -> tuple[asyncio.AbstractServer, list[asyncio.BaseTransport]]:
+        server = await loop.create_server(Hold, "127.0.0.1", 0)
+        port = server.sockets[0].getsockname()[1]
+        pairs = await asyncio.gather(
+            *(loop.create_connection(asyncio.Protocol, "127.0.0.1", port) for _ in range(connection_count))
+        )
+        while len(accepted) < connection_count:
+            await asyncio.sleep(0)
+        return server, [transport for transport, _protocol in pairs]
+
+    async def work() -> None:
+        for _ in range(1_000):
+            await asyncio.sleep(0)
+
+    server, clients = loop.run_until_complete(setup())
+    try:
+        benchmark(drive(loop, work))
+    finally:
+        for transport in clients + accepted:
+            transport.close()
+        server.close()
+        loop.run_until_complete(server.wait_closed())
+        loop.run_until_complete(asyncio.sleep(0))
+
+
 # ---------------------------------------------------------------------------
 # networking
 


### PR DESCRIPTION
## Summary

Add CodSpeed and standalone benchmarks for ready-chain throughput while 250 idle TCP connections remain active.

The baseline measures zuvloop at 0.71x uvloop on this workload.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `ready_with_io` benchmark that measures ready-chain throughput while 250 idle TCP connections keep I/O active. The baseline exposes a regression: zuvloop runs at 0.71x uvloop on this workload.

<sup>Written for commit 63e63feafdc5e774dc2625abaf9e4c2ac0c3ddf0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

