### PR TITLE
Skip incompatible benchmark shard in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,13 +394,6 @@ jobs:
             uv run --no-sync pytest benchmarks/ --codspeed
             -k "not parallel_event_loops and not ready_chain_with_idle_connections"
 
-      - name: Run profiler-incompatible benchmarks
-        # The CodSpeed walltime runner hangs around these threaded and socket-heavy
-        # cases. pytest-codspeed still measures and prints them without the runner.
-        run: >-
-          uv run --no-sync pytest benchmarks/ --codspeed --codspeed-mode=walltime
-          -k "parallel_event_loops or ready_chain_with_idle_connections"
-
   docs:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -395,17 +395,11 @@ jobs:
             -k "not parallel_event_loops and not ready_chain_with_idle_connections"
 
       - name: Run profiler-incompatible benchmarks
-        uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8 # v5.0.3
-        env:
-          CODSPEED_PERF_ENABLED: "false"
-        with:
-          mode: walltime
-          # Disabling the runner profiler does not stop pytest-codspeed from
-          # activating CPython's perf trampoline while CODSPEED_ENV is set.
-          run: >-
-            env -u CODSPEED_ENV uv run --no-sync pytest benchmarks/
-            --codspeed --codspeed-mode=walltime
-            -k "parallel_event_loops or ready_chain_with_idle_connections"
+        # The CodSpeed walltime runner hangs around these threaded and socket-heavy
+        # cases. pytest-codspeed still measures and prints them without the runner.
+        run: >-
+          uv run --no-sync pytest benchmarks/ --codspeed --codspeed-mode=walltime
+          -k "parallel_event_loops or ready_chain_with_idle_connections"
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,8 +400,11 @@ jobs:
           CODSPEED_PERF_ENABLED: "false"
         with:
           mode: walltime
+          # Disabling the runner profiler does not stop pytest-codspeed from
+          # activating CPython's perf trampoline while CODSPEED_ENV is set.
           run: >-
-            uv run --no-sync pytest benchmarks/ --codspeed
+            env -u CODSPEED_ENV uv run --no-sync pytest benchmarks/
+            --codspeed --codspeed-mode=walltime
             -k "parallel_event_loops or ready_chain_with_idle_connections"
 
   docs:


### PR DESCRIPTION
## Summary

Stop running the threaded and socket-heavy benchmark shard on GitHub-hosted Linux. Keep the other 51 benchmarks running and uploaded through CodSpeed.

The excluded shard repeatedly hangs until the 15-minute job timeout. It hangs both inside the CodSpeed walltime runner and as a direct `pytest-codspeed` command on the hosted runner, while completing locally. The benchmark implementations remain available for dedicated local runs.

## Validation

- Confirmed the main 51-test CodSpeed shard completes in about 3.5 minutes
- Reproduced the incompatible shard timeout in consecutive hosted CI runs
- Ran the six excluded benchmarks locally in 14.8 seconds
- Confirmed the workflow diff passes `git diff --check`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.