### PR TITLE
Allow free-threaded event loops to scale independently

### DIFF
--- a/benchmarks/test_benchmarks.py
+++ b/benchmarks/test_benchmarks.py
@@ -20,6 +20,7 @@ see `uvicorn_bench.py`, `aiohttp_bench.py` and `write_batching.py`.
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import os
 import socket
 import threading
@@ -221,6 +222,57 @@ def test_tasks(benchmark: BenchmarkFixture, loop: asyncio.AbstractEventLoop) -> 
         await asyncio.gather(*(tiny_task() for _ in range(5_000)))
 
     benchmark(drive(loop, work))
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("factory", LOOPS.values(), ids=LOOPS)
+def test_parallel_event_loops(
+    benchmark: BenchmarkFixture,
+    factory: Factory | None,
+) -> None:
+    """Four independent loops run CPU-bound callbacks in parallel."""
+    workers = 4
+    iterations = 1_000_000
+
+    def setup() -> tuple[tuple[list[asyncio.AbstractEventLoop], threading.Barrier, list[int]], dict[str, int]]:
+        loops = [(factory or asyncio.new_event_loop)() for _ in range(workers)]
+        barrier = threading.Barrier(workers)
+        results: list[int] = []
+        for loop in loops:
+
+            def compute(loop: asyncio.AbstractEventLoop = loop) -> None:
+                result = 0
+                for value in range(iterations):
+                    result = (result + value) & 0xFFFFFFFF
+                results.append(result)
+                loop.stop()
+
+            loop.call_soon(compute)
+        return (loops, barrier, results), {}
+
+    def measure(
+        loops: list[asyncio.AbstractEventLoop],
+        barrier: threading.Barrier,
+        results: list[int],
+    ) -> None:
+        def run(loop: asyncio.AbstractEventLoop) -> None:
+            barrier.wait()
+            loop.run_forever()
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+            list(executor.map(run, loops))
+        assert len(set(results)) == 1
+
+    def teardown(
+        loops: list[asyncio.AbstractEventLoop],
+        barrier: threading.Barrier,
+        results: list[int],
+    ) -> None:
+        del barrier, results
+        for loop in loops:
+            loop.close()
+
+    benchmark.pedantic(measure, setup=setup, teardown=teardown, rounds=5)
 
 
 @pytest.mark.benchmark

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,9 +21,11 @@ packet, Python if it runs per connection or per loop.**
 
 The interpreter thread state is detached for the whole `uv_run` call and
 reattached for each libuv callback. On a standard build, this releases and
-reacquires the GIL. On a free-threaded build, an extension-wide critical section
-protects the native object graph and the ready queue from concurrent producers.
-Blocking Python calls suspend the critical section, as CPython requires.
+reacquires the GIL. On a free-threaded build, each loop's critical section
+protects its cross-thread inbox while the native object graph stays confined to
+the loop thread. Thread-safe handles use their own critical sections. Independent
+loops can run concurrently. Blocking Python calls suspend a critical section, as
+CPython requires.
 
 ## Scheduling
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -674,7 +674,7 @@ async def test_pause_writing_cannot_overfill_a_reentrant_batch() -> None:
                 self.transport.write(b"r")
 
     async def until_markers_arrive() -> None:
-        while b"rrrr" not in sinks[0].received:
+        while not sinks or b"rrrr" not in sinks[0].received:
             await asyncio.sleep(0.01)
 
     transport, client = await loop.create_connection(RefillsBatch, "127.0.0.1", port)

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -394,6 +394,19 @@ def test_call_soon_threadsafe_accepts_concurrent_producers() -> None:
     assert seen == expected
 
 
+def test_call_soon_preserves_order_after_threadsafe_scheduling() -> None:
+    loop = zuvloop.new_event_loop()
+    seen: list[str] = []
+    loop.call_soon_threadsafe(seen.append, "threadsafe")
+    loop.call_soon(seen.append, "local")
+    loop.call_soon(loop.stop)
+    try:
+        loop.run_forever()
+    finally:
+        loop.close()
+    assert seen == ["threadsafe", "local"]
+
+
 def test_call_soon_threadsafe_captures_the_worker_context() -> None:
     loop = zuvloop.new_event_loop()
     variable: contextvars.ContextVar[str] = contextvars.ContextVar("variable", default="default")

--- a/zig/context.zig
+++ b/zig/context.zig
@@ -39,7 +39,10 @@ pub fn capture(explicit: ?*py.Object, flags: *u32) py.Error!?*py.Object {
 /// Returns the context in `context`, allocating or borrowing an empty one.
 pub fn materialize(loop: ?*py.Object, context: *?*py.Object) py.Error!*py.Object {
     if (context.*) |existing| return existing;
-    const created = if (loop) |loop_obj| loopmod.takeEmptyContext(loop_obj) else null;
+    const created = if (loop) |loop_obj|
+        if (loopmod.isRunningThread(loop_obj)) loopmod.takeEmptyContext(loop_obj) else null
+    else
+        null;
     context.* = created orelse c.PyContext_New() orelse return py.Error.Python;
     return context.*.?;
 }
@@ -53,7 +56,7 @@ pub fn release(loop: ?*py.Object, context: *?*py.Object, flags: u32) void {
         const size = c.PyObject_Size(current);
         if (size == 0 and context_obj.weakrefs == null and context_obj.entered == 0) {
             if (loop) |loop_obj| {
-                if (loopmod.recycleEmptyContext(loop_obj, current)) return;
+                if (loopmod.isRunningThread(loop_obj) and loopmod.recycleEmptyContext(loop_obj, current)) return;
             }
         } else if (size < 0) {
             c.PyErr_Clear();

--- a/zig/loop.zig
+++ b/zig/loop.zig
@@ -1,9 +1,9 @@
 //! The native event loop: scheduling, timers, and the libuv run loop.
 //!
 //! `_run` detaches the thread state for the whole `uv_run` call. Each libuv
-//! callback reattaches it and enters the extension critical section. The depth
-//! starts at 1 because object methods enter with an attached thread state, so
-//! nested runs such as `close` skip the detach/attach pair.
+//! callback reattaches it. The depth starts at 1 because object methods enter
+//! with an attached thread state, so nested runs such as `close` skip the
+//! detach/attach pair.
 
 const std = @import("std");
 const py = @import("py.zig");
@@ -39,6 +39,7 @@ pub const State = struct {
     block: []u8,
 
     ready: collections.Ready = .empty,
+    threadsafe_ready: collections.Ready = .empty,
     timers: collections.Timers = .empty,
     pollers: pollermod.Map = .empty,
     scratch: ?[*]u8 = null,
@@ -51,8 +52,6 @@ pub const State = struct {
 
     tstate: ?*c.PyThreadState = null,
     python_depth: c_int = 1,
-    critical_section: py.CriticalSection,
-    critical_section_active: bool = false,
     fatal: ?*py.Object = null,
     metrics_cb: ?*py.Object = null,
     task_factory: ?*py.Object = null,
@@ -81,8 +80,6 @@ pub const State = struct {
         if (self.python_depth == 0) {
             c.PyEval_RestoreThread(self.tstate);
             self.tstate = null;
-            py.beginCriticalSection(&self.critical_section);
-            self.critical_section_active = true;
         }
         self.python_depth += 1;
     }
@@ -90,16 +87,12 @@ pub const State = struct {
     pub inline fn pythonExit(self: *State) void {
         self.python_depth -= 1;
         if (self.python_depth == 0) {
-            if (self.critical_section_active) {
-                py.endCriticalSection(&self.critical_section);
-                self.critical_section_active = false;
-            }
             self.tstate = c.PyEval_SaveThread();
         }
     }
 
     pub inline fn pythonResume(self: *State) void {
-        std.debug.assert(self.python_depth == 0 and !self.critical_section_active);
+        std.debug.assert(self.python_depth == 0);
         c.PyEval_RestoreThread(self.tstate);
         self.tstate = null;
         self.python_depth = 1;
@@ -140,6 +133,12 @@ pub inline fn asLoop(obj: *py.Object) *LoopObject {
 
 pub inline fn isReaping(st: *State) bool {
     return @atomicLoad(u8, &st.reap_state, .acquire) != 0;
+}
+
+/// True while the current thread owns and runs `loop_obj`.
+pub inline fn isRunningThread(loop_obj: *py.Object) bool {
+    const thread_id = @atomicLoad(c_ulong, &asLoop(loop_obj).state().thread_id, .acquire);
+    return thread_id != 0 and thread_id == c.PyThread_get_thread_ident();
 }
 
 /// Seconds on the clock `time.monotonic()` reads.
@@ -246,7 +245,16 @@ fn onWake(waker: ?*uv.Async) callconv(.c) void {
     const st = self.state();
     st.pythonEnter();
     defer st.pythonExit();
+    // SAFETY: PyCriticalSection_Begin initializes this storage before reading it.
+    var critical_section: py.CriticalSection = undefined;
+    py.beginCriticalSection(&critical_section, @ptrCast(self));
+    defer py.endCriticalSection(&critical_section);
     st.waker_pending = false;
+    drainThreadsafe(st) catch {
+        py.errNoMemory() catch {};
+        captureFatal(self);
+        return;
+    };
     startIdle(st);
 }
 
@@ -376,6 +384,12 @@ fn clearThreadsafeCandidate(st: *State, untrack_queue_only: bool) void {
     py.decref(candidate);
 }
 
+fn drainThreadsafe(st: *State) error{OutOfMemory}!void {
+    try st.ready.ensureUnusedCapacity(st.threadsafe_ready.len);
+    clearThreadsafeCandidate(st, true);
+    while (st.threadsafe_ready.pop()) |handle| st.ready.pushAssumeCapacity(handle);
+}
+
 /// The ready queue holds both handle types; only the type says which protocol
 /// a callback runs under.
 inline fn runOne(obj: *py.Object) void {
@@ -398,7 +412,6 @@ fn runReady(self: *LoopObject) void {
     st.callbacks_run += remaining;
     while (remaining != 0) : (remaining -= 1) {
         const obj = st.ready.pop() orelse break;
-        if (st.threadsafe_candidate == obj) clearThreadsafeCandidate(st, true);
         if ((st.debug or st.slow_callback_monitoring) and st.slow_callback_duration < std.math.inf(f64)) {
             const started = uv.uv_hrtime();
             runOne(obj);
@@ -572,11 +585,16 @@ pub inline fn checkClosed(st: *State) py.Error!void {
 
 fn scheduleSoon(self: *LoopObject, callback: *py.Object, p: Parsed) py.Error!*py.Object {
     const st = self.state();
-    try checkClosed(st);
     const h = try handlemod.create(handlemod.handle_type.?, @ptrCast(self), callback, p.positional, p.context);
+    errdefer py.decref(h);
+    // SAFETY: PyCriticalSection_Begin initializes this storage before reading it.
+    var critical_section: py.CriticalSection = undefined;
+    py.beginCriticalSection(&critical_section, @ptrCast(self));
+    defer py.endCriticalSection(&critical_section);
+    try checkClosed(st);
+    drainThreadsafe(st) catch return py.errNoMemory();
     py.incref(h);
     st.ready.push(@as(*py.Object, @ptrCast(h))) catch {
-        py.decref(h);
         py.decref(h);
         return py.errNoMemory();
     };
@@ -602,10 +620,9 @@ fn callSoonThreadsafe(self_obj: *py.Object, args: []const ?*py.Object, nargs: us
     clearThreadsafeCandidate(st, true);
     const h = try tshandle.create(self_obj, args[0].?, p.positional, p.context);
     py.incref(h);
-    // One FIFO for both schedulers, so a `call_soon` issued after a
-    // `call_soon_threadsafe` still runs after it. Producers and the loop touch
-    // `ready` only inside the extension critical section.
-    st.ready.push(h) catch {
+    // A loop-thread `call_soon` drains this inbox before appending its own
+    // handle, so both schedulers preserve registration order.
+    st.threadsafe_ready.push(h) catch {
         py.decref(h);
         py.decref(h);
         return py.errNoMemory();
@@ -615,7 +632,7 @@ fn callSoonThreadsafe(self_obj: *py.Object, args: []const ?*py.Object, nargs: us
     st.threadsafe_candidate = h;
     // libuv clears its pending bit before `onWake` enters Python. Keep one at
     // this layer so a producer cannot issue another kernel wake in that window.
-    if (!st.idle_active and !st.waker_pending) {
+    if (!st.waker_pending) {
         st.waker_pending = true;
         _ = uv.uv_async_send(st.waker);
     }
@@ -670,7 +687,7 @@ fn runLoop(self_obj: *py.Object) py.Error!*py.Object {
 
     st.running = true;
     st.stopping = false;
-    st.thread_id = c.PyThread_get_thread_ident();
+    @atomicStore(c_ulong, &st.thread_id, c.PyThread_get_thread_ident(), .release);
     startIdle(st);
     armTimer(self);
 
@@ -680,7 +697,7 @@ fn runLoop(self_obj: *py.Object) py.Error!*py.Object {
 
     st.running = false;
     st.stopping = false;
-    st.thread_id = 0;
+    @atomicStore(c_ulong, &st.thread_id, 0, .release);
     // A write from the callback that stopped the loop has had no iteration left
     // to flush it. Draining after clearing `running` sends anything those
     // callbacks write in turn.
@@ -832,7 +849,7 @@ fn buildMetrics(st: *State) ?*py.Object {
         "callbacks_run",
         st.callbacks_run,
         "ready",
-        @as(c.Py_ssize_t, @intCast(st.ready.len)),
+        @as(c.Py_ssize_t, @intCast(st.ready.len + st.threadsafe_ready.len)),
         "timers",
         @as(c.Py_ssize_t, @intCast(st.timers.len)),
         "watchers",
@@ -907,6 +924,7 @@ fn closeLoop(self_obj: *py.Object) py.Error!*py.Object {
 
     clearThreadsafeCandidate(st, false);
     st.ready.deinit();
+    st.threadsafe_ready.deinit();
     st.timers.deinit();
     clearEmptyContexts(st);
     dropFlushList(st);
@@ -1076,8 +1094,6 @@ fn newLoop(tp: ?*c.PyTypeObject, _: ?*py.Object, _: ?*py.Object) callconv(.c) ?*
         .waker = @ptrCast(block.ptr + loop_size + idle_size + 2 * timer_size),
         .flusher = @ptrCast(block.ptr + loop_size + idle_size + 2 * timer_size + async_size),
         .block = block,
-        // SAFETY: PyCriticalSection_BeginMutex initializes this storage before reading it.
-        .critical_section = undefined,
     };
 
     if (uv.uv_loop_init(st.uvloop) < 0) {
@@ -1121,6 +1137,7 @@ fn dealloc(obj: ?*py.Object) callconv(.c) void {
         if (needs_close) {
             clearThreadsafeCandidate(st, false);
             st.ready.deinit();
+            st.threadsafe_ready.deinit();
             st.timers.deinit();
             clearEmptyContexts(st);
         }
@@ -1163,6 +1180,14 @@ fn traverse(obj: ?*py.Object, visitproc: c.visitproc, arg: ?*anyopaque) callconv
             if (r != 0) return r;
         }
         i = 0;
+        while (i < st.threadsafe_ready.len) : (i += 1) {
+            const handle = st.threadsafe_ready.items[
+                (st.threadsafe_ready.head + i) & (st.threadsafe_ready.items.len - 1)
+            ].?;
+            r = tshandle.traverseQueued(handle, visitproc, arg);
+            if (r != 0) return r;
+        }
+        i = 0;
         while (i < st.timers.len) : (i += 1) {
             r = py.visit(st.timers.items[i].handle, visitproc, arg);
             if (r != 0) return r;
@@ -1195,6 +1220,7 @@ fn clear_(obj: ?*py.Object) callconv(.c) c_int {
     const self = asLoop(obj.?);
     if (self.st) |st| {
         st.ready.deinit();
+        st.threadsafe_ready.deinit();
         st.timers.deinit();
         py.clear(&st.fatal);
         py.clear(&st.metrics_cb);
@@ -1204,18 +1230,18 @@ fn clear_(obj: ?*py.Object) callconv(.c) c_int {
 }
 
 var methods = [_]c.PyMethodDef{
-    py.methodKw("call_soon", callSoon, "Schedule a callback for the next iteration."),
+    py.methodKwUnlocked("call_soon", callSoon, "Schedule a callback for the next iteration."),
     py.methodKw("call_soon_threadsafe", callSoonThreadsafe, "Schedule a callback from another thread."),
     py.methodKw("call_later", callLater, "Schedule a callback after a delay in seconds."),
     py.methodKw("call_at", callAt, "Schedule a callback at an absolute loop time."),
     py.methodNoArgs("time", time, "Return the loop's monotonic clock, in seconds."),
-    py.methodNoArgs("_run", runLoop, "Run the libuv loop until stopped."),
+    py.methodNoArgsUnlocked("_run", runLoop, "Run the libuv loop until stopped."),
     py.methodNoArgs("stop", stop, "Stop the loop."),
     py.methodNoArgs("is_running", isRunning, "Return True while the loop is running."),
     py.methodNoArgs("is_closed", isClosed, "Return True once the loop is closed."),
     py.methodNoArgs("get_debug", getDebug, "Return the debug mode flag."),
     py.methodO("set_debug", setDebug, "Set the debug mode flag."),
-    py.methodKw("create_task", createTask, "Schedule a coroutine as a task."),
+    py.methodKwUnlocked("create_task", createTask, "Schedule a coroutine as a task."),
     py.methodO("set_task_factory", setTaskFactory, "Set the task factory."),
     py.methodNoArgs("get_task_factory", getTaskFactory, "Return the task factory."),
     py.methodO("_set_slow_callback_monitoring", setSlowCallbackMonitoring, "Enable slow callback monitoring."),

--- a/zig/py.zig
+++ b/zig/py.zig
@@ -8,8 +8,8 @@ pub const Object = c.PyObject;
 pub const Ref = *Object;
 pub const CriticalSection = c.zuvloop_critical_section;
 
-pub inline fn beginCriticalSection(section: *CriticalSection) void {
-    if (@hasDecl(c, "Py_GIL_DISABLED")) c.zuvloop_critical_section_begin(section);
+pub inline fn beginCriticalSection(section: *CriticalSection, object: *Object) void {
+    if (@hasDecl(c, "Py_GIL_DISABLED")) c.zuvloop_critical_section_begin(section, object);
 }
 
 pub inline fn endCriticalSection(section: *CriticalSection) void {
@@ -258,9 +258,9 @@ pub fn errUvIfNeg(status: c_int) Error!void {
 pub fn wrap(comptime f: anytype) fn (?*Object, [*c]?*Object, c.Py_ssize_t) callconv(.c) ?*Object {
     const Inner = struct {
         fn call(self: ?*Object, args: [*c]?*Object, nargs: c.Py_ssize_t) callconv(.c) ?*Object {
-            // SAFETY: PyCriticalSection_BeginMutex initializes this storage before reading it.
+            // SAFETY: PyCriticalSection_Begin initializes this storage before reading it.
             var critical_section: CriticalSection = undefined;
-            beginCriticalSection(&critical_section);
+            beginCriticalSection(&critical_section, self.?);
             defer endCriticalSection(&critical_section);
             return f(self.?, args[0..@intCast(nargs)]) catch |e| switch (e) {
                 Error.Python => null,
@@ -275,10 +275,24 @@ pub fn wrap(comptime f: anytype) fn (?*Object, [*c]?*Object, c.Py_ssize_t) callc
 pub fn wrapKw(comptime f: anytype) fn (?*Object, [*c]?*Object, c.Py_ssize_t, ?*Object) callconv(.c) ?*Object {
     const Inner = struct {
         fn call(self: ?*Object, args: [*c]?*Object, nargs: c.Py_ssize_t, kwnames: ?*Object) callconv(.c) ?*Object {
-            // SAFETY: PyCriticalSection_BeginMutex initializes this storage before reading it.
+            // SAFETY: PyCriticalSection_Begin initializes this storage before reading it.
             var critical_section: CriticalSection = undefined;
-            beginCriticalSection(&critical_section);
+            beginCriticalSection(&critical_section, self.?);
             defer endCriticalSection(&critical_section);
+            const nkw: usize = if (kwnames) |names| @intCast(c.PyTuple_Size(names)) else 0;
+            const total: usize = @as(usize, @intCast(nargs)) + nkw;
+            return f(self.?, args[0..total], @intCast(nargs), kwnames) catch |e| switch (e) {
+                Error.Python => null,
+            };
+        }
+    };
+    return Inner.call;
+}
+
+/// Wraps a keyword method that does not require wrapper-level synchronization.
+pub fn wrapKwUnlocked(comptime f: anytype) fn (?*Object, [*c]?*Object, c.Py_ssize_t, ?*Object) callconv(.c) ?*Object {
+    const Inner = struct {
+        fn call(self: ?*Object, args: [*c]?*Object, nargs: c.Py_ssize_t, kwnames: ?*Object) callconv(.c) ?*Object {
             const nkw: usize = if (kwnames) |names| @intCast(c.PyTuple_Size(names)) else 0;
             const total: usize = @as(usize, @intCast(nargs)) + nkw;
             return f(self.?, args[0..total], @intCast(nargs), kwnames) catch |e| switch (e) {
@@ -292,10 +306,22 @@ pub fn wrapKw(comptime f: anytype) fn (?*Object, [*c]?*Object, c.Py_ssize_t, ?*O
 pub fn wrapNoArgs(comptime f: anytype) fn (?*Object, ?*Object) callconv(.c) ?*Object {
     const Inner = struct {
         fn call(self: ?*Object, _: ?*Object) callconv(.c) ?*Object {
-            // SAFETY: PyCriticalSection_BeginMutex initializes this storage before reading it.
+            // SAFETY: PyCriticalSection_Begin initializes this storage before reading it.
             var critical_section: CriticalSection = undefined;
-            beginCriticalSection(&critical_section);
+            beginCriticalSection(&critical_section, self.?);
             defer endCriticalSection(&critical_section);
+            return f(self.?) catch |e| switch (e) {
+                Error.Python => null,
+            };
+        }
+    };
+    return Inner.call;
+}
+
+/// Wraps a no-argument method that does not require wrapper-level synchronization.
+pub fn wrapNoArgsUnlocked(comptime f: anytype) fn (?*Object, ?*Object) callconv(.c) ?*Object {
+    const Inner = struct {
+        fn call(self: ?*Object, _: ?*Object) callconv(.c) ?*Object {
             return f(self.?) catch |e| switch (e) {
                 Error.Python => null,
             };
@@ -307,9 +333,9 @@ pub fn wrapNoArgs(comptime f: anytype) fn (?*Object, ?*Object) callconv(.c) ?*Ob
 pub fn wrapO(comptime f: anytype) fn (?*Object, ?*Object) callconv(.c) ?*Object {
     const Inner = struct {
         fn call(self: ?*Object, arg: ?*Object) callconv(.c) ?*Object {
-            // SAFETY: PyCriticalSection_BeginMutex initializes this storage before reading it.
+            // SAFETY: PyCriticalSection_Begin initializes this storage before reading it.
             var critical_section: CriticalSection = undefined;
-            beginCriticalSection(&critical_section);
+            beginCriticalSection(&critical_section, self.?);
             defer endCriticalSection(&critical_section);
             return f(self.?, arg.?) catch |e| switch (e) {
                 Error.Python => null,
@@ -322,9 +348,9 @@ pub fn wrapO(comptime f: anytype) fn (?*Object, ?*Object) callconv(.c) ?*Object 
 pub fn wrapDealloc(comptime f: anytype) fn (?*Object) callconv(.c) void {
     const Inner = struct {
         fn call(self: ?*Object) callconv(.c) void {
-            // SAFETY: PyCriticalSection_BeginMutex initializes this storage before reading it.
+            // SAFETY: PyCriticalSection_Begin initializes this storage before reading it.
             var critical_section: CriticalSection = undefined;
-            beginCriticalSection(&critical_section);
+            beginCriticalSection(&critical_section, self.?);
             defer endCriticalSection(&critical_section);
             f(self);
         }
@@ -335,9 +361,9 @@ pub fn wrapDealloc(comptime f: anytype) fn (?*Object) callconv(.c) void {
 pub fn wrapTraverse(comptime f: anytype) fn (?*Object, c.visitproc, ?*anyopaque) callconv(.c) c_int {
     const Inner = struct {
         fn call(self: ?*Object, visitproc: c.visitproc, arg: ?*anyopaque) callconv(.c) c_int {
-            // SAFETY: PyCriticalSection_BeginMutex initializes this storage before reading it.
+            // SAFETY: PyCriticalSection_Begin initializes this storage before reading it.
             var critical_section: CriticalSection = undefined;
-            beginCriticalSection(&critical_section);
+            beginCriticalSection(&critical_section, self.?);
             defer endCriticalSection(&critical_section);
             return f(self, visitproc, arg);
         }
@@ -348,9 +374,9 @@ pub fn wrapTraverse(comptime f: anytype) fn (?*Object, c.visitproc, ?*anyopaque)
 pub fn wrapClear(comptime f: anytype) fn (?*Object) callconv(.c) c_int {
     const Inner = struct {
         fn call(self: ?*Object) callconv(.c) c_int {
-            // SAFETY: PyCriticalSection_BeginMutex initializes this storage before reading it.
+            // SAFETY: PyCriticalSection_Begin initializes this storage before reading it.
             var critical_section: CriticalSection = undefined;
-            beginCriticalSection(&critical_section);
+            beginCriticalSection(&critical_section, self.?);
             defer endCriticalSection(&critical_section);
             return f(self);
         }
@@ -361,9 +387,9 @@ pub fn wrapClear(comptime f: anytype) fn (?*Object) callconv(.c) c_int {
 pub fn wrapRepr(comptime f: anytype) fn (?*Object) callconv(.c) ?*Object {
     const Inner = struct {
         fn call(self: ?*Object) callconv(.c) ?*Object {
-            // SAFETY: PyCriticalSection_BeginMutex initializes this storage before reading it.
+            // SAFETY: PyCriticalSection_Begin initializes this storage before reading it.
             var critical_section: CriticalSection = undefined;
-            beginCriticalSection(&critical_section);
+            beginCriticalSection(&critical_section, self.?);
             defer endCriticalSection(&critical_section);
             return f(self);
         }
@@ -374,9 +400,9 @@ pub fn wrapRepr(comptime f: anytype) fn (?*Object) callconv(.c) ?*Object {
 pub fn wrapGet(comptime f: anytype) fn (?*Object, ?*anyopaque) callconv(.c) ?*Object {
     const Inner = struct {
         fn call(self: ?*Object, closure: ?*anyopaque) callconv(.c) ?*Object {
-            // SAFETY: PyCriticalSection_BeginMutex initializes this storage before reading it.
+            // SAFETY: PyCriticalSection_Begin initializes this storage before reading it.
             var critical_section: CriticalSection = undefined;
-            beginCriticalSection(&critical_section);
+            beginCriticalSection(&critical_section, self.?);
             defer endCriticalSection(&critical_section);
             return f(self, closure);
         }
@@ -387,9 +413,9 @@ pub fn wrapGet(comptime f: anytype) fn (?*Object, ?*anyopaque) callconv(.c) ?*Ob
 pub fn wrapSet(comptime f: anytype) fn (?*Object, ?*Object, ?*anyopaque) callconv(.c) c_int {
     const Inner = struct {
         fn call(self: ?*Object, value: ?*Object, closure: ?*anyopaque) callconv(.c) c_int {
-            // SAFETY: PyCriticalSection_BeginMutex initializes this storage before reading it.
+            // SAFETY: PyCriticalSection_Begin initializes this storage before reading it.
             var critical_section: CriticalSection = undefined;
-            beginCriticalSection(&critical_section);
+            beginCriticalSection(&critical_section, self.?);
             defer endCriticalSection(&critical_section);
             return f(self, value, closure);
         }
@@ -415,10 +441,34 @@ pub fn methodKw(comptime name: [:0]const u8, comptime f: anytype, comptime doc: 
     };
 }
 
+/// Defines a keyword method that does not require wrapper-level synchronization.
+pub fn methodKwUnlocked(comptime name: [:0]const u8, comptime f: anytype, comptime doc: ?[*:0]const u8) c.PyMethodDef {
+    return .{
+        .ml_name = name.ptr,
+        .ml_meth = @ptrCast(&wrapKwUnlocked(f)),
+        .ml_flags = c.METH_FASTCALL | c.METH_KEYWORDS,
+        .ml_doc = doc,
+    };
+}
+
 pub fn methodNoArgs(comptime name: [:0]const u8, comptime f: anytype, comptime doc: ?[*:0]const u8) c.PyMethodDef {
     return .{
         .ml_name = name.ptr,
         .ml_meth = @ptrCast(&wrapNoArgs(f)),
+        .ml_flags = c.METH_NOARGS,
+        .ml_doc = doc,
+    };
+}
+
+/// Defines a no-argument method that does not require wrapper-level synchronization.
+pub fn methodNoArgsUnlocked(
+    comptime name: [:0]const u8,
+    comptime f: anytype,
+    comptime doc: ?[*:0]const u8,
+) c.PyMethodDef {
+    return .{
+        .ml_name = name.ptr,
+        .ml_meth = @ptrCast(&wrapNoArgsUnlocked(f)),
         .ml_flags = c.METH_NOARGS,
         .ml_doc = doc,
     };

--- a/zig/python_shim.c
+++ b/zig/python_shim.c
@@ -1,15 +1,12 @@
 #include "python_shim.h"
 
-#ifdef Py_GIL_DISABLED
-static PyMutex zuvloop_mutex;
-#endif
-
-void zuvloop_critical_section_begin(zuvloop_critical_section *section) {
+void zuvloop_critical_section_begin(zuvloop_critical_section *section, PyObject *object) {
 #ifdef Py_GIL_DISABLED
     _Static_assert(sizeof(*section) >= sizeof(PyCriticalSection), "critical section storage is too small");
-    PyCriticalSection_BeginMutex((PyCriticalSection *)section, &zuvloop_mutex);
+    PyCriticalSection_Begin((PyCriticalSection *)section, object);
 #else
     (void)section;
+    (void)object;
 #endif
 }
 

--- a/zig/python_shim.h
+++ b/zig/python_shim.h
@@ -21,7 +21,7 @@ typedef struct {
     uintptr_t storage[2];
 } zuvloop_critical_section;
 
-void zuvloop_critical_section_begin(zuvloop_critical_section *section);
+void zuvloop_critical_section_begin(zuvloop_critical_section *section, PyObject *object);
 void zuvloop_critical_section_end(zuvloop_critical_section *section);
 PyObject *zuvloop_PyModuleDef_Init(PyModuleDef *definition);
 void zuvloop_Py_INCREF(PyObject *object);

--- a/zig/tshandle.zig
+++ b/zig/tshandle.zig
@@ -26,7 +26,7 @@ const cancelled_flag: u32 = 1 << 0;
 /// One blocked `cancel` or `cancelled` call, parked on a lock it acquired
 /// twice; the loop thread releases it when the callback finishes. Lives on the
 /// blocked thread's stack, which the block itself keeps alive. The list is
-/// only touched inside the extension critical section, which serialises linking
+/// only touched inside the handle's critical section, which serialises linking
 /// against the loop thread's drain.
 const Waiter = struct {
     lock: c.PyThread_type_lock,
@@ -66,6 +66,10 @@ pub inline fn owns(obj: *py.Object) bool {
 
 /// Untracks a handle owned only by the ready queue and candidate slot.
 pub fn untrackIfQueueOnly(obj: *py.Object) void {
+    // SAFETY: PyCriticalSection_Begin initializes this storage before reading it.
+    var critical_section: py.CriticalSection = undefined;
+    py.beginCriticalSection(&critical_section, obj);
+    defer py.endCriticalSection(&critical_section);
     if (c.Py_REFCNT(obj) == 2 and c.PyObject_GC_IsTracked(obj) != 0) c.PyObject_GC_UnTrack(obj);
 }
 
@@ -110,6 +114,10 @@ pub fn create(
 /// Runs the callback unless a cancellation already won the state word, then
 /// releases any thread blocked in `cancel` or `cancelled`.
 pub fn run(obj: *py.Object) void {
+    // SAFETY: PyCriticalSection_Begin initializes this storage before reading it.
+    var critical_section: py.CriticalSection = undefined;
+    py.beginCriticalSection(&critical_section, obj);
+    defer py.endCriticalSection(&critical_section);
     const self = payload(obj);
     if (@cmpxchgStrong(u32, &self.run_state, PENDING, RUNNING, .acq_rel, .acquire) != null) return;
     const previous_running = running_payload;
@@ -245,6 +253,10 @@ fn visitReferences(obj: *py.Object, visitproc: c.visitproc, arg: ?*anyopaque) c_
 
 /// Visits queued references transparently when the handle is untracked.
 pub fn traverseQueued(obj: *py.Object, visitproc: c.visitproc, arg: ?*anyopaque) c_int {
+    // SAFETY: PyCriticalSection_Begin initializes this storage before reading it.
+    var critical_section: py.CriticalSection = undefined;
+    py.beginCriticalSection(&critical_section, obj);
+    defer py.endCriticalSection(&critical_section);
     if (c.PyObject_GC_IsTracked(obj) != 0) return py.visit(obj, visitproc, arg);
     return visitReferences(obj, visitproc, arg);
 }


### PR DESCRIPTION
## Summary

- Replace the process-wide critical section with per-object synchronization.
- Move cross-thread scheduling into a protected per-loop inbox.
- Run callbacks and task context switches outside the loop lock.

This PR is stacked on [#130](https://github.com/Kludex/zuvloop/pull/130).

## Performance

CPython 3.14.3t on an M3 Max. Ratios are `zuvloop` throughput relative to `uvloop`, except for four-loop scaling.

| Benchmark | Before | After |
| --- | ---: | ---: |
| `call_soon_threadsafe` | 1.38x | 1.93x |
| `sleep(0)` | 2.26x | 26.46x |
| Tasks | 0.11x | 1.29x |
| Ready chain with idle I/O | 1.55x | 5.00x |
| Four-loop throughput scaling | 1.01x | 2.94x |

## Testing

- CPython 3.14: 519 passed, 2 skipped, 100% coverage
- CPython 3.14t ReleaseFast and ReleaseSafe: 519 passed, 2 skipped
- CPython 3.15t: 514 passed, 2 skipped; the `aiohttp` integration is excluded because its current wheel is ABI-incompatible with 3.15.0rc1
- Ruff, mypy, stubtest, and Zig formatting

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the process-wide critical section with per-object synchronization so free-threaded event loops can run independently without contending for a single lock. Cross-thread scheduling moves into a per-loop inbox, and callbacks run outside the loop lock, improving throughput for multi-loop workloads.

**What changed**
- Each loop and thread-safe handle now owns its own critical section.
- `call_soon_threadsafe` producers push into a per-loop inbox drained before local callbacks.
- Tasks, callbacks, and context switches run outside the loop lock.
- Adds a test for `call_soon` ordering after a threadsafe call.
- Updates architecture docs for the per-object locking model.
- Guards a network test against an empty sink list.

<sup>Written for commit 24d53fa35a4d81d0ba3d773fdd1e3e18e65e5841. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

