### PR TITLE
Cache cibuildwheel tools on Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,10 +186,18 @@ jobs:
         shell: pwsh
         run: ./scripts/setup-zig-x86_64-windows.ps1
 
+      - name: Cache cibuildwheel tools
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.temp }}/cibw-cache
+          key: cibuildwheel-4.2.0-${{ matrix.os }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys: cibuildwheel-4.2.0-${{ matrix.os }}-
+
       - name: Build and test the release wheel
         uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
         env:
           CIBW_ARCHS: ${{ matrix.archs }}
+          CIBW_CACHE_PATH: ${{ runner.temp }}/cibw-cache
           HATCH_ZIG_TARGET: ${{ matrix.target }}
 
 


### PR DESCRIPTION
Persist cibuildwheel's downloaded CPython tools between Windows CI runs. The cache is separated by runner and cibuildwheel version, with the project configuration included for invalidation.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI cache for cibuildwheel's downloaded CPython tools on Windows, so subsequent runs reuse the existing toolchain instead of re-downloading it.

- The cache key includes the runner, cibuildwheel version, and `pyproject.toml` hash, with a restore key fallback to the version and runner.
- The cache directory is set via `CIBW_CACHE_PATH` so cibuildwheel stores tools in `runner.temp` and the cache persists across workflow runs.

<sup>Written for commit 7bb7f63983428ba5648d3812a08983fd92ba6cc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

