### PR TITLE
Run profiler-incompatible benchmarks without profiling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,15 +377,19 @@ jobs:
       - uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8 # v5.0.3
         with:
           mode: walltime
-          run: uv run --no-sync pytest benchmarks/ --codspeed -k "not parallel_event_loops"
+          run: >-
+            uv run --no-sync pytest benchmarks/ --codspeed
+            -k "not parallel_event_loops and not ready_chain_with_idle_connections"
 
-      - name: Run the parallel benchmark without profiling
+      - name: Run profiler-incompatible benchmarks
         uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8 # v5.0.3
         env:
           CODSPEED_PERF_ENABLED: "false"
         with:
           mode: walltime
-          run: uv run --no-sync pytest benchmarks/test_benchmarks.py::test_parallel_event_loops --codspeed
+          run: >-
+            uv run --no-sync pytest benchmarks/ --codspeed
+            -k "parallel_event_loops or ready_chain_with_idle_connections"
 
   docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Run the idle-connection and parallel-loop benchmarks without perf profiling.
- Keep the remaining 39 benchmarks in the profiled CodSpeed step.

## Testing

| Check | Result |
| --- | --- |
| Workflow YAML | Passed |
| Profiled benchmark selection | 39 passed in 2m 24s |
| Unprofiled benchmark selection | 6 passed in 14.7s |

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs the idle-connection and parallel-loop benchmarks without profiling in CI. Previously, only the parallel-loop benchmark ran unprofiled; now idle-connection joins it, while the other 39 benchmarks remain in the profiled CodSpeed step.

<sup>Written for commit b6982ff484b80a124e63904d4031050e7f5a4b1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

