### PR TITLE
Queue already-due timers for the next round

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ interleaved in-process runs or five interleaved HTTP runs. The labels show the a
 | `call_soon` with arguments | 2.14M/s | 3.51M/s | **8.86M/s** |
 | `call_soon_threadsafe` | 0.44M/s | 5.13M/s | **11.9M/s** |
 | timer schedule + cancel | 1.17M/s | 1.93M/s | **9.02M/s** |
-| completed timer rounds | 70.2k/s | 76.9k/s | 78.0k/s |
+| completed timer rounds | 71.1k/s | 78.2k/s | **2.93M/s** |
 | prebuilt due timer batch | 1.38M/s | 2.73M/s | **5.89M/s** |
 | ready chain with 250 idle connections | 70.7k/s | 76.3k/s | **362.6k/s** |
 | bulk stream | 7.1 GiB/s | 7.9 GiB/s | **9.7 GiB/s** |

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -315,6 +315,26 @@ async def test_a_cancelled_zero_delay_timer_retires_without_running() -> None:
     assert called == []
 
 
+async def test_a_zero_delay_timer_does_not_overtake_an_older_due_timer() -> None:
+    loop = running_loop()
+    called: list[str] = []
+    done: asyncio.Future[None] = loop.create_future()
+
+    def record(value: str) -> None:
+        called.append(value)
+        if len(called) == 2:
+            done.set_result(None)
+
+    def block_past_deadline() -> None:
+        time.sleep(0.02)
+        loop.call_later(0, record, "zero")
+
+    loop.call_later(0.005, record, "older")
+    loop.call_soon(block_past_deadline)
+    await done
+    assert called == ["older", "zero"]
+
+
 async def test_a_cancelled_timer_stops_being_scheduled_when_it_leaves_the_heap() -> None:
     """Cancelling alone leaves it in the heap, as it does in asyncio. Reaching the
     deadline retires it, and so does the compaction a run of cancellations sets off."""

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -303,6 +303,18 @@ async def test_a_fired_timer_is_no_longer_scheduled() -> None:
     assert handle._scheduled is False
 
 
+async def test_a_cancelled_zero_delay_timer_retires_without_running() -> None:
+    loop = running_loop()
+    called: list[None] = []
+    handle = loop.call_later(0, called.append, None)
+    handle.cancel()
+    assert handle._scheduled is True
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert handle._scheduled is False
+    assert called == []
+
+
 async def test_a_cancelled_timer_stops_being_scheduled_when_it_leaves_the_heap() -> None:
     """Cancelling alone leaves it in the heap, as it does in asyncio. Reaching the
     deadline retires it, and so does the compaction a run of cancellations sets off."""

--- a/zig/loop.zig
+++ b/zig/loop.zig
@@ -653,14 +653,17 @@ fn scheduleAt(
     const h = try timermod.create(@ptrCast(self), callback, p.positional, p.context, when, original_when);
     py.incref(h);
     if (already_due) {
-        timermod.markReady(h);
-        st.ready.push(h) catch {
-            py.decref(h);
-            py.decref(h);
-            return py.errNoMemory();
-        };
-        startIdle(st);
-        return h;
+        const can_bypass_heap = if (st.timers.peek()) |entry| when < entry.when else true;
+        if (can_bypass_heap) {
+            timermod.markReady(h);
+            st.ready.push(h) catch {
+                py.decref(h);
+                py.decref(h);
+                return py.errNoMemory();
+            };
+            startIdle(st);
+            return h;
+        }
     }
     st.timers.push(when, h) catch {
         py.decref(h);

--- a/zig/loop.zig
+++ b/zig/loop.zig
@@ -394,6 +394,7 @@ fn drainThreadsafe(st: *State) error{OutOfMemory}!void {
 /// a callback runs under.
 inline fn runOne(obj: *py.Object) void {
     if (timermod.owns(obj)) {
+        timermod.clearScheduled(obj);
         timermod.run(obj);
     } else if (tshandle.owns(obj)) {
         tshandle.run(obj);
@@ -642,6 +643,7 @@ fn callSoonThreadsafe(self_obj: *py.Object, args: []const ?*py.Object, nargs: us
 fn scheduleAt(
     self: *LoopObject,
     when: f64,
+    already_due: bool,
     original_when: ?*py.Object,
     callback: *py.Object,
     p: Parsed,
@@ -650,6 +652,16 @@ fn scheduleAt(
     try checkClosed(st);
     const h = try timermod.create(@ptrCast(self), callback, p.positional, p.context, when, original_when);
     py.incref(h);
+    if (already_due) {
+        timermod.markReady(h);
+        st.ready.push(h) catch {
+            py.decref(h);
+            py.decref(h);
+            return py.errNoMemory();
+        };
+        startIdle(st);
+        return h;
+    }
     st.timers.push(when, h) catch {
         py.decref(h);
         py.decref(h);
@@ -664,14 +676,14 @@ fn callLater(self_obj: *py.Object, args: []const ?*py.Object, nargs: usize, kwna
     const delay = try py.asF64(args[0].?);
     const p = try parseCall(args, nargs, kwnames, 2);
     const when = now() + @max(delay, 0);
-    return scheduleAt(asLoop(self_obj), when, null, args[1].?, p);
+    return scheduleAt(asLoop(self_obj), when, delay <= 0, null, args[1].?, p);
 }
 
 fn callAt(self_obj: *py.Object, args: []const ?*py.Object, nargs: usize, kwnames: ?*py.Object) py.Error!*py.Object {
     if (nargs < 2) return py.errType("call_at() requires a time and a callback");
     const when = try py.asF64(args[0].?);
     const p = try parseCall(args, nargs, kwnames, 2);
-    return scheduleAt(asLoop(self_obj), when, args[0], args[1].?, p);
+    return scheduleAt(asLoop(self_obj), when, when <= now(), args[0], args[1].?, p);
 }
 
 fn time(self_obj: *py.Object) py.Error!*py.Object {

--- a/zig/timer.zig
+++ b/zig/timer.zig
@@ -22,6 +22,7 @@ const arg_alloc = std.heap.c_allocator;
 
 const CANCELLED: u32 = 1 << 0;
 const SCHEDULED: u32 = 1 << 1;
+const in_heap: u32 = 1 << 2;
 
 const Payload = extern struct {
     loop: ?*py.Object,
@@ -58,11 +59,15 @@ pub fn deadline(obj: *py.Object) f64 {
     return payload(obj).when;
 }
 
-/// Leaving the heap is what ends being scheduled, by whichever route: run, due
-/// but cancelled, or compacted away. Cancelling alone does not, because the
-/// entry is still in the heap - the same order `BaseEventLoop` clears it in.
+/// Marks an already-due timer as ready without losing its scheduled state.
+pub fn markReady(obj: *py.Object) void {
+    payload(obj).flags &= ~in_heap;
+}
+
+/// Leaving the scheduler ends the scheduled state, whether by running, expiry,
+/// or compaction. Cancellation alone leaves the state set until retirement.
 pub fn clearScheduled(obj: *py.Object) void {
-    payload(obj).flags &= ~SCHEDULED;
+    payload(obj).flags &= ~(SCHEDULED | in_heap);
 }
 
 pub fn create(
@@ -76,7 +81,7 @@ pub fn create(
     const obj = c.PyType_GenericAlloc(timer_type.?, 0) orelse return py.Error.Python;
     const self = payload(obj);
     self.when = at;
-    self.flags = SCHEDULED;
+    self.flags = SCHEDULED | in_heap;
     if (original_when) |value| {
         py.incref(value);
         self.when_obj = value;
@@ -139,7 +144,9 @@ fn cancel(self_obj: *py.Object) py.Error!*py.Object {
         self.flags |= CANCELLED;
         clearArgs(self);
         py.clear(&self.callback);
-        if (self.loop) |l| loopmod.noteTimerCancelled(@ptrCast(@alignCast(l)));
+        if (self.flags & in_heap != 0) {
+            if (self.loop) |l| loopmod.noteTimerCancelled(@ptrCast(@alignCast(l)));
+        }
     }
     return py.noneRef();
 }


### PR DESCRIPTION
## Summary

Queue already-due timers for the next logical ready round instead of arming libuv for another zero-time timer iteration. Keep returning a real `TimerHandle`, preserve `_scheduled` until retirement, and leave positive-delay timers on the existing heap path.

## Results

On an M3 Max with CPython 3.14.6, using seven interleaved runs:

| Benchmark | Base | Head |
| --- | ---: | ---: |
| completed timer rounds | 78.0k/s | 2.93M/s |
| future timer schedule + cancel | 23.67ms | 23.90ms |

Completed timer rounds are about 38x faster. Future timer churn is unchanged within noise.

## Validation

- `uv run coverage run -m pytest`
- `uv run coverage report`
- `uv run python scripts/conformance.py`
- `uv run python scripts/build.py --debug`
- `uv run pytest tests/test_scheduling.py`
- `zig fmt --check build.zig zig`
- `uv run ruff check tests/test_scheduling.py`
- `uv run mypy tests/test_scheduling.py`
- `uv run --group bench python benchmarks/compare.py timer_rounds timer_schedule_cancel`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Queues already-due timers directly onto the ready list for the next round instead of arming libuv for another zero-time timer iteration. Completed timer rounds are about 38x faster, while future timer schedule + cancel throughput is unchanged within noise.

- Already-due timers keep returning a real `TimerHandle` and keep `_scheduled` set until they retire.
- Timers bypass the heap only when already due and earlier than the heap's next deadline; otherwise they use the existing heap path.
- Cancelling an already-due timer no longer notifies the loop of a cancelled heap entry.

<sup>Written for commit 1f5efd9fc1d1e6a53698621f276a0553cdd17ed2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

