### PR TITLE
Bound parallel event loop benchmark work

### DIFF
--- a/benchmarks/test_benchmarks.py
+++ b/benchmarks/test_benchmarks.py
@@ -232,7 +232,7 @@ def test_parallel_event_loops(
 ) -> None:
     """Four independent loops run CPU-bound callbacks in parallel."""
     workers = 4
-    iterations = 1_000_000
+    iterations = 250_000
 
     def setup() -> tuple[tuple[list[asyncio.AbstractEventLoop], threading.Barrier, list[int]], dict[str, int]]:
         loops = [(factory or asyncio.new_event_loop)() for _ in range(workers)]


### PR DESCRIPTION
## Summary

Reduce the CPU loop from 1,000,000 to 250,000 iterations per worker. The benchmark still measures about 30 ms locally with 0.4-1.3% relative standard deviation, while fitting within the 15-minute CodSpeed job limit.

## Testing

| Check | Result |
| --- | --- |
| Parallel benchmark | 3 passed in 1.49s |
| Complete benchmark suite | 45 passed in 2m38s |
| Ruff and mypy | Passed |

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces the parallel event loop benchmark from 1,000,000 to 250,000 iterations per worker so the suite completes within CodSpeed's 15-minute job limit. The benchmark still takes about 30 ms locally with 0.4–1.3% relative standard deviation, so measurement quality is unchanged.

<sup>Written for commit b09a79b89b07c5c409481814065e3302ed24ccd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

