### PR TITLE
Benchmark monitored callback dispatch

### DIFF
--- a/benchmarks/callback_cpu_time.py
+++ b/benchmarks/callback_cpu_time.py
@@ -10,24 +10,30 @@ from opentelemetry.sdk.trace import TracerProvider
 
 import zuvloop
 
-trace.set_tracer_provider(TracerProvider())
-loop = zuvloop.new_event_loop()
-loop.slow_callback_duration = 1000000
-samples = []
-for _ in range(9):
-    remaining = 200000
 
-    def callback() -> None:
-        global remaining
-        remaining -= 1
-        if remaining:
-            loop.call_soon(callback)
-        else:
-            loop.stop()
+def main() -> None:
+    trace.set_tracer_provider(TracerProvider())
+    loop = zuvloop.new_event_loop()
+    loop.slow_callback_duration = 1000000
+    samples = []
+    for _ in range(9):
+        remaining = 200000
 
-    loop.call_soon(callback)
-    started = time.perf_counter_ns()
-    loop.run_forever()
-    samples.append((time.perf_counter_ns() - started) / 200000)
-loop.close()
-print({"median_ns_per_callback": statistics.median(samples), "samples": samples})
+        def callback() -> None:
+            nonlocal remaining
+            remaining -= 1
+            if remaining:
+                loop.call_soon(callback)
+            else:
+                loop.stop()
+
+        loop.call_soon(callback)
+        started = time.perf_counter_ns()
+        loop.run_forever()
+        samples.append((time.perf_counter_ns() - started) / 200000)
+    loop.close()
+    print({"median_ns_per_callback": statistics.median(samples), "samples": samples})
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/callback_cpu_time.py
+++ b/benchmarks/callback_cpu_time.py
@@ -1,0 +1,33 @@
+"""Measure native callback timing overhead with a tracing provider installed."""
+
+from __future__ import annotations
+
+import statistics
+import time
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+
+import zuvloop
+
+trace.set_tracer_provider(TracerProvider())
+loop = zuvloop.new_event_loop()
+loop.slow_callback_duration = 1000000
+samples = []
+for _ in range(9):
+    remaining = 200000
+
+    def callback() -> None:
+        global remaining
+        remaining -= 1
+        if remaining:
+            loop.call_soon(callback)
+        else:
+            loop.stop()
+
+    loop.call_soon(callback)
+    started = time.perf_counter_ns()
+    loop.run_forever()
+    samples.append((time.perf_counter_ns() - started) / 200000)
+loop.close()
+print({"median_ns_per_callback": statistics.median(samples), "samples": samples})


### PR DESCRIPTION
Add a standalone benchmark for monitored `call_soon` dispatch with a tracing provider installed. It records nine samples of 200,000 callbacks so optional CPU timing can be compared against the same workload.

Validation: Ruff and the benchmark command pass on Python 3.14.6, macOS ARM64. Baseline before the native change was approximately 313 ns per callback.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a standalone benchmark for monitored `call_soon` dispatch with a tracing provider installed, so CPU timing overhead can be compared against the same workload without a provider. The benchmark runs only when executed directly, not on import.

- Runs nine samples of 200,000 callbacks each.
- Prints the median nanoseconds per callback and the full sample list.

<sup>Written for commit 2b5b1a720b796342e858d194831792b0658ef150. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zuvloop/pull/172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

