### PR TITLE
Stabilize lifecycle and Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,6 @@ jobs:
         if: matrix.os != 'windows-11-arm'
         with:
           version: 0.16.0
-          # Interrupted Windows builds can leave cached runners pointing at deleted executables.
-          use-cache: ${{ runner.os != 'Windows' }}
 
       # Zig 0.16's native ARM64 Windows compiler exits with an access violation
       # on `zig build`. Windows 11 runs the pinned x86-64 compiler under
@@ -56,10 +54,24 @@ jobs:
           version: 0.12.3
 
       - name: Install
+        id: install
+        continue-on-error: ${{ runner.os == 'Windows' }}
         env:
           HATCH_ZIG_TARGET: ${{ matrix.os == 'windows-11-arm' && 'aarch64-windows' || '' }}
           PYTHON_VERSION: ${{ matrix.python-version }}
         run: uv sync --locked --python "$PYTHON_VERSION" --group dev --group bench
+
+      - name: Retry the Windows install without the Zig cache
+        if: runner.os == 'Windows' && steps.install.outcome == 'failure'
+        env:
+          HATCH_ZIG_TARGET: ${{ matrix.os == 'windows-11-arm' && 'aarch64-windows' || '' }}
+          PYTHON_VERSION: ${{ matrix.python-version }}
+        shell: pwsh
+        run: |
+          if (Test-Path .zig-cache) {
+            Remove-Item -Recurse -Force .zig-cache
+          }
+          uv sync --locked --python "$env:PYTHON_VERSION" --group dev --group bench
 
       - name: Verify the hashed build constraints
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         if: matrix.os != 'windows-11-arm'
         with:
+          use-cache: false
           version: 0.16.0
 
       # Zig 0.16's native ARM64 Windows compiler exits with an access violation
@@ -48,30 +49,23 @@ jobs:
         shell: pwsh
         run: ./scripts/setup-zig-x86_64-windows.ps1
 
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .zig-cache
+          key: >-
+            zig-test-0.16.0-${{ matrix.os }}-${{ matrix.python-version }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: zig-test-0.16.0-${{ matrix.os }}-${{ matrix.python-version }}-
+
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
           version: 0.12.3
 
       - name: Install
-        id: install
-        continue-on-error: ${{ runner.os == 'Windows' }}
         env:
           HATCH_ZIG_TARGET: ${{ matrix.os == 'windows-11-arm' && 'aarch64-windows' || '' }}
           PYTHON_VERSION: ${{ matrix.python-version }}
         run: uv sync --locked --python "$PYTHON_VERSION" --group dev --group bench
-
-      - name: Retry the Windows install without the Zig cache
-        if: runner.os == 'Windows' && steps.install.outcome == 'failure'
-        env:
-          HATCH_ZIG_TARGET: ${{ matrix.os == 'windows-11-arm' && 'aarch64-windows' || '' }}
-          PYTHON_VERSION: ${{ matrix.python-version }}
-        shell: pwsh
-        run: |
-          if (Test-Path .zig-cache) {
-            Remove-Item -Recurse -Force .zig-cache
-          }
-          uv sync --locked --python "$env:PYTHON_VERSION" --group dev --group bench
 
       - name: Verify the hashed build constraints
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
         if: matrix.os != 'windows-11-arm'
         with:
           version: 0.16.0
+          # Interrupted Windows builds can leave cached runners pointing at deleted executables.
+          use-cache: ${{ runner.os != 'Windows' }}
 
       # Zig 0.16's native ARM64 Windows compiler exits with an access violation
       # on `zig build`. Windows 11 runs the pinned x86-64 compiler under

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -32,9 +32,13 @@ def test_run_returns_the_coroutine_result() -> None:
     assert zuvloop.run(main()) == "done"
 
 
-def test_self_pipe_drain_stops_watching_at_eof() -> None:
+def test_self_pipe_drain_stops_watching_at_eof(monkeypatch: pytest.MonkeyPatch) -> None:
     loop = zuvloop.new_event_loop()
     errors: list[BaseException] = []
+    self_pipe_removed = threading.Event()
+    removal_results: list[bool] = []
+    self_pipe_fd = loop._ssock.fileno()
+    original_remove_reader = loop.remove_reader
 
     def run() -> None:
         try:
@@ -42,16 +46,26 @@ def test_self_pipe_drain_stops_watching_at_eof() -> None:
         except BaseException as exc:  # pragma: no cover - assertion diagnostic
             errors.append(exc)
 
+    def remove_self_pipe_reader(fd: int) -> bool:
+        assert fd == self_pipe_fd
+        removed = original_remove_reader(fd)
+        removal_results.append(removed)
+        self_pipe_removed.set()
+        return removed
+
+    monkeypatch.setattr(loop, "remove_reader", remove_self_pipe_reader)
     loop._csock.close()
-    loop.call_later(0.02, loop.stop)
     thread = threading.Thread(target=run, daemon=True)
     thread.start()
-    thread.join(1)
     try:
+        assert self_pipe_removed.wait(1), "event loop did not stop watching the self-pipe at EOF"
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(1)
         assert not thread.is_alive(), "event loop kept polling the self-pipe at EOF"
         assert errors == []
-        assert loop.remove_reader(loop._ssock.fileno()) is False
+        assert removal_results == [True]
     finally:
+        monkeypatch.setattr(loop, "remove_reader", original_remove_reader)
         loop.call_soon_threadsafe(loop.stop)
         thread.join(1)
         if not loop.is_running():  # pragma: no branch - watchdog failure may leave a daemon spinning


### PR DESCRIPTION
The lifecycle test stopped the loop after a fixed 20 ms delay. On slower runners, that timer became due before the self-pipe EOF was processed and left the reader registered.

The test now waits for the reader removal itself and keeps a one-second watchdog for regressions. Zig caching follows the [OpenTUI workflow](https://github.com/anomalyco/opentui/blob/main/.github/workflows/build-native.yml): `setup-zig` configures the compiler, while `actions/cache` restores build state and saves it only after a successful job. The cache key includes the OS and Python version as the [`setup-zig` matrix guidance](https://github.com/mlugg/setup-zig#setup-zig) recommends.

| Check | Result |
| --- | --- |
| Forced delayed-start reproduction | Old test retained the reader 10/10 times |
| Repetition | 500/500 passed |
| Full suite | 519 passed, 2 skipped |
| Coverage | 100% |
| Mypy and Ruff | Passed |
| Windows cache failure | Reproduced on `main` and the first PR run |

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
