### PR TITLE
Avoid locking objects during deallocation

### DIFF
--- a/zig/py.zig
+++ b/zig/py.zig
@@ -348,10 +348,6 @@ pub fn wrapO(comptime f: anytype) fn (?*Object, ?*Object) callconv(.c) ?*Object 
 pub fn wrapDealloc(comptime f: anytype) fn (?*Object) callconv(.c) void {
     const Inner = struct {
         fn call(self: ?*Object) callconv(.c) void {
-            // SAFETY: PyCriticalSection_Begin initializes this storage before reading it.
-            var critical_section: CriticalSection = undefined;
-            beginCriticalSection(&critical_section, self.?);
-            defer endCriticalSection(&critical_section);
             f(self);
         }
     };


### PR DESCRIPTION
Free-threaded `tp_dealloc` currently frees an object before its wrapper exits the object critical section. The deferred unlock then accesses the freed mutex and can abort with `PyMutex_Unlock: unlocking mutex that is not locked` under contention.

| Check | Result |
| --- | --- |
| Python 3.14t suite | 519 passed, 2 skipped |
| Python 3.15t suite | 514 passed, 2 skipped; aiohttp excluded because its published extension is ABI-incompatible with 3.15.0rc1 |
| Python 3.15t producer stress | `main` aborts; this branch passed 3 consecutive 5-second runs |
| Paired Python 3.15t `pyperf` | `call_soon`: 178 ns to 169 ns; tasks: 1.12 us to 1.05 us |

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the critical section from the deallocation wrapper so deallocation no longer locks the object. In free-threaded builds, the deferred unlock could run after the object was freed and abort under contention.

<sup>Written for commit 4f5c57f5b7b4e31806955bd4140236e95d90038d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

