### PR TITLE
Benchmark multi-buffer writelines throughput

### DIFF
--- a/benchmarks/compare.py
+++ b/benchmarks/compare.py
@@ -22,6 +22,7 @@ import sys
 import threading
 import time
 from collections.abc import Callable, Coroutine
+from functools import partial
 
 import uvloop
 
@@ -128,9 +129,9 @@ def split_write(loop: asyncio.AbstractEventLoop) -> Callable[[], None]:
     return _driver(loop, once)
 
 
-def writelines_8(loop: asyncio.AbstractEventLoop) -> Callable[[], None]:
-    """A response passed to `writelines()` as eight buffers."""
-    fragments = tuple(b"x" * 16 for _ in range(8))
+def writelines(loop: asyncio.AbstractEventLoop, buffer_count: int) -> Callable[[], None]:
+    """A 128-byte response passed to `writelines()` in equal fragments."""
+    fragments = tuple(b"x" * (128 // buffer_count) for _ in range(buffer_count))
     payload_size = sum(map(len, fragments))
     connections = 64
     responses = 100
@@ -339,7 +340,8 @@ def spawn(loop: asyncio.AbstractEventLoop) -> Callable[[], None]:
 WORKLOADS: dict[str, Workload] = {
     "echo": echo,
     "split_write": split_write,
-    "writelines_8": writelines_8,
+    "writelines_4": partial(writelines, buffer_count=4),
+    "writelines_8": partial(writelines, buffer_count=8),
     "bulk": bulk,
     "call_soon": call_soon,
     "call_soon_threadsafe": call_soon_threadsafe,

--- a/benchmarks/compare.py
+++ b/benchmarks/compare.py
@@ -128,6 +128,53 @@ def split_write(loop: asyncio.AbstractEventLoop) -> Callable[[], None]:
     return _driver(loop, once)
 
 
+def writelines_8(loop: asyncio.AbstractEventLoop) -> Callable[[], None]:
+    """A response passed to `writelines()` as eight buffers."""
+    fragments = tuple(b"x" * 16 for _ in range(8))
+    payload_size = sum(map(len, fragments))
+    connections = 64
+    responses = 100
+
+    class Server(asyncio.Protocol):
+        def connection_made(self, transport: asyncio.BaseTransport) -> None:
+            self.transport = transport
+
+        def data_received(self, data: bytes) -> None:
+            for _ in data:
+                self.transport.writelines(fragments)  # type: ignore[attr-defined]
+
+    server = loop.run_until_complete(loop.create_server(Server, "127.0.0.1", 0))
+    port = server.sockets[0].getsockname()[1]
+
+    class Client(asyncio.Protocol):
+        def __init__(self) -> None:
+            self.seen = 0
+            self.remaining = responses
+            self.done = loop.create_future()
+
+        def connection_made(self, transport: asyncio.BaseTransport) -> None:
+            self.transport = transport
+            transport.write(b"\n")  # type: ignore[attr-defined]
+
+        def data_received(self, data: bytes) -> None:
+            self.seen += len(data)
+            while self.seen >= payload_size:
+                self.seen -= payload_size
+                self.remaining -= 1
+                if self.remaining == 0:
+                    self.done.set_result(None)
+                    return
+                self.transport.write(b"\n")  # type: ignore[attr-defined]
+
+    async def once() -> None:
+        pairs = await asyncio.gather(*(loop.create_connection(Client, "127.0.0.1", port) for _ in range(connections)))
+        await asyncio.gather(*(protocol.done for _transport, protocol in pairs))
+        for transport, _protocol in pairs:
+            transport.close()
+
+    return _driver(loop, once)
+
+
 def bulk(loop: asyncio.AbstractEventLoop) -> Callable[[], None]:
     """16 MiB in one direction, with flow control engaged."""
     chunk = b"x" * 65536
@@ -292,6 +339,7 @@ def spawn(loop: asyncio.AbstractEventLoop) -> Callable[[], None]:
 WORKLOADS: dict[str, Workload] = {
     "echo": echo,
     "split_write": split_write,
+    "writelines_8": writelines_8,
     "bulk": bulk,
     "call_soon": call_soon,
     "call_soon_threadsafe": call_soon_threadsafe,

--- a/benchmarks/test_benchmarks.py
+++ b/benchmarks/test_benchmarks.py
@@ -496,6 +496,62 @@ def test_split_response_write(benchmark: BenchmarkFixture, loop: asyncio.Abstrac
 
 
 @pytest.mark.benchmark
+@pytest.mark.parametrize("buffer_count", [4, 8], ids=["4-buffers", "8-buffers"])
+def test_writelines_roundtrips(
+    benchmark: BenchmarkFixture,
+    loop: asyncio.AbstractEventLoop,
+    buffer_count: int,
+) -> None:
+    payload_size = 128
+    fragments = tuple(b"x" * (payload_size // buffer_count) for _ in range(buffer_count))
+    connections = 64
+    responses = 100
+
+    class Server(asyncio.Protocol):
+        def connection_made(self, transport: asyncio.BaseTransport) -> None:
+            self.transport = transport
+
+        def data_received(self, data: bytes) -> None:
+            for _ in data:
+                self.transport.writelines(fragments)  # type: ignore[attr-defined]
+
+    class Client(asyncio.Protocol):
+        def __init__(self) -> None:
+            self.seen = 0
+            self.remaining = responses
+            self.done = loop.create_future()
+
+        def connection_made(self, transport: asyncio.BaseTransport) -> None:
+            self.transport = transport
+            transport.write(b"\n")  # type: ignore[attr-defined]
+
+        def data_received(self, data: bytes) -> None:
+            self.seen += len(data)
+            while self.seen >= payload_size:
+                self.seen -= payload_size
+                self.remaining -= 1
+                if self.remaining == 0:
+                    self.done.set_result(None)
+                    return
+                self.transport.write(b"\n")  # type: ignore[attr-defined]
+
+    server = loop.run_until_complete(loop.create_server(Server, "127.0.0.1", 0))
+    port = server.sockets[0].getsockname()[1]
+
+    async def work() -> None:
+        pairs = await asyncio.gather(*(loop.create_connection(Client, "127.0.0.1", port) for _ in range(connections)))
+        await asyncio.gather(*(client.done for _transport, client in pairs))
+        for transport, _client in pairs:
+            transport.close()
+
+    try:
+        benchmark.pedantic(drive(loop, work), rounds=10)
+    finally:
+        server.close()
+        loop.run_until_complete(server.wait_closed())
+
+
+@pytest.mark.benchmark
 def test_bulk_stream(benchmark: BenchmarkFixture, loop: asyncio.AbstractEventLoop) -> None:
     """Bulk transfer with flow control engaged."""
     chunk = b"x" * 65536


### PR DESCRIPTION
Adds a public TCP benchmark comparing four- and eight-buffer `writelines()` calls, plus an interleaved comparison workload. The baseline shows zuvloop at 0.85x uvloop for eight-buffer responses and exposes the fixed four-slot batching cliff.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a public TCP benchmark for multi-buffer `writelines()` throughput, covering four- and eight-buffer responses, plus a parametrized roundtrip test for both counts. The baseline shows `zuvloop` at 0.85x `uvloop` for eight-buffer responses and exposes the fixed four-slot batching cliff.

<sup>Written for commit 0672d94fa430f51d3aaaf6dd4f282b4ac4be3ead. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

