### PR TITLE
Benchmark large callback queues

### DIFF
--- a/benchmarks/handle_queue.py
+++ b/benchmarks/handle_queue.py
@@ -1,0 +1,79 @@
+"""Measure the peak resident memory added by a queue of callback handles.
+
+Each measurement runs in a child process because `ru_maxrss` is a process-wide
+high-water mark. The callbacks remain queued while memory is sampled.
+
+    uv run --group bench python benchmarks/handle_queue.py
+    uv run --group bench python benchmarks/handle_queue.py --depths 1000000
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import resource
+import subprocess
+import sys
+from collections.abc import Callable
+
+import zuvloop
+
+Factory = Callable[[], asyncio.AbstractEventLoop]
+
+
+def main() -> int:
+    factories: dict[str, Factory] = {"asyncio": asyncio.new_event_loop, "zuvloop": zuvloop.new_event_loop}
+    try:
+        import uvloop
+    except ImportError:
+        pass
+    else:
+        factories["uvloop"] = uvloop.new_event_loop
+
+    parser = argparse.ArgumentParser(description="Measure callback queue memory by event loop.")
+    parser.add_argument("--depths", nargs="+", type=int, default=[100_000, 1_000_000])
+    parser.add_argument("--only", nargs="+", choices=factories, default=list(factories))
+    parser.add_argument("--measure", choices=factories, help=argparse.SUPPRESS)
+    args = parser.parse_args()
+    if any(depth < 1 for depth in args.depths):
+        parser.error("depths must be positive")
+
+    if args.measure is not None:
+        loop = factories[args.measure]()
+        scale = 1 if sys.platform == "darwin" else 1024
+        baseline = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * scale
+
+        def callback() -> None:
+            pass
+
+        try:
+            for _ in range(args.depths[0]):
+                loop.call_soon(callback)
+            peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * scale
+        finally:
+            loop.close()
+        added = max(0, peak - baseline)
+        print(args.measure, args.depths[0], added)
+        return 0
+
+    print(f"python {sys.version.split()[0]}\n")
+    for depth in args.depths:
+        print(f"{depth:,} queued callbacks")
+        for label in args.only:
+            result = subprocess.run(
+                [sys.executable, __file__, "--measure", label, "--depths", str(depth)],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            measured_label, measured_depth, child_added = result.stdout.split()
+            if measured_label != label or int(measured_depth) != depth:
+                raise RuntimeError(f"unexpected child result: {result.stdout!r}")
+            added_bytes = int(child_added)
+            print(f"  {label:<8}{added_bytes / (1 << 20):>9.1f} MiB  {added_bytes / depth:>6.1f} bytes/callback")
+        print()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/test_benchmarks.py
+++ b/benchmarks/test_benchmarks.py
@@ -80,6 +80,32 @@ def test_call_soon(benchmark: BenchmarkFixture, loop: asyncio.AbstractEventLoop)
 
 
 @pytest.mark.benchmark
+@pytest.mark.parametrize("iterations", [100_000, 1_000_000], ids=["100k", "1m"])
+def test_call_soon_large_queue(
+    benchmark: BenchmarkFixture,
+    loop: asyncio.AbstractEventLoop,
+    iterations: int,
+) -> None:
+    """Schedule the full queue before draining it, exposing handle allocation cost."""
+
+    async def work() -> None:
+        done = loop.create_future()
+        seen = 0
+
+        def step() -> None:
+            nonlocal seen
+            seen += 1
+            if seen == iterations:
+                done.set_result(None)
+
+        for _ in range(iterations):
+            loop.call_soon(step)
+        await done
+
+    benchmark(drive(loop, work))
+
+
+@pytest.mark.benchmark
 def test_call_soon_threadsafe(benchmark: BenchmarkFixture, loop: asyncio.AbstractEventLoop) -> None:
     """Cross-thread scheduling, where the 3.14 handle contract sets the price."""
     iterations = 10_000


### PR DESCRIPTION
## Summary

Add CodSpeed coverage for queues of 100,000 and 1,000,000 callbacks. Add an isolated peak RSS benchmark for callback queue memory.

On an M3 Max with CPython 3.14.6, one million queued callbacks added 136.3 MiB for zuvloop, 177.8 MiB for asyncio, and 208.3 MiB for uvloop.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds benchmarks for very large callback queues, covering both peak memory usage and scheduling throughput.

- A new script measures peak RSS added per queued callback for asyncio, zuvloop, and uvloop, each in a child process.
- A new CodSpeed test drives 100,000 and 1,000,000 queued callbacks before draining to expose handle allocation cost.

<sup>Written for commit 7328a324ab823e45c843e23a0b1cf35bb780a39f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

