### PR TITLE
Measure optional thread CPU time for slow callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,14 @@ snapshot is dropped).
 
 You get:
 
-- **`zuvloop.slow_callback`** spans — with real start/end timestamps measured by `uv_hrtime()`
-  in native code, and the awaiting call graph attached (via `asyncio.format_call_graph()`),
-  so you see *why* a callback was running, not just its repr.
+- **`zuvloop.slow_callback`** spans include elapsed callback time measured by `uv_hrtime()`
+  in native code. The call graph is captured after the callback returns, so its last
+  await identifies the next suspension point, not necessarily the work that was slow.
+  `thread.id` identifies the loop thread. Set `loop.slow_callback_cpu_time_enabled = True`
+  to add `cpu_time` in seconds when the platform clock is available. The default is
+  `False`, avoiding a thread CPU clock read on every monitored callback. A low CPU/wall
+  ratio can reflect synchronous waiting or scheduling delays; it does not distinguish
+  them. GC CPU time is included in callback CPU time.
 - **`zuvloop.unhandled_exception`** spans — with the exception recorded.
 - Counters, a callback-duration histogram, and live loop gauges (`loop_count`, `events`,
   `idle_time_ns`, `ready`, `timers`, `watchers`, ...).

--- a/benchmarks/callback_cpu_time.py
+++ b/benchmarks/callback_cpu_time.py
@@ -10,24 +10,30 @@ from opentelemetry.sdk.trace import TracerProvider
 
 import zuvloop
 
-trace.set_tracer_provider(TracerProvider())
-loop = zuvloop.new_event_loop()
-loop.slow_callback_duration = 1000000
-samples = []
-for _ in range(9):
-    remaining = 200000
 
-    def callback() -> None:
-        global remaining
-        remaining -= 1
-        if remaining:
-            loop.call_soon(callback)
-        else:
-            loop.stop()
+def main() -> None:
+    trace.set_tracer_provider(TracerProvider())
+    loop = zuvloop.new_event_loop()
+    loop.slow_callback_duration = 1000000
+    samples = []
+    for _ in range(9):
+        remaining = 200000
 
-    loop.call_soon(callback)
-    started = time.perf_counter_ns()
-    loop.run_forever()
-    samples.append((time.perf_counter_ns() - started) / 200000)
-loop.close()
-print({"median_ns_per_callback": statistics.median(samples), "samples": samples})
+        def callback() -> None:
+            nonlocal remaining
+            remaining -= 1
+            if remaining:
+                loop.call_soon(callback)
+            else:
+                loop.stop()
+
+        loop.call_soon(callback)
+        started = time.perf_counter_ns()
+        loop.run_forever()
+        samples.append((time.perf_counter_ns() - started) / 200000)
+    loop.close()
+    print({"median_ns_per_callback": statistics.median(samples), "samples": samples})
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/callback_cpu_time.py
+++ b/benchmarks/callback_cpu_time.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import statistics
 import time
 
@@ -10,9 +11,14 @@ from opentelemetry.sdk.trace import TracerProvider
 
 import zuvloop
 
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("--cpu-time", action="store_true")
+args = parser.parse_args()
 trace.set_tracer_provider(TracerProvider())
 loop = zuvloop.new_event_loop()
 loop.slow_callback_duration = 1000000
+if args.cpu_time:
+    loop.slow_callback_cpu_time_enabled = True
 samples = []
 for _ in range(9):
     remaining = 200000
@@ -30,4 +36,4 @@ for _ in range(9):
     loop.run_forever()
     samples.append((time.perf_counter_ns() - started) / 200000)
 loop.close()
-print({"median_ns_per_callback": statistics.median(samples), "samples": samples})
+print({"cpu_time": args.cpu_time, "median_ns_per_callback": statistics.median(samples), "samples": samples})

--- a/benchmarks/callback_cpu_time.py
+++ b/benchmarks/callback_cpu_time.py
@@ -1,0 +1,33 @@
+"""Measure native callback timing overhead with a tracing provider installed."""
+
+from __future__ import annotations
+
+import statistics
+import time
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+
+import zuvloop
+
+trace.set_tracer_provider(TracerProvider())
+loop = zuvloop.new_event_loop()
+loop.slow_callback_duration = 1000000
+samples = []
+for _ in range(9):
+    remaining = 200000
+
+    def callback() -> None:
+        global remaining
+        remaining -= 1
+        if remaining:
+            loop.call_soon(callback)
+        else:
+            loop.stop()
+
+    loop.call_soon(callback)
+    started = time.perf_counter_ns()
+    loop.run_forever()
+    samples.append((time.perf_counter_ns() - started) / 200000)
+loop.close()
+print({"median_ns_per_callback": statistics.median(samples), "samples": samples})

--- a/tests/test_instrumentation.py
+++ b/tests/test_instrumentation.py
@@ -4,6 +4,7 @@ import asyncio
 import contextvars
 import logging
 import sys
+import threading
 import time
 import traceback
 from collections.abc import Mapping
@@ -51,6 +52,8 @@ async def test_slow_callbacks_are_reported_without_debug_mode(telemetry: Telemet
     assert span.status.status_code is StatusCode.UNSET
     assert numeric_attribute(span, "logfire.level_num") == 13
     assert numeric_attribute(span, "duration") >= 0.01
+    assert span.attributes is not None
+    assert "cpu_time" not in span.attributes
     assert "Handle" in str(attribute(span, "code.callback"))
     assert telemetry.counted("zuvloop.slow_callbacks") >= 1
 
@@ -757,3 +760,38 @@ async def test_the_stdlib_call_graph_apis_work_on_this_loop() -> None:
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task
+
+
+@pytest.mark.parametrize("busy", [False, True])
+async def test_opt_in_callback_cpu_time_distinguishes_sleep_from_cpu_work(telemetry: Telemetry, busy: bool) -> None:
+    loop = running_loop()
+    assert loop.slow_callback_cpu_time_enabled is False
+    loop.slow_callback_cpu_time_enabled = True
+    assert loop.slow_callback_cpu_time_enabled is True
+    loop.slow_callback_duration = 0.01
+
+    def measured_callback() -> None:
+        if busy:
+            deadline = time.thread_time() + 0.05
+            while time.thread_time() < deadline:
+                pass
+        else:
+            time.sleep(0.05)
+
+    try:
+        loop.call_soon(measured_callback)
+        await asyncio.sleep(0.2)
+    finally:
+        loop.slow_callback_cpu_time_enabled = False
+        loop.slow_callback_duration = 0.1
+    span = next(
+        span
+        for span in telemetry.spans("zuvloop.slow_callback")
+        if "measured_callback" in str(attribute(span, "code.callback"))
+    )
+    cpu_time = numeric_attribute(span, "cpu_time")
+    if busy:
+        assert cpu_time >= 0.045
+    else:
+        assert 0 <= cpu_time < numeric_attribute(span, "duration") / 2
+    assert numeric_attribute(span, "thread.id") == threading.get_ident()

--- a/zig/loop.zig
+++ b/zig/loop.zig
@@ -65,6 +65,7 @@ pub const State = struct {
     stopping: bool = false,
     debug: bool = false,
     slow_callback_monitoring: bool = false,
+    slow_callback_cpu_time_enabled: bool = false,
     idle_active: bool = false,
     waker_pending: bool = false,
     timer_active: bool = false,
@@ -405,10 +406,18 @@ fn runReady(self: *LoopObject) void {
     while (remaining != 0) : (remaining -= 1) {
         const obj = st.ready.pop() orelse break;
         if ((st.debug or st.slow_callback_monitoring) and st.slow_callback_duration < std.math.inf(f64)) {
+            const cpu_started = if (st.slow_callback_cpu_time_enabled) c.zuvloop_thread_cpu_time() else -1;
             const started = uv.uv_hrtime();
             runOne(obj);
             const elapsed = @as(f64, @floatFromInt(uv.uv_hrtime() - started)) / 1e9;
-            if (elapsed > st.slow_callback_duration) reportSlowCallback(self, obj, elapsed);
+            if (elapsed > st.slow_callback_duration) {
+                const cpu_ended = if (cpu_started >= 0) c.zuvloop_thread_cpu_time() else -1;
+                const cpu_time: f64 = if (cpu_ended >= cpu_started and cpu_started >= 0)
+                    @as(f64, @floatFromInt(cpu_ended - cpu_started)) / 1e9
+                else
+                    -1;
+                reportSlowCallback(self, obj, elapsed, cpu_time);
+            }
         } else {
             runOne(obj);
         }
@@ -416,17 +425,22 @@ fn runReady(self: *LoopObject) void {
     }
 }
 
-fn reportSlowCallback(self: *LoopObject, h: *py.Object, elapsed: f64) void {
+fn reportSlowCallback(self: *LoopObject, h: *py.Object, elapsed: f64, cpu_elapsed: f64) void {
     const duration = py.float(elapsed) orelse {
         c.PyErr_Clear();
         return;
     };
     defer py.decref(duration);
-    const args = [_]?*py.Object{ @ptrCast(self), h, duration };
+    const cpu_time = py.float(cpu_elapsed) orelse {
+        c.PyErr_Clear();
+        return;
+    };
+    defer py.decref(cpu_time);
+    const args = [_]?*py.Object{ @ptrCast(self), h, duration, cpu_time };
     const res = c.PyObject_VectorcallMethod(
         str_on_slow_callback,
         &args,
-        3 | c.PY_VECTORCALL_ARGUMENTS_OFFSET,
+        4 | c.PY_VECTORCALL_ARGUMENTS_OFFSET,
         null,
     );
     if (res) |r| py.decref(r) else py.writeUnraisable(@ptrCast(self));
@@ -818,6 +832,16 @@ fn getTaskFactory(self_obj: *py.Object) py.Error!*py.Object {
 fn setSlowCallbackMonitoring(self_obj: *py.Object, value: *py.Object) py.Error!*py.Object {
     asLoop(self_obj).state().slow_callback_monitoring = try py.isTrue(value);
     return py.noneRef();
+}
+
+fn getSlowCallbackCPUTimeEnabled(self_obj: ?*py.Object, _: ?*anyopaque) callconv(.c) ?*py.Object {
+    return py.boolRef(asLoop(self_obj.?).state().slow_callback_cpu_time_enabled);
+}
+
+fn setSlowCallbackCPUTimeEnabled(self_obj: ?*py.Object, value: ?*py.Object, _: ?*anyopaque) callconv(.c) c_int {
+    const enabled = py.isTrue(value orelse return -1) catch return -1;
+    asLoop(self_obj.?).state().slow_callback_cpu_time_enabled = enabled;
+    return 0;
 }
 
 fn getSlowCallbackDuration(self_obj: ?*py.Object, _: ?*anyopaque) callconv(.c) ?*py.Object {
@@ -1271,6 +1295,13 @@ var methods = [_]c.PyMethodDef{
 };
 
 var getsets = [_]c.PyGetSetDef{
+    .{
+        .name = "slow_callback_cpu_time_enabled",
+        .get = py.wrapGet(getSlowCallbackCPUTimeEnabled),
+        .set = py.wrapSet(setSlowCallbackCPUTimeEnabled),
+        .doc = "Measure thread CPU time for slow callbacks (disabled by default).",
+        .closure = null,
+    },
     .{
         .name = "slow_callback_duration",
         .get = py.wrapGet(getSlowCallbackDuration),

--- a/zig/loop.zig
+++ b/zig/loop.zig
@@ -431,16 +431,17 @@ fn reportSlowCallback(self: *LoopObject, h: *py.Object, elapsed: f64, cpu_elapse
         return;
     };
     defer py.decref(duration);
-    const cpu_time = py.float(cpu_elapsed) orelse {
-        c.PyErr_Clear();
-        return;
-    };
-    defer py.decref(cpu_time);
-    const args = [_]?*py.Object{ @ptrCast(self), h, duration, cpu_time };
+    var args = [_]?*py.Object{ @ptrCast(self), h, duration, null };
+    if (cpu_elapsed >= 0) {
+        args[3] = py.float(cpu_elapsed);
+        if (args[3] == null) c.PyErr_Clear();
+    }
+    defer if (args[3]) |cpu_time| py.decref(cpu_time);
+    const nargs: usize = if (args[3] != null) 4 else 3;
     const res = c.PyObject_VectorcallMethod(
         str_on_slow_callback,
         &args,
-        4 | c.PY_VECTORCALL_ARGUMENTS_OFFSET,
+        nargs | c.PY_VECTORCALL_ARGUMENTS_OFFSET,
         null,
     );
     if (res) |r| py.decref(r) else py.writeUnraisable(@ptrCast(self));

--- a/zig/python_shim.c
+++ b/zig/python_shim.c
@@ -1,5 +1,29 @@
 #include "python_shim.h"
 
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <time.h>
+#endif
+
+int64_t zuvloop_thread_cpu_time(void) {
+#ifdef _WIN32
+    FILETIME created, exited, kernel, user;
+    if (!GetThreadTimes(GetCurrentThread(), &created, &exited, &kernel, &user)) {
+        return -1;
+    }
+    uint64_t kernel_ticks = ((uint64_t)kernel.dwHighDateTime << 32) | kernel.dwLowDateTime;
+    uint64_t user_ticks = ((uint64_t)user.dwHighDateTime << 32) | user.dwLowDateTime;
+    return (int64_t)((kernel_ticks + user_ticks) * 100);
+#else
+    struct timespec value;
+    if (clock_gettime(CLOCK_THREAD_CPUTIME_ID, &value) != 0) {
+        return -1;
+    }
+    return (int64_t)value.tv_sec * 1000000000 + value.tv_nsec;
+#endif
+}
+
 void zuvloop_critical_section_begin(zuvloop_critical_section *section, PyObject *object) {
 #ifdef Py_GIL_DISABLED
     _Static_assert(sizeof(*section) >= sizeof(PyCriticalSection), "critical section storage is too small");

--- a/zig/python_shim.h
+++ b/zig/python_shim.h
@@ -21,6 +21,9 @@ typedef struct {
     uintptr_t storage[2];
 } zuvloop_critical_section;
 
+// Thread CPU nanoseconds, or -1 if the clock is unavailable.
+int64_t zuvloop_thread_cpu_time(void);
+
 void zuvloop_critical_section_begin(zuvloop_critical_section *section, PyObject *object);
 void zuvloop_critical_section_end(zuvloop_critical_section *section);
 PyObject *zuvloop_PyModuleDef_Init(PyModuleDef *definition);

--- a/zuvloop/_base.py
+++ b/zuvloop/_base.py
@@ -337,8 +337,8 @@ class LoopBase(_zuvloop.Loop, asyncio.AbstractEventLoop):  # type: ignore[misc]
                     "an unexpected error in custom exception handler"
                 )
 
-    def _on_slow_callback(self, handle: object, duration: float) -> None:
-        self._instrumentation.report_slow_callback(handle, duration)
+    def _on_slow_callback(self, handle: object, duration: float, cpu_time: float = -1) -> None:
+        self._instrumentation.report_slow_callback(handle, duration, cpu_time)
 
     def _on_sample(self, snapshot: dict[str, int]) -> None:
         if not self._monitoring_armed and instrumentation_provider_installed():

--- a/zuvloop/_instrumentation.py
+++ b/zuvloop/_instrumentation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import functools
+import threading
 import time
 import traceback
 from collections.abc import Mapping
@@ -51,7 +52,7 @@ class Instrumentation:
     as installing a provider, as does any other OpenTelemetry setup.
     """
 
-    def report_slow_callback(self, handle: object, duration: float) -> None:
+    def report_slow_callback(self, handle: object, duration: float, cpu_time: float = -1) -> None:
         try:
             _counter("slow_callbacks", "Callbacks that exceeded slow_callback_duration").add(1)
             _histogram("callback_duration", "Duration of slow callbacks", "s").record(duration)
@@ -65,8 +66,11 @@ class Instrumentation:
             attributes: dict[str, AttributeValue] = {
                 "code.callback": _safe_repr(handle),
                 "duration": duration,
+                "thread.id": threading.get_ident(),
                 "logfire.level_num": 13,
             }
+            if cpu_time >= 0:
+                attributes["cpu_time"] = cpu_time
             if graph is not None:
                 attributes["asyncio.call_graph"] = _bounded(graph)
             span = _tracer().start_span(

--- a/zuvloop/_zuvloop.pyi
+++ b/zuvloop/_zuvloop.pyi
@@ -111,6 +111,7 @@ class Loop:
     """Native scheduling core: everything on a hot path lives here."""
 
     slow_callback_duration: float
+    slow_callback_cpu_time_enabled: bool
 
     def create_task[T](
         self,


### PR DESCRIPTION
Add opt-in native thread CPU timing for slow callbacks through `loop.slow_callback_cpu_time_enabled`, disabled by default. Slow callback spans include `cpu_time` when the clock is available and `thread.id` for correlation. Document that the call graph is captured after execution and that low CPU relative to wall time can indicate either synchronous waiting or scheduling delays.

Depends on the standalone benchmark in [#172](https://github.com/Kludex/zuvloop/pull/172). On Python 3.14.6/macOS ARM64, the benchmark measured roughly 301 ns per callback with CPU timing disabled and 404 ns enabled; the pre-change baseline was approximately 313 ns. The added clock read is avoided by default.

Validation: 522 tests passed, 3 skipped; mypy, Ruff, and Zig formatting checks passed. Tests distinguish sleeping callbacks from CPU work and verify default-off behavior. Linux and Windows builds remain for CI.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
