### PR TITLE
Make build-constraint verification deterministic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,10 @@ jobs:
       - name: Verify the hashed build constraints
         if: runner.os == 'Linux'
         run: |
+          uv pip compile .github/build-requirements.in --universal --generate-hashes \
+            --no-header --no-annotate --constraint .github/build-constraints.txt \
+            --output-file /tmp/build-constraints.txt
+          sed '/^[[:space:]]*#/d' .github/build-constraints.txt | diff -u - /tmp/build-constraints.txt
           uv build --sdist --wheel --build-constraints .github/build-constraints.txt \
             --require-hashes --out-dir /tmp/zuv-sdist
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,9 +70,6 @@ jobs:
       - name: Verify the hashed build constraints
         if: runner.os == 'Linux'
         run: |
-          uv pip compile .github/build-requirements.in --universal --generate-hashes \
-            --no-header --output-file /tmp/build-constraints.txt
-          tail -n +3 .github/build-constraints.txt | diff -u - /tmp/build-constraints.txt
           uv build --sdist --wheel --build-constraints .github/build-constraints.txt \
             --require-hashes --out-dir /tmp/zuv-sdist
 


### PR DESCRIPTION
## Summary

Regenerate the build constraints using the committed versions as resolver constraints. This detects changes to the input requirements without failing when PyPI publishes a newer transitive dependency.

Build with `--require-hashes` so missing or mismatched hashes still fail.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
