### PR TITLE
Benchmark parallel event loop scaling

### DIFF
--- a/benchmarks/test_benchmarks.py
+++ b/benchmarks/test_benchmarks.py
@@ -20,6 +20,7 @@ see `uvicorn_bench.py`, `aiohttp_bench.py` and `write_batching.py`.
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import os
 import socket
 import threading
@@ -221,6 +222,57 @@ def test_tasks(benchmark: BenchmarkFixture, loop: asyncio.AbstractEventLoop) -> 
         await asyncio.gather(*(tiny_task() for _ in range(5_000)))
 
     benchmark(drive(loop, work))
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("factory", LOOPS.values(), ids=LOOPS)
+def test_parallel_event_loops(
+    benchmark: BenchmarkFixture,
+    factory: Factory | None,
+) -> None:
+    """Four independent loops run CPU-bound callbacks in parallel."""
+    workers = 4
+    iterations = 1_000_000
+
+    def setup() -> tuple[tuple[list[asyncio.AbstractEventLoop], threading.Barrier, list[int]], dict[str, int]]:
+        loops = [(factory or asyncio.new_event_loop)() for _ in range(workers)]
+        barrier = threading.Barrier(workers)
+        results: list[int] = []
+        for loop in loops:
+
+            def compute(loop: asyncio.AbstractEventLoop = loop) -> None:
+                result = 0
+                for value in range(iterations):
+                    result = (result + value) & 0xFFFFFFFF
+                results.append(result)
+                loop.stop()
+
+            loop.call_soon(compute)
+        return (loops, barrier, results), {}
+
+    def measure(
+        loops: list[asyncio.AbstractEventLoop],
+        barrier: threading.Barrier,
+        results: list[int],
+    ) -> None:
+        def run(loop: asyncio.AbstractEventLoop) -> None:
+            barrier.wait()
+            loop.run_forever()
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+            list(executor.map(run, loops))
+        assert len(set(results)) == 1
+
+    def teardown(
+        loops: list[asyncio.AbstractEventLoop],
+        barrier: threading.Barrier,
+        results: list[int],
+    ) -> None:
+        del barrier, results
+        for loop in loops:
+            loop.close()
+
+    benchmark.pedantic(measure, setup=setup, teardown=teardown, rounds=5)
 
 
 @pytest.mark.benchmark


### PR DESCRIPTION
## Summary

Add a benchmark that runs CPU-bound callbacks across four independent event loops.

## Baseline

Lower is better. Results use CPython 3.14.3 on an M3 Max.

| Runtime | `asyncio` | `uvloop` | `zuvloop` |
| --- | ---: | ---: | ---: |
| Standard | 239.3 ms | 155.8 ms | 140.2 ms |
| Free-threaded | 39.8 ms | 47.4 ms | 47.2 ms |

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a benchmark that runs CPU-bound callbacks across four independent event loops to measure scaling under free-threaded CPython. Baseline results on CPython 3.14.3 (M3 Max) show standard runtimes of 140–239 ms versus 40–47 ms for free-threaded across `asyncio`, `uvloop`, and `zuvloop`.

<sup>Written for commit 6525dcd80164a2ea90e52523e5ee8d5517a7c101. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

