### PR TITLE
Benchmark timers running to completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Your code stays the same. The loop underneath gets faster. 🚀
 
 The key features are:
 
-- **Fast**: Scheduling, timers, sockets, and DNS run in native code, driven by [libuv](https://libuv.org) - the same engine behind Node.js. Over **25x faster than asyncio** at thread-safe scheduling and faster than [uvloop](https://github.com/MagicStack/uvloop) on 11 of the 12 benchmarks below.
+- **Fast**: Scheduling, timers, sockets, and DNS run in native code, driven by [libuv](https://libuv.org) - the same engine behind Node.js. Over **25x faster than asyncio** at thread-safe scheduling and matches or beats [uvloop](https://github.com/MagicStack/uvloop) on 12 of the 14 benchmarks below.
 - **Drop-in**: One line to switch. Everything is standard `asyncio` — same `Task` objects, same protocols, same APIs.
 - **Fully typed**: Ships type hints for everything and passes **strict mypy**. Your editor will love it. ✨
 - **Observable**: Built-in [OpenTelemetry](https://opentelemetry.io) instrumentation — slow-callback spans, unhandled-exception spans, loop metrics. Zero cost until you turn it on.
@@ -31,7 +31,7 @@ The key features are:
 </p>
 
 Throughput relative to stock asyncio (higher is better), measured with the suite in
-`benchmarks/` on an M3 Max, macOS 26, CPython 3.14.3, and libuv 1.51.0. Each result is the median of seven
+`benchmarks/` on an M3 Max, macOS 26, CPython 3.14, and libuv 1.51.0. Each result is the median of seven
 interleaved in-process runs or five interleaved HTTP runs. The labels show the absolute numbers.
 
 | Benchmark | asyncio | uvloop | zuvloop |
@@ -39,7 +39,9 @@ interleaved in-process runs or five interleaved HTTP runs. The labels show the a
 | `call_soon` | 2.36M/s | 4.49M/s | **8.81M/s** |
 | `call_soon` with arguments | 2.14M/s | 3.51M/s | **8.86M/s** |
 | `call_soon_threadsafe` | 0.44M/s | 5.13M/s | **11.9M/s** |
-| timer schedule + cancel | 1.32M/s | 2.53M/s | **9.37M/s** |
+| timer schedule + cancel | 1.17M/s | 1.93M/s | **9.02M/s** |
+| completed timer rounds | 70.2k/s | 76.9k/s | 78.0k/s |
+| prebuilt due timer batch | 1.42M/s | **25.0M/s** | 8.82M/s |
 | ready chain with 250 idle connections | 70.7k/s | 76.3k/s | **362.6k/s** |
 | bulk stream | 7.1 GiB/s | 7.9 GiB/s | **9.7 GiB/s** |
 | echo round trips, 1 KiB | 36.8k/s | 53.6k/s | **57.6k/s** |
@@ -48,6 +50,10 @@ interleaved in-process runs or five interleaved HTTP runs. The labels show the a
 | aiohttp server | 46.2k req/s | 58.0k req/s | **58.8k req/s** |
 | aiohttp client | 12.6k req/s | **15.0k req/s** | 14.8k req/s |
 | `getaddrinfo`, numeric host | 27.0k/s | 1.48M/s | **1.70M/s** |
+
+The timer rows measure different work. Timer schedule + cancel isolates heap bookkeeping and handle cleanup without
+firing callbacks. Completed timer rounds chain one zero-delay timer per event loop turn. The prebuilt due timer batch
+measures heap draining and callback dispatch, with allocation and deallocation outside the timed section.
 
 Curious how? The [architecture docs](https://zuvloop.marcelotryle.com) explain the design:
 argument storage inside handles (no tuple per callback), a native timer heap behind a single

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Your code stays the same. The loop underneath gets faster. 🚀
 
 The key features are:
 
-- **Fast**: Scheduling, timers, sockets, and DNS run in native code, driven by [libuv](https://libuv.org) - the same engine behind Node.js. Over **25x faster than asyncio** at thread-safe scheduling and matches or beats [uvloop](https://github.com/MagicStack/uvloop) on 12 of the 14 benchmarks below.
+- **Fast**: Scheduling, timers, sockets, and DNS run in native code, driven by [libuv](https://libuv.org) - the same engine behind Node.js. Over **25x faster than asyncio** at thread-safe scheduling and matches or beats [uvloop](https://github.com/MagicStack/uvloop) on 13 of the 14 benchmarks below.
 - **Drop-in**: One line to switch. Everything is standard `asyncio` — same `Task` objects, same protocols, same APIs.
 - **Fully typed**: Ships type hints for everything and passes **strict mypy**. Your editor will love it. ✨
 - **Observable**: Built-in [OpenTelemetry](https://opentelemetry.io) instrumentation — slow-callback spans, unhandled-exception spans, loop metrics. Zero cost until you turn it on.
@@ -41,7 +41,7 @@ interleaved in-process runs or five interleaved HTTP runs. The labels show the a
 | `call_soon_threadsafe` | 0.44M/s | 5.13M/s | **11.9M/s** |
 | timer schedule + cancel | 1.17M/s | 1.93M/s | **9.02M/s** |
 | completed timer rounds | 70.2k/s | 76.9k/s | 78.0k/s |
-| prebuilt due timer batch | 1.42M/s | **25.0M/s** | 8.82M/s |
+| prebuilt due timer batch | 1.38M/s | 2.73M/s | **5.89M/s** |
 | ready chain with 250 idle connections | 70.7k/s | 76.3k/s | **362.6k/s** |
 | bulk stream | 7.1 GiB/s | 7.9 GiB/s | **9.7 GiB/s** |
 | echo round trips, 1 KiB | 36.8k/s | 53.6k/s | **57.6k/s** |

--- a/benchmarks/compare.py
+++ b/benchmarks/compare.py
@@ -1,7 +1,7 @@
 """Compare zuvloop against uvloop, honestly.
 
     uv run --group bench python benchmarks/compare.py
-    uv run --group bench python benchmarks/compare.py echo timers
+    uv run --group bench python benchmarks/compare.py echo timer_rounds
 
 `test_benchmarks.py` records what changed between commits, which is what CodSpeed
 is for, but its table cannot answer "how does this compare to uvloop" - see the
@@ -208,13 +208,35 @@ def call_soon_threadsafe(loop: asyncio.AbstractEventLoop) -> Callable[[], None]:
     return _driver(loop, once)
 
 
-def timers(loop: asyncio.AbstractEventLoop) -> Callable[[], None]:
+def timer_schedule_cancel(loop: asyncio.AbstractEventLoop) -> Callable[[], None]:
     """Timer bookkeeping: schedule and cancel, never firing."""
     iterations = 10_000
 
     async def once() -> None:
         for _ in range(iterations):
             loop.call_later(30, _noop).cancel()
+
+    return _driver(loop, once)
+
+
+def timer_rounds(loop: asyncio.AbstractEventLoop) -> Callable[[], None]:
+    """Ten thousand zero-delay timers, with each scheduling the next turn."""
+    iterations = 10_000
+
+    async def once() -> None:
+        done = loop.create_future()
+        remaining = iterations
+
+        def step() -> None:
+            nonlocal remaining
+            remaining -= 1
+            if remaining == 0:
+                done.set_result(None)
+            else:
+                loop.call_later(0, step)
+
+        loop.call_later(0, step)
+        await done
 
     return _driver(loop, once)
 
@@ -273,7 +295,8 @@ WORKLOADS: dict[str, Workload] = {
     "bulk": bulk,
     "call_soon": call_soon,
     "call_soon_threadsafe": call_soon_threadsafe,
-    "timers": timers,
+    "timer_schedule_cancel": timer_schedule_cancel,
+    "timer_rounds": timer_rounds,
     "loop_iterations": loop_iterations,
     "tasks": tasks,
     "getaddrinfo": getaddrinfo,

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -1,7 +1,7 @@
 """Absolute throughput per loop - the numbers behind the README table.
 
     uv run --group bench python benchmarks/run.py
-    uv run --group bench python benchmarks/run.py --only call_soon timers
+    uv run --group bench python benchmarks/run.py --only call_soon timer_rounds
 
 `compare.py` answers "how does this compare to uvloop" with interleaved wall
 times, and CodSpeed tracks what changed between commits. Neither reports the
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import math
 import os
 import socket
 import statistics
@@ -110,13 +111,47 @@ async def bench_call_soon_threadsafe(iterations: int = 200_000) -> float:
     return iterations / elapsed
 
 
-async def bench_timers(iterations: int = 200_000) -> float:
+async def bench_timer_schedule_cancel(iterations: int = 200_000) -> float:
     """Timer churn: schedule then cancel, never firing."""
     loop = asyncio.get_running_loop()
     started = time.perf_counter()
     for _ in range(iterations):
         loop.call_later(30, _noop).cancel()
     return iterations / (time.perf_counter() - started)
+
+
+async def bench_timer_rounds(iterations: int = 10_000) -> float:
+    """Run one zero-delay timer per loop turn until the chain completes."""
+    loop = asyncio.get_running_loop()
+    done = loop.create_future()
+    remaining = iterations
+
+    def step() -> None:
+        nonlocal remaining
+        remaining -= 1
+        if remaining == 0:
+            done.set_result(None)
+        else:
+            loop.call_later(0, step)
+
+    started = time.perf_counter()
+    loop.call_later(0, step)
+    await done
+    return iterations / (time.perf_counter() - started)
+
+
+async def bench_timer_due_batch(iterations: int = 200_000) -> float:
+    """Drain a prebuilt batch of due timers without timing allocation or deallocation."""
+    loop = asyncio.get_running_loop()
+    done = loop.create_future()
+    deadline = loop.time()
+    handles = [loop.call_at(deadline, _noop) for _ in range(iterations)]
+    handles.append(loop.call_at(math.nextafter(deadline, math.inf), done.set_result, None))
+    started = time.perf_counter()
+    await done
+    elapsed = time.perf_counter() - started
+    handles.clear()
+    return iterations / elapsed
 
 
 async def bench_sleep_zero(iterations: int = 30_000) -> float:
@@ -303,7 +338,9 @@ BENCHMARKS: dict[str, tuple[Benchmark, str]] = {
     "call_soon": (bench_call_soon, "callbacks/s"),
     "call_soon_args": (bench_call_soon_args, "callbacks/s"),
     "call_soon_threadsafe": (bench_call_soon_threadsafe, "callbacks/s"),
-    "timers": (bench_timers, "timers/s"),
+    "timer_schedule_cancel": (bench_timer_schedule_cancel, "timers/s"),
+    "timer_rounds": (bench_timer_rounds, "timers/s"),
+    "timer_due_batch": (bench_timer_due_batch, "timers/s"),
     "sleep_zero": (bench_sleep_zero, "iterations/s"),
     "tasks": (bench_tasks, "tasks/s"),
     "ready_with_io": (bench_ready_with_io, "iterations/s"),

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -23,11 +23,20 @@ import sys
 import threading
 import time
 from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
 
 import zuvloop
 
 Factory = Callable[[], asyncio.AbstractEventLoop]
-Benchmark = Callable[[], Coroutine[None, None, float]]
+AsyncBenchmark = Callable[[], Coroutine[None, None, float]]
+StoppedLoopBenchmark = Callable[[asyncio.AbstractEventLoop], float]
+
+
+@dataclass(frozen=True)
+class Benchmark:
+    unit: str
+    async_work: AsyncBenchmark | None = None
+    stopped_loop_work: StoppedLoopBenchmark | None = None
 
 
 def loop_factories() -> dict[str, Factory]:
@@ -43,7 +52,11 @@ def loop_factories() -> dict[str, Factory]:
 def run_on(factory: Factory, benchmark: Benchmark) -> float:
     loop = factory()
     try:
-        return loop.run_until_complete(benchmark())
+        if benchmark.stopped_loop_work is not None:
+            return benchmark.stopped_loop_work(loop)
+        if benchmark.async_work is None:
+            raise RuntimeError("benchmark has no workload")
+        return loop.run_until_complete(benchmark.async_work())
     finally:
         loop.close()
 
@@ -140,15 +153,18 @@ async def bench_timer_rounds(iterations: int = 10_000) -> float:
     return iterations / (time.perf_counter() - started)
 
 
-async def bench_timer_due_batch(iterations: int = 200_000) -> float:
+def bench_timer_due_batch(loop: asyncio.AbstractEventLoop, iterations: int = 100_000) -> float:
     """Drain a prebuilt batch of due timers without timing allocation or deallocation."""
-    loop = asyncio.get_running_loop()
     done = loop.create_future()
-    deadline = loop.time()
+    deadline = loop.time() + 0.5
     handles = [loop.call_at(deadline, _noop) for _ in range(iterations)]
-    handles.append(loop.call_at(math.nextafter(deadline, math.inf), done.set_result, None))
+    sentinel_deadline = deadline + 0.01
+    handles.append(loop.call_at(sentinel_deadline, done.set_result, None))
+    if not all(math.isfinite(handle.when()) for handle in handles):
+        raise RuntimeError("timer returned a non-finite deadline")
+    time.sleep(max(0.0, sentinel_deadline - loop.time()) + 0.001)
     started = time.perf_counter()
-    await done
+    loop.run_until_complete(done)
     elapsed = time.perf_counter() - started
     handles.clear()
     return iterations / elapsed
@@ -334,21 +350,21 @@ async def bench_process_pipe(repetitions: int = 12, payload_size: int = 4 << 20)
     return repetitions * payload_size / (time.perf_counter() - started)
 
 
-BENCHMARKS: dict[str, tuple[Benchmark, str]] = {
-    "call_soon": (bench_call_soon, "callbacks/s"),
-    "call_soon_args": (bench_call_soon_args, "callbacks/s"),
-    "call_soon_threadsafe": (bench_call_soon_threadsafe, "callbacks/s"),
-    "timer_schedule_cancel": (bench_timer_schedule_cancel, "timers/s"),
-    "timer_rounds": (bench_timer_rounds, "timers/s"),
-    "timer_due_batch": (bench_timer_due_batch, "timers/s"),
-    "sleep_zero": (bench_sleep_zero, "iterations/s"),
-    "tasks": (bench_tasks, "tasks/s"),
-    "ready_with_io": (bench_ready_with_io, "iterations/s"),
-    "echo_1kb": (bench_echo, "roundtrips/s"),
-    "stream": (bench_stream, "bytes/s"),
-    "getaddrinfo": (bench_getaddrinfo, "lookups/s"),
-    "process_spawn": (bench_process_spawn, "processes/s"),
-    "process_pipe": (bench_process_pipe, "bytes/s"),
+BENCHMARKS: dict[str, Benchmark] = {
+    "call_soon": Benchmark("callbacks/s", async_work=bench_call_soon),
+    "call_soon_args": Benchmark("callbacks/s", async_work=bench_call_soon_args),
+    "call_soon_threadsafe": Benchmark("callbacks/s", async_work=bench_call_soon_threadsafe),
+    "timer_schedule_cancel": Benchmark("timers/s", async_work=bench_timer_schedule_cancel),
+    "timer_rounds": Benchmark("timers/s", async_work=bench_timer_rounds),
+    "timer_due_batch": Benchmark("timers/s", stopped_loop_work=bench_timer_due_batch),
+    "sleep_zero": Benchmark("iterations/s", async_work=bench_sleep_zero),
+    "tasks": Benchmark("tasks/s", async_work=bench_tasks),
+    "ready_with_io": Benchmark("iterations/s", async_work=bench_ready_with_io),
+    "echo_1kb": Benchmark("roundtrips/s", async_work=bench_echo),
+    "stream": Benchmark("bytes/s", async_work=bench_stream),
+    "getaddrinfo": Benchmark("lookups/s", async_work=bench_getaddrinfo),
+    "process_spawn": Benchmark("processes/s", async_work=bench_process_spawn),
+    "process_pipe": Benchmark("bytes/s", async_work=bench_process_pipe),
 }
 
 
@@ -371,7 +387,7 @@ def main() -> int:
     print(f"python {sys.version.split()[0]}   libuv {zuvloop.libuv_version()}\n")
 
     for name in args.only or list(BENCHMARKS):
-        benchmark, unit = BENCHMARKS[name]
+        benchmark = BENCHMARKS[name]
         print(name)
         # Interleave the rounds. Running every sample for one loop back to back
         # lets thermal drift and background load bias whichever went first.
@@ -384,7 +400,7 @@ def main() -> int:
         for label, value in results.items():
             values = samples[label]
             spread = statistics.pstdev(values) / statistics.mean(values) if len(values) > 1 else 0.0
-            print(f"  {label:<8}{humanise(value, unit)}  (+/- {spread:.1%})")
+            print(f"  {label:<8}{humanise(value, benchmark.unit)}  (+/- {spread:.1%})")
         print(f"  {'':<8}{'zuvloop / ' + baseline:>15}  {results['zuvloop'] / results[baseline]:.2f}x\n")
     return 0
 

--- a/benchmarks/test_benchmarks.py
+++ b/benchmarks/test_benchmarks.py
@@ -25,6 +25,7 @@ import math
 import os
 import socket
 import threading
+import time
 from collections.abc import Callable, Coroutine, Iterator
 
 import pytest
@@ -257,9 +258,13 @@ def test_timer_due_batch(benchmark: BenchmarkFixture, loop: asyncio.AbstractEven
 
     def setup() -> tuple[tuple[asyncio.Future[None], list[asyncio.TimerHandle]], dict[str, int]]:
         done = loop.create_future()
-        deadline = loop.time()
+        deadline = loop.time() + 0.5
         handles = [loop.call_at(deadline, _noop) for _ in range(iterations)]
-        handles.append(loop.call_at(math.nextafter(deadline, math.inf), done.set_result, None))
+        sentinel_deadline = deadline + 0.01
+        handles.append(loop.call_at(sentinel_deadline, done.set_result, None))
+        if not all(math.isfinite(handle.when()) for handle in handles):
+            raise RuntimeError("timer returned a non-finite deadline")
+        time.sleep(max(0.0, sentinel_deadline - loop.time()) + 0.001)
         return (done, handles), {}
 
     def measure(done: asyncio.Future[None], _handles: list[asyncio.TimerHandle]) -> None:
@@ -268,7 +273,7 @@ def test_timer_due_batch(benchmark: BenchmarkFixture, loop: asyncio.AbstractEven
     def teardown(_done: asyncio.Future[None], handles: list[asyncio.TimerHandle]) -> None:
         handles.clear()
 
-    benchmark.pedantic(measure, setup=setup, teardown=teardown, rounds=10)
+    benchmark.pedantic(measure, setup=setup, teardown=teardown, rounds=7)
 
 
 @pytest.mark.benchmark

--- a/benchmarks/test_benchmarks.py
+++ b/benchmarks/test_benchmarks.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import math
 import os
 import socket
 import threading
@@ -215,7 +216,7 @@ def test_call_soon_args(benchmark: BenchmarkFixture, loop: asyncio.AbstractEvent
 
 
 @pytest.mark.benchmark
-def test_timers(benchmark: BenchmarkFixture, loop: asyncio.AbstractEventLoop) -> None:
+def test_timer_schedule_cancel(benchmark: BenchmarkFixture, loop: asyncio.AbstractEventLoop) -> None:
     """Schedule then cancel, never firing: timer bookkeeping on its own."""
     iterations = 10_000
 
@@ -224,6 +225,50 @@ def test_timers(benchmark: BenchmarkFixture, loop: asyncio.AbstractEventLoop) ->
             loop.call_later(30, _noop).cancel()
 
     benchmark(drive(loop, work))
+
+
+@pytest.mark.benchmark
+def test_timer_rounds(benchmark: BenchmarkFixture, loop: asyncio.AbstractEventLoop) -> None:
+    """Run one zero-delay timer per loop turn until the chain completes."""
+    iterations = 10_000
+
+    async def work() -> None:
+        done = loop.create_future()
+        remaining = iterations
+
+        def step() -> None:
+            nonlocal remaining
+            remaining -= 1
+            if remaining == 0:
+                done.set_result(None)
+            else:
+                loop.call_later(0, step)
+
+        loop.call_later(0, step)
+        await done
+
+    benchmark(drive(loop, work))
+
+
+@pytest.mark.benchmark
+def test_timer_due_batch(benchmark: BenchmarkFixture, loop: asyncio.AbstractEventLoop) -> None:
+    """Drain a prebuilt batch of due timers without timing allocation or deallocation."""
+    iterations = 100_000
+
+    def setup() -> tuple[tuple[asyncio.Future[None], list[asyncio.TimerHandle]], dict[str, int]]:
+        done = loop.create_future()
+        deadline = loop.time()
+        handles = [loop.call_at(deadline, _noop) for _ in range(iterations)]
+        handles.append(loop.call_at(math.nextafter(deadline, math.inf), done.set_result, None))
+        return (done, handles), {}
+
+    def measure(done: asyncio.Future[None], _handles: list[asyncio.TimerHandle]) -> None:
+        loop.run_until_complete(done)
+
+    def teardown(_done: asyncio.Future[None], handles: list[asyncio.TimerHandle]) -> None:
+        handles.clear()
+
+    benchmark.pedantic(measure, setup=setup, teardown=teardown, rounds=10)
 
 
 @pytest.mark.benchmark


### PR DESCRIPTION
## Summary

Separate timer scheduling and cancellation from timer execution. Add a zero-delay timer chain that crosses event loop turns and a prebuilt due-timer batch that excludes allocation and deallocation from the timed region.

Schedule the due batch against a future deadline, verify that every result is a real timer handle, and let the deadline expire before timing. Update the comparison harnesses and README with the completed-timer workloads.

## Results

On an M3 Max with CPython 3.14.6, using the median of seven interleaved runs:

| Benchmark | asyncio | uvloop | zuvloop |
| --- | ---: | ---: | ---: |
| timer schedule + cancel | 1.17M/s | 1.93M/s | 9.02M/s |
| completed timer rounds | 70.2k/s | 76.9k/s | 78.0k/s |
| prebuilt due timer batch | 1.38M/s | 2.73M/s | 5.89M/s |

## Validation

- `uv run ruff check benchmarks/test_benchmarks.py benchmarks/run.py benchmarks/compare.py`
- `uv run ruff format --check benchmarks/test_benchmarks.py benchmarks/run.py benchmarks/compare.py`
- `uv run mypy benchmarks/test_benchmarks.py benchmarks/run.py benchmarks/compare.py`
- `uv run --group bench pytest benchmarks/test_benchmarks.py -k timer`
- `uv run --group bench pytest benchmarks/test_benchmarks.py -k timer_due_batch --codspeed`
- `uv run --group docs zensical build --clean`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.