### PR TITLE
Run the threaded benchmark without CodSpeed profiling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,7 +377,15 @@ jobs:
       - uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8 # v5.0.3
         with:
           mode: walltime
-          run: uv run --no-sync pytest benchmarks/ --codspeed
+          run: uv run --no-sync pytest benchmarks/ --codspeed -k "not parallel_event_loops"
+
+      - name: Run the parallel benchmark without profiling
+        uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8 # v5.0.3
+        env:
+          CODSPEED_PERF_ENABLED: "false"
+        with:
+          mode: walltime
+          run: uv run --no-sync pytest benchmarks/test_benchmarks.py::test_parallel_event_loops --codspeed
 
   docs:
     runs-on: ubuntu-latest

--- a/benchmarks/test_benchmarks.py
+++ b/benchmarks/test_benchmarks.py
@@ -232,7 +232,7 @@ def test_parallel_event_loops(
 ) -> None:
     """Four independent loops run CPU-bound callbacks in parallel."""
     workers = 4
-    iterations = 250_000
+    iterations = 1_000_000
 
     def setup() -> tuple[tuple[list[asyncio.AbstractEventLoop], threading.Barrier, list[int]], dict[str, int]]:
         loops = [(factory or asyncio.new_event_loop)() for _ in range(workers)]
@@ -259,8 +259,7 @@ def test_parallel_event_loops(
             barrier.wait()
             loop.run_forever()
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
-            list(executor.map(run, loops))
+        list(executor.map(run, loops))
         assert len(set(results)) == 1
 
     def teardown(
@@ -272,7 +271,13 @@ def test_parallel_event_loops(
         for loop in loops:
             loop.close()
 
-    benchmark.pedantic(measure, setup=setup, teardown=teardown, rounds=5)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+        barrier = threading.Barrier(workers + 1)
+        started = [executor.submit(barrier.wait) for _ in range(workers)]
+        barrier.wait()
+        for future in started:
+            future.result()
+        benchmark.pedantic(measure, setup=setup, teardown=teardown, rounds=5)
 
 
 @pytest.mark.benchmark


### PR DESCRIPTION
## Summary

- Keep the full 1,000,000-iteration parallel event-loop workload.
- Reuse prestarted worker threads outside the measured block.
- Run only this threaded benchmark with CodSpeed perf profiling disabled, as supported by the CodSpeed CLI.

## Testing

| Runtime | Result | Best range |
| --- | --- | ---: |
| CPython 3.14 | 3 passed in 2.84s | 129.8-132.6 ms |
| CPython 3.14t | 3 passed in 1.19s | 30.6-36.3 ms |
| Ruff, mypy, workflow YAML | Passed | - |

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs the threaded parallel benchmark outside CodSpeed's profiler and restores its original 1,000,000-iteration workload. This avoids profiler interference in the measurement of parallel event-loop execution.

**Changes**
- In CI, the parallel benchmark runs in a separate CodSpeed step with profiling disabled.
- The benchmark now reuses a pre-started thread pool so the measured block only exercises the event loops.

<sup>Written for commit 39da85fffd1ec5dbc8afc22cd317eaf92be1e3d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

